### PR TITLE
Public types, error classes, and the spec-surface checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,15 @@ updates:
     # The package has no runtime dependencies, so only the toolchain is updated here.
     allow:
       - dependency-type: development
+    # Two majors are held back deliberately. TypeScript stays on 5.9 until typescript-eslint
+    # supports a newer one, since the lint rules are what the strictness rests on; @types/node
+    # tracks the Node 20 floor in `engines`, so a major here would describe a Node the package
+    # does not claim to support. Both move by hand, with the reason in the pull request.
+    ignore:
+      - dependency-name: typescript
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
     groups:
       dev-dependencies:
         patterns:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
       - run: npm run typecheck
       - run: npm run depcruise
       - run: npm run build
+      # The fixtures whose imports already exist in the build, compiled against it rather
+      # than against the spec — 5 of 13 today, more as the remaining exports land.
+      - name: Compile the fixtures the build can satisfy against it
+        run: node scripts/check-types-fixtures.mjs --target package
+      - name: Check the built exports against the specification
+        run: node scripts/check-spec-surface.mjs
       - run: npm run publint
       - run: npm run attw
       - run: npm run api:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ coverage/
 api/
 package-lock.json
 test/fixtures/
+test/types/spec-surface*.d.ts
 *.tgz
 
 # The published documents are edited as prose and kept byte-for-byte as written.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,13 @@ npm ci
 npm run check
 ```
 
-`npm run check` is the whole local pass: formatting, lint, types, module boundaries, the
-build, package linting, package typing, the public type surface, the size budget, and the
-unit tests with coverage. If it is green, continuous integration will almost certainly
-agree — it runs the same thing plus a few checks that need a database, a second Node, or
-a network download.
+`npm run check` is the whole local pass: formatting, lint, types — the compile fixtures
+included — module boundaries, the build, then the subset of those fixtures whose imports
+already exist in the build compiled against it (5 of 13 today; the rest join as the remaining
+exports land), the export inventory comparing `dist/` with the specification, package
+linting, package typing, the public type surface, the size budget, and the unit tests with
+coverage. If it is green, continuous integration will almost certainly agree — it runs the
+same thing plus a few checks that need a database, a second Node, or a network download.
 
 Node 24.19.0 is the development version (`.nvmrc`); the package supports Node 20 and up,
 and the tests are run there too.
@@ -32,9 +34,10 @@ tests. Type-only imports are written as such.
 
 **Module boundaries.** The folders in `src/` are a dependency order, not a filing system;
 [`docs/architecture.md`](docs/architecture.md) draws it and `npm run depcruise` enforces
-it. The short version: `errors` depends on nothing, `core` decides and performs no I/O,
-`providers` and `stores` adapt one thing each, `conformance` only ever sees interfaces,
-and the entry modules assemble. Each folder has a `README.md` restating its own rule.
+it. The short version: `types.ts` is the floor and imports nothing but Zod, `errors` depends
+on nothing else, `core` decides and performs no I/O, `providers` and `stores` adapt one thing
+each, `conformance` only ever sees interfaces, and the entry modules assemble. Each folder
+has a `README.md` restating its own rule.
 
 **Dependencies.** The published package has none. Zod is a peer dependency the adopter
 already has; anything else would be an install they did not ask for. Development
@@ -46,8 +49,32 @@ where a change to the published surface becomes visible, and it is the part of a
 request worth reading first. From the first release onward, such a change also needs a
 changeset (`npx changeset`).
 
-**Errors.** One error class, a closed set of codes, and a `retryable` flag that is copied
-from the classification table rather than worked out on the spot. Messages never contain a
+**The specification is the surface.** `test/types/spec-surface*.d.ts` are generated from the
+§6 and §6b code fences of [`docs/spec.md`](docs/spec.md): edit the spec, run `npm run
+surface:update`, never edit them by hand. `check-spec-surface.mjs` compares every name
+`dist/` exports — both module systems, type told from value — with what the spec declares. A
+spec name the implementation has not reached yet is listed in `test/types/spec-pending.json`;
+a name on that list which has appeared in `dist/` fails as loudly as one that is missing.
+
+**Compile fixtures.** `test/types/positive/` must compile with no diagnostic at all — the
+README's examples among them — and `test/types/negative/` holds the shapes the README
+promises will not compile. `check-types-fixtures.mjs` compiles each in a program of its own:
+
+- line one is `// @targets spec[, package]`; every fixture targets `spec`, and gains
+  `package` once every value it imports exists in `dist/`.
+- a negative fixture carries `// @expect TS####` on the line above the offending one and must
+  produce exactly that: "something went wrong" is not evidence.
+- no suppression and no `any` — either would let a fixture compile proving nothing.
+- `test/types/scaffold.d.ts` declares the values the README examples use without introducing
+  them, so those examples compile as printed.
+
+**Errors.** Two public classes. `LLMSwitchError` has a closed set of codes and a `retryable`
+flag copied from the classification row in spec §5b rather than worked out on the spot. The
+flag belongs to the row and not to the code — `PROVIDER_FAILED` is retryable for a
+`transient` failure and not for a `refused` one — which is why `src/errors` has one factory
+per classification, and why nothing is ever constructed by hand. `ProviderError` is what a
+provider adapter throws, and it is recognised with `ProviderError.is()` — never bare
+`instanceof`, which breaks the moment ESM and CommonJS copies meet. Messages never contain a
 prompt, a model's output, or a raw provider error.
 
 **Tests.** Vitest. Unit tests run everywhere; the ones that need PostgreSQL live in
@@ -62,19 +89,23 @@ section.
 
 ## Commands
 
-| Command                            | What it does                                                         |
-| ---------------------------------- | -------------------------------------------------------------------- |
-| `npm run check`                    | everything below that does not need a database or the network        |
-| `npm run build`                    | the dual ESM + CommonJS build into `dist/`                           |
-| `npm test`                         | unit tests                                                           |
-| `npm run test:coverage`            | unit tests with the coverage thresholds applied                      |
-| `npm run test:integration`         | tests that need `DATABASE_URL`                                       |
-| `npm run depcruise`                | module boundaries                                                    |
-| `npm run api:check` / `api:update` | compare or record the public type surface                            |
-| `npm run size`                     | gzipped size of the root entry against `sizeBudget`                  |
-| `npm run scan`                     | scan the tree for addresses, unreviewed links and key-shaped strings |
-| `npm run audit:tarball -- <tgz>`   | what a packed tarball contains and whether it would run anything     |
-| `npm run test:consumers -- <tgz>`  | install that tarball into ESM, CommonJS and TypeScript projects      |
+| Command                                                  | What it does                                                         |
+| -------------------------------------------------------- | -------------------------------------------------------------------- |
+| `npm run check`                                          | everything below that does not need a database or the network        |
+| `npm run build`                                          | the dual ESM + CommonJS build into `dist/`                           |
+| `npm test`                                               | unit tests                                                           |
+| `npm run test:coverage`                                  | unit tests with the coverage thresholds applied                      |
+| `npm run test:integration`                               | tests that need `DATABASE_URL`                                       |
+| `npm run depcruise`                                      | module boundaries                                                    |
+| `npm run api:check` / `api:update`                       | compare or record the public type surface                            |
+| `npm run surface:update`                                 | regenerate the spec surfaces after editing `docs/spec.md`            |
+| `node scripts/check-spec-surface.mjs`                    | compare what `dist/` exports with what the spec declares             |
+| `node scripts/check-types-fixtures.mjs --target spec`    | compile the type fixtures against the spec surfaces                  |
+| `node scripts/check-types-fixtures.mjs --target package` | the fixtures the build can satisfy, against it                       |
+| `npm run size`                                           | gzipped size of the root entry against `sizeBudget`                  |
+| `npm run scan`                                           | scan the tree for addresses, unreviewed links and key-shaped strings |
+| `npm run audit:tarball -- <tgz>`                         | what a packed tarball contains and whether it would run anything     |
+| `npm run test:consumers -- <tgz>`                        | install that tarball into ESM, CommonJS and TypeScript projects      |
 
 The last two take a tarball you produced with `npm pack`; they never pack one themselves,
 so what you audit is what you test.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ const q = await ai.getQuota('summarize', user.id)
 // reads config before usage.
 ```
 
-Set `perDay: 0` to halt an operation during an incident: every reservation is denied, nothing is inserted, and callers get `QUOTA_EXCEEDED` whenever the usage store answers — if that store is itself unreachable the call still refuses, as `USAGE_STORE_UNAVAILABLE`. It takes effect like any other config change (see the cache note below), and `getQuota` keeps reporting the day's real `used` while `limit` and `remaining` read 0.
+Set `perDay: 0` to halt an operation during an incident: every reservation is denied, no reservation is recorded, and callers get `QUOTA_EXCEEDED` whenever the usage store answers — if that store is itself unreachable the call still refuses, as `USAGE_STORE_UNAVAILABLE`. It takes effect like any other config change (see the cache note below), and `getQuota` keeps reporting the day's real `used` while `limit` and `remaining` read 0.
 
 The Postgres adapter stores metadata only — operation, subject, day, states, token counts — **never prompts or outputs**, and ships with pruning guidance (spec §4).
 
@@ -203,6 +203,8 @@ stores: postgresStores({ pool, schema: 'llmswitch' })  // production — plain S
 ```
 
 `postgresStores` ships a versioned SQL migration (you run it — llmswitch never touches your schema on its own) and uses single-statement atomic operations, safe under concurrency. The exact `ConfigStore`/`UsageStore` contracts — including the idempotent commit protocol and lease semantics — are spec §4 and §6, and a **conformance test suite** ships with the package: passing it verifies your custom adapter against every executed case, concurrency included — check its `skipped` list, because scenarios you don't supply are unverified, not passed.
+
+Whatever store you write it against, the strings llmswitch hands a store — operation names, provider IDs, models, subject IDs, reservation IDs — are well-formed Unicode, free of U+0000, and at most 1 000 bytes of UTF-8, checked before every store call, so any relational backend can hold them verbatim (spec §6).
 
 ## Providers
 

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -1,1 +1,270 @@
-export {}
+import { z } from "zod";
+//#region src/types.d.ts
+/** The operations a switch is built from; every entry MUST be wrapped in `defineOperation`. */
+type OperationsMap = Record<string, OperationDefinition<z.ZodType, z.ZodType>>;
+/** A configured switch: one `run` method plus the admin surface for its runtime config. */
+interface Switch<Ops extends OperationsMap> {
+  /**
+   * Runs one operation end to end and resolves with its validated result.
+   *
+   * @throws `LLMSwitchError` with the code the final classification maps to (spec §5b).
+   */
+  run<K extends keyof Ops & string>(operation: K, args: {
+    input: z.input<Ops[K]['input']>;
+    subjectId?: string;
+  }, options?: {
+    signal?: AbortSignal;
+  }): Promise<RunResult<z.output<Ops[K]['output']>>>;
+  getConfig(): Promise<Record<keyof Ops & string, OperationConfigView>>;
+  setConfig(operation: keyof Ops & string, route: OperationRoute): Promise<void>;
+  resetConfig(operation: keyof Ops & string): Promise<void>;
+  getQuota(operation: keyof Ops & string, subjectId: string): Promise<QuotaView>;
+}
+/** Everything `createSwitch` needs: who can be called, what the app does, where state lives. */
+interface CreateSwitchConfig<Ops extends OperationsMap> {
+  providers: Record<string, Provider>;
+  operations: Ops;
+  stores: StorePair;
+  pricing?: Record<string, Record<string, ModelPrice>>;
+  configTtlMs?: number;
+  treatUnclassifiedAsTransient?: boolean;
+  fallbackOnAuthOrModelNotFound?: boolean;
+  onSettlementError?: (error: unknown, record: SettlementFailure) => void | Promise<void>;
+  logger?: Logger;
+}
+/** What `onSettlementError` is handed: the accounting that could not be written. */
+interface SettlementFailure {
+  reservation: ReservationEnvelope;
+  outcome: 'succeeded' | 'failed';
+  attempts: AttemptRecord[];
+}
+/** The two stores a switch runs on, handed over together. */
+interface StorePair {
+  config: ConfigStore;
+  usage: UsageStore;
+}
+/** A sink for the package's diagnostics; invoked through caught promise chains. */
+interface Logger {
+  info(message: string, data?: unknown): void | Promise<void>;
+  warn(message: string, data?: unknown): void | Promise<void>;
+  error(message: string, data?: unknown): void | Promise<void>;
+}
+/** One operation: its schemas, its prompt, and the optional gates around them. */
+interface OperationDefinition<In extends z.ZodType, Out extends z.ZodType> {
+  input: In;
+  output: Out;
+  prompt: (input: z.output<In>) => string | Promise<string>;
+  format?: 'json' | 'json-any' | 'text';
+  quality?: (ctx: {
+    input: z.output<In>;
+    data: z.output<Out>;
+  }) => QualityVerdict | Promise<QualityVerdict>;
+  quota?: {
+    perDay: number;
+  };
+  timeoutMs?: number;
+  defaultRoute?: OperationRoute;
+}
+/** What a `quality` gate answers: accepted, or rejected with an optional reason. */
+type QualityVerdict = {
+  ok: true;
+} | {
+  ok: false;
+  reason?: string;
+};
+/** One operation's stored route: who answers, with what, under which limit. */
+interface OperationRoute {
+  provider: string;
+  model: string;
+  maxOutputTokens?: number;
+  temperature?: number;
+  quota?: {
+    perDay: number;
+  };
+  fallback?: RouteTarget | null;
+}
+/** Where a fallback attempt goes: a route without a quota or a fallback of its own. */
+interface RouteTarget {
+  provider: string;
+  model: string;
+  maxOutputTokens?: number;
+  temperature?: number;
+}
+/** What `getConfig` reports per operation: what is stored, and what that resolves to. */
+interface OperationConfigView {
+  stored: OperationRoute | null | 'malformed';
+  effective: OperationRoute | null;
+}
+/** One subject's standing against one operation's daily limit. */
+interface QuotaView {
+  limit: number;
+  used: number;
+  remaining: number;
+  resetsAt: string;
+}
+/** What a successful `run` resolves with. */
+interface RunResult<Out> {
+  data: Out;
+  route: {
+    provider: string;
+    model: string;
+  };
+  usedFallback: boolean;
+  attempts: AttemptRecord[];
+  usage: TokenUsage;
+  usageComplete: boolean;
+  cost: number | null;
+}
+/** How one dispatched attempt ended, per the §5b classification table. */
+type AttemptOutcome = 'succeeded' | 'timeout' | 'truncated' | 'refused' | 'output_rejected' | 'output_schema_error' | 'quality_error' | 'provider_unclassified' | ProviderErrorKind;
+/** One dispatched attempt, as it is reported and as it is persisted. */
+interface AttemptRecord {
+  provider: string;
+  model: string;
+  outcome: AttemptOutcome;
+  status?: number;
+  usage: TokenUsage | null;
+  costUsd: number | null;
+  durationMs: number;
+}
+/** Provider-reported token counts. Non-negative SAFE integers. */
+interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+/** One model's price, per million tokens. Finite, ≥ 0. */
+interface ModelPrice {
+  inputPerM: number;
+  outputPerM: number;
+}
+/** What a provider adapter implements: one call out, optionally with a readiness step. */
+interface Provider {
+  prepare?(): PreparedProvider | Promise<PreparedProvider>;
+  complete(req: ProviderRequest): Promise<ProviderResponse>;
+}
+/** What `prepare()` hands back: a dispatcher scoped to one run. */
+interface PreparedProvider {
+  complete(req: ProviderRequest): Promise<ProviderResponse>;
+}
+/** One attempt, as the adapter receives it. */
+interface ProviderRequest {
+  prompt: string;
+  model: string;
+  responseFormat: {
+    type: 'text';
+  } | {
+    type: 'json';
+    topLevel: 'object' | 'any';
+  };
+  maxOutputTokens?: number;
+  temperature?: number;
+  signal: AbortSignal;
+}
+/**
+ * What an attempt returned, discriminated by how the provider terminated.
+ *
+ * Truncation and refusal are billable HTTP-200 terminations, so they travel on the RESPONSE
+ * (usage retained), not as thrown errors. `kind: 'complete'` proceeds to the output pipeline;
+ * `'truncated'` classifies `truncated`; `'refused'` classifies `refused`.
+ */
+type ProviderResponse = {
+  kind: 'complete';
+  text: string;
+  usage: TokenUsage | null;
+} | {
+  kind: 'truncated';
+  text: string;
+  usage: TokenUsage | null;
+} | {
+  kind: 'refused';
+  text: string;
+  usage: TokenUsage | null;
+};
+/** How an adapter classifies a failure; the classification drives fallback (§5b). */
+type ProviderErrorKind = 'transient' | 'rate_limit' | 'auth' | 'model_not_found' | 'invalid_request' | 'aborted' | 'malformed_response';
+/** How a built-in adapter reaches its API key, resolved lazily on every run. */
+type ApiKeyResolver = () => string | undefined | Promise<string | undefined>;
+/** Where routes live. Rows come back verbatim; validating them is the core's job. */
+interface ConfigStore {
+  getAll(): Promise<Record<string, unknown>>;
+  set(operation: string, route: OperationRoute): Promise<void>;
+  delete(operation: string): Promise<void>;
+}
+/** What a daily allowance is counted against: one operation, one subject. */
+type QuotaKey = {
+  operation: string;
+  subjectId: string;
+};
+/** The store-created handle for one reserved slot. `day`: 'YYYY-MM-DD' UTC, store-chosen. */
+interface ReservationEnvelope {
+  reservationId: string;
+  key: QuotaKey;
+  day: string;
+}
+/** Where quota slots are counted. The store's clock owns the UTC day (§4). */
+interface UsageStore {
+  reserve(key: QuotaKey, limit: number): Promise<{
+    ok: true;
+    reservation: ReservationEnvelope;
+    expiresAt: string;
+  } | {
+    ok: false;
+    used: number;
+    resetsAt: string;
+  }>;
+  commit(reservationId: string): Promise<'committed' | 'expired' | 'missing'>;
+  settle(reservation: ReservationEnvelope, outcome: 'succeeded' | 'failed', attempts: AttemptRecord[]): Promise<void>;
+  snapshot(key: QuotaKey): Promise<{
+    used: number;
+    resetsAt: string;
+  }>;
+}
+//#endregion
+//#region src/errors/llmswitch-error.d.ts
+/** A classified llmswitch failure: a stable `code`, a literal `retryable`, no content. */
+declare class LLMSwitchError extends Error {
+  private constructor();
+  /** What went wrong, as a closed set (spec §5b). */
+  readonly code: 'INVALID_INPUT' | 'MISSING_SUBJECT' | 'QUOTA_EXCEEDED' | 'USAGE_STORE_UNAVAILABLE' | 'CONFIG_STORE_UNAVAILABLE' | 'INVALID_CONFIG' | 'ABORTED' | 'PROVIDER_FAILED' | 'OUTPUT_REJECTED';
+  /** The operation that failed. */
+  readonly operation?: string;
+  /** Literal per §5a/§5b. */
+  readonly retryable: boolean;
+  /** When the daily allowance resets, as an ISO instant. `QUOTA_EXCEEDED` carries it. */
+  readonly resetsAt?: string;
+  /** Whether an `INVALID_CONFIG` was found locally or reported by the provider. */
+  readonly detectedAt?: 'local' | 'provider';
+  /** Every dispatched attempt, in dispatch order. */
+  readonly attempts?: AttemptRecord[];
+}
+//#endregion
+//#region src/errors/provider-error.d.ts
+/** A provider failure, classified by the adapter that saw it (spec §5b). */
+declare class ProviderError extends Error {
+  /**
+   * Classifies a failed provider call.
+   *
+   * @param kind The §5b row that describes what happened; it decides whether the run falls back.
+   * @param opts `status` when the provider returned one; `message` replaces the default, which
+   *   is the classification itself. Keep any message free of prompt and model output (§4).
+   */
+  constructor(kind: ProviderErrorKind, opts?: {
+    status?: number;
+    message?: string;
+  });
+  /** How the call failed. The classification, not the wire detail. */
+  readonly kind: ProviderErrorKind;
+  /** The HTTP status, when the provider returned one. */
+  readonly status?: number;
+  /**
+   * Reports whether a value is a `ProviderError`, from any copy of this package.
+   *
+   * Total by construction: every read is inside the `try`, so a throwing getter or a hostile
+   * `Proxy` answers `false` rather than escaping into the caller's classification path. The
+   * shape is checked as well as the brand.
+   */
+  static is(value: unknown): value is ProviderError;
+}
+//#endregion
+export { type ApiKeyResolver, type AttemptOutcome, type AttemptRecord, type ConfigStore, type CreateSwitchConfig, LLMSwitchError, type Logger, type ModelPrice, type OperationConfigView, type OperationDefinition, type OperationRoute, type OperationsMap, type PreparedProvider, type Provider, ProviderError, type ProviderErrorKind, type ProviderRequest, type ProviderResponse, type QualityVerdict, type QuotaKey, type QuotaView, type ReservationEnvelope, type RouteTarget, type RunResult, type SettlementFailure, type StorePair, type Switch, type TokenUsage, type UsageStore };
+//# sourceMappingURL=index.d.ts.map

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,17 +22,24 @@ graph TD
   stores["stores/<br/>one adapter per backend"]
   suites["conformance/<br/>harnesses over interfaces"]
   errors["errors/<br/>the error surface"]
+  types["types.ts<br/>the public shapes"]
 
   root --> core
   root --> providers
   root --> stores
   root --> errors
+  root --> types
   pg --> stores
   conf --> suites
   core --> errors
   providers --> errors
   stores --> errors
   suites --> errors
+  core --> types
+  providers --> types
+  stores --> types
+  suites --> types
+  errors --> types
 ```
 
 Every arrow points down the same slope, so the graph has no cycles, and the layer that
@@ -40,9 +47,15 @@ changes most often — the adapters — sits where nothing depends on it.
 
 ## What each folder is for
 
-**`errors/`** is the bottom. One error class with a closed set of codes, the typed
-factories that construct it, and the literal `retryable` value that belongs to each code.
-Everything may depend on it; it depends on nothing.
+**`types.ts`** is the floor: every shape the package publishes, declared once from spec §6,
+importing nothing but Zod.
+
+**`errors/`** is the bottom layer of behaviour. Two public classes: `LLMSwitchError`, with a
+closed set of codes, the typed factories that construct it, and the literal `retryable` of
+the spec §5b classification row — the row, not the code, since `PROVIDER_FAILED` is retryable
+for a `transient` failure and not for a `refused` one; and `ProviderError`, which an adapter
+throws to classify a failed call and which is recognised by a brand rather than by
+`instanceof`. Everything may depend on it; it depends on nothing but the public types.
 
 **`core/`** decides. The run state machine, config resolution and its cache, failure
 classification, the quota lifecycle. It is pure: no HTTP, no SQL, no Node built-ins at

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -158,6 +158,9 @@ active envelope.
   counts committed + unexpired pending slots for the store's current UTC day; under `limit`
   → insert pending reservation, lease `expiresAt = min(now + leaseMs, resetsAt)` (a lease
   never crosses the day boundary).
+  A denial's `used` is authoritative for that `reserve`'s own snapshot-and-lock point: it is
+  never lower than live usage, and it exceeds live usage only by rows that lapsed or appeared
+  while that `reserve` waited for the counter.
   **`limit === 0`:** the core **still calls `reserve`** and never short-circuits — `used` and
   `resetsAt` must be store-authoritative. An available store returns the complete denial
   `{ ok: false, used, resetsAt }` — `used` being the day's authoritative count, which may be
@@ -414,7 +417,7 @@ export declare function defineOperation<In extends z.ZodType, Out extends z.ZodT
   def: OperationDefinition<In, Out>
 ): OperationDefinition<In, Out>
 export declare function defineOperations<Ops extends OperationsMap>(ops: Ops): Ops
-export type OperationsMap = Record<string, OperationDefinition<any, any>>
+export type OperationsMap = Record<string, OperationDefinition<z.ZodType, z.ZodType>>
 
 export interface Switch<Ops extends OperationsMap> {
   run<K extends keyof Ops & string>(
@@ -571,13 +574,14 @@ export interface UsageStore {
 }
 export declare function memoryStores(): StorePair
 export declare function postgresStores(opts: {
-  pool: { query(sql: string, params?: unknown[]): Promise<{ rows: any[] }> }
+  pool: { query(sql: string, params?: unknown[]): Promise<{ rows: unknown[] }> }
   schema?: string                                        // default 'llmswitch'; validated identifier
   leaseMs?: number                                       // default 120_000; 5_000–600_000
 }): StorePair
 
 // ——— errors ———
 export declare class LLMSwitchError extends Error {
+  private constructor()                                  // instances come from the package; narrow on `code`
   readonly code: 'INVALID_INPUT' | 'MISSING_SUBJECT' | 'QUOTA_EXCEEDED'
     | 'USAGE_STORE_UNAVAILABLE' | 'CONFIG_STORE_UNAVAILABLE' | 'INVALID_CONFIG'
     | 'ABORTED' | 'PROVIDER_FAILED' | 'OUTPUT_REJECTED'
@@ -597,6 +601,22 @@ pricing finite ≥ 0; provider responses failing the `ProviderResponse` union sh
 non-string prompt returns → unwrapped
 `TypeError` (pre-quota); malformed quality verdicts → `quality_error`; malformed prepared
 dispatchers → `INVALID_CONFIG` (local).
+
+**String domain.** Every string that reaches a store — operation names, provider
+registration IDs, `OperationRoute`/`RouteTarget` `provider` and `model`, `subjectId`,
+`ReservationEnvelope.reservationId`, and `AttemptRecord.provider`/`model` — is well-formed
+Unicode (`String.prototype.isWellFormed()`), contains no U+0000, and is at most 1 000 bytes
+of UTF-8. The core checks this **before any store call**, at these boundaries: operation
+names, provider IDs and declared routes at `createSwitch` → `INVALID_CONFIG`; a route at
+`setConfig` → `INVALID_CONFIG`; `subjectId` before `reserve` and before `getQuota`'s
+`snapshot` → `INVALID_INPUT`. A stored `ConfigStore` row that violates it is a malformed row
+and follows the §2 rules. A `ReservationEnvelope` returned by `reserve` that violates it is a
+malformed store result → `USAGE_STORE_UNAVAILABLE`, checked before `commit`; the envelope and
+the attempt records are checked again before `settle`. A store additionally rejects
+out-of-domain values as defence in depth. The bound is part of the contract because a
+relational store cannot hold every JavaScript string: PostgreSQL `text` and `jsonb` reject
+U+0000, lone surrogates do not survive a round trip, and index entries are size-capped — so a
+store that had to narrow the domain itself would not be substitutable.
 
 ## 6a. Core-enforced store deadlines
 
@@ -623,7 +643,8 @@ export interface ConformanceResult { passed: boolean; failures: string[]; skippe
 export declare function runUsageStoreConformance(opts: {
   // create returns the store under test plus REQUIRED test controls:
   // setTime drives the STORE's authoritative clock (for Postgres: a session/test hook the
-  // adapter documents); reset wipes state; readSettled exposes what settle() persisted so
+  // adapter documents) and is called with non-decreasing instants between reset() calls;
+  // reset wipes state; readSettled exposes what settle() persisted so
   // duplicate/conflict/unknown-reservation behavior is observable.
   create(): Promise<{
     store: UsageStore
@@ -684,7 +705,8 @@ persists only a whitelist of route fields, needs updating. Coverage:
   rollover via `setTime`, snapshot correctness including pending, settle
   duplicate/conflict/unknown-reservation behavior observed via `readSettled`,
   envelope validity (key match, `YYYY-MM-DD` day format), a `reserve` call with `limit: 0`
-  denying without inserting a reservation, and a limit lowered below existing
+  denying without inserting a reservation (observed as: a following `reserve` at `limit: 1`
+  on the same key is admitted with `used` 0), and a limit lowered below existing
   pending/committed usage denying new reservations while leaving those rows intact.
   (Settle-FAILURE isolation — a rejecting store not affecting run outcomes — is core
   behavior, tested internally.)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,10 @@ export default tseslint.config(
       'test/consumers/**/node_modules/',
       '**/*.tgz',
       '.changeset/',
+      // Copied byte for byte out of the spec's code fences by
+      // `scripts/check-spec-surface.mjs`. Every other file under `test/types/` is written
+      // by hand and linted like any other.
+      'test/types/spec-surface*.d.ts',
     ],
   },
   js.configs.recommended,
@@ -38,7 +42,7 @@ export default tseslint.config(
     extends: [tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked],
     languageOptions: {
       parserOptions: {
-        project: ['./tsconfig.json', './tsconfig.test.json'],
+        project: ['./tsconfig.json', './tsconfig.test.json', './test/types/tsconfig.json'],
         tsconfigRootDir: import.meta.dirname,
       },
     },
@@ -61,6 +65,20 @@ export default tseslint.config(
     },
   },
 
+  // The negative compile fixtures contain deliberate type errors, so the expressions built
+  // on them have no type the rules can trust. Only that family is turned off: an actual
+  // `any` written into a fixture would defeat the fixture, so `no-explicit-any` stays on.
+  {
+    files: ['test/types/negative/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+    },
+  },
+
   // Maintenance scripts and this config: plain JavaScript, no type information.
   {
     files: ['**/*.js', '**/*.mjs'],
@@ -74,8 +92,8 @@ export default tseslint.config(
   // The consumer fixture templates. They import the package by its published name, which
   // only resolves inside a copy of them with the tarball installed, so they are linted
   // without type information. Not loosely, though: an `any` here would hide the very
-  // thing they exist to prove. They come under the type-aware rules once they carry real
-  // assertions and can be resolved from here.
+  // thing they exist to prove. They come under the type-aware rules if they ever become
+  // resolvable from here.
   {
     files: ['test/consumers/**/*.{mts,cts,mjs,cjs}'],
     extends: [tseslint.configs.strict, tseslint.configs.stylistic],

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "sizeBudget": 32768,
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit && node scripts/check-types-fixtures.mjs --target spec",
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -80,6 +80,7 @@
     "test:coverage": "vitest run --project unit --coverage",
     "api:check": "node scripts/check-api.mjs",
     "api:update": "node scripts/check-api.mjs --update",
+    "surface:update": "node scripts/check-spec-surface.mjs --update",
     "size": "node scripts/check-size.mjs",
     "publint": "publint",
     "attw": "attw --pack . --profile node16",
@@ -87,7 +88,7 @@
     "audit:tarball": "node scripts/audit-tarball.mjs",
     "test:consumers": "node scripts/test-consumers.mjs",
     "scan": "node scripts/scan-denylist.mjs",
-    "check": "npm run format:check && npm run lint && npm run typecheck && npm run depcruise && npm run build && npm run publint && npm run attw && npm run api:check && npm run size && npm run test:coverage"
+    "check": "npm run format:check && npm run lint && npm run typecheck && npm run depcruise && npm run build && node scripts/check-types-fixtures.mjs --target package && node scripts/check-spec-surface.mjs && npm run publint && npm run attw && npm run api:check && npm run size && npm run test:coverage"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.5",

--- a/scripts/check-spec-surface.mjs
+++ b/scripts/check-spec-surface.mjs
@@ -1,0 +1,562 @@
+#!/usr/bin/env node
+/**
+ * Regenerates `test/types/spec-surface*.d.ts` from the §6 and §6b code fences of
+ * docs/spec.md, compiles them with the fixtures' own options, and compares every name
+ * `dist/` exports — ESM and CommonJS, type told apart from value — with what the spec says.
+ *
+ * A spec name the implementation has not reached yet belongs in `spec-pending.json`; any
+ * other difference is a failure. Signatures are not compared: printed text does not
+ * establish what a name resolves to, which is what the `api/*.d.ts` diff is read for.
+ *
+ * Usage: node scripts/check-spec-surface.mjs [--update]
+ * Exit codes: 0 everything agrees, 1 something does not, 2 bad arguments.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import ts from 'typescript'
+
+const ROOT = join(import.meta.dirname, '..')
+const SPEC = join(ROOT, 'docs', 'spec.md')
+const TYPES_DIR = join(ROOT, 'test', 'types')
+const PENDING = join(TYPES_DIR, 'spec-pending.json')
+const USAGE = 'usage: check-spec-surface.mjs [--update]\n'
+
+const HEADER =
+  '// Generated from the code fences of docs/spec.md by scripts/check-spec-surface.mjs.\n' +
+  '// Edit the spec, then run `npm run surface:update`.\n\n'
+
+/** Where each entry point's surface is generated. */
+const ENTRY_POINTS = [
+  { entry: 'index', surface: 'spec-surface.d.ts' },
+  { entry: 'postgres', surface: 'spec-surface-postgres.d.ts' },
+  { entry: 'conformance', surface: 'spec-surface-conformance.d.ts' },
+]
+
+/** The comments §6b uses to say which subpath the declarations under them belong to. */
+const SUBPATH_MARKERS = {
+  postgres: '// subpath: llmswitch/postgres',
+  conformance: '// subpath: llmswitch/conformance',
+}
+
+/** A section: its heading down to the next one of the same level. */
+function sectionAfter(markdown, heading, problems) {
+  const at = markdown.indexOf(heading)
+  if (at === -1) {
+    problems.push(`docs/spec.md has no heading '${heading.trim()}'`)
+    return null
+  }
+  const next = markdown.indexOf('\n## ', at + heading.length)
+  return markdown.slice(at, next === -1 ? markdown.length : next)
+}
+
+/** Every fenced block in a section, in either CommonMark fence form. */
+function fences(section) {
+  const lines = section.split('\n')
+  const blocks = []
+  let open = null
+  for (const [index, line] of lines.entries()) {
+    const marker = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line)
+    if (marker?.[1] === undefined) continue
+    const rail = marker[1]
+    const info = (marker[2] ?? '').trim()
+    if (open === null) {
+      open = { rail, info, from: index + 1 }
+      continue
+    }
+    // A closing rail is the same character, no shorter, and carries no info string.
+    if (rail[0] !== open.rail[0] || rail.length < open.rail.length || info !== '') continue
+    blocks.push({ info: open.info, body: `${lines.slice(open.from, index).join('\n')}\n` })
+    open = null
+  }
+  return { blocks, unclosed: open !== null }
+}
+
+/** The body of a section's one `ts` fence; reading the first of several would publish half. */
+function soleFence(section, label, problems) {
+  const before = problems.length
+  const { blocks, unclosed } = fences(section)
+  if (unclosed) problems.push(`a code fence in ${label} is not closed`)
+  for (const block of blocks) {
+    if (block.info !== 'ts') {
+      problems.push(`a code fence in ${label} is labelled '${block.info}'; it must be 'ts'`)
+    }
+  }
+  if (blocks.length !== 1) {
+    problems.push(`${label} has ${String(blocks.length)} code fences; it must have exactly one`)
+  }
+  const only = blocks[0]
+  return problems.length > before || only === undefined ? null : only.body
+}
+
+/** The names a chunk of declarations exports, read off the declaration keywords. */
+function declaredNames(text) {
+  const names = new Set()
+  const pattern =
+    /^export\s+(?:declare\s+)?(?:interface|type|class|function|const)\s+([A-Za-z_$][\w$]*)/gm
+  for (const match of text.matchAll(pattern)) {
+    const name = match[1]
+    if (name !== undefined) names.add(name)
+  }
+  return names
+}
+
+/**
+ * The import line a subpath surface needs to stand on its own.
+ *
+ * §6b names §6's types freely; compiled alone it would not know what a `UsageStore` is.
+ */
+function importPrelude(chunk, sectionSixNames) {
+  const own = declaredNames(chunk)
+  // Comments come out first: §6b's prose names types the declarations never mention, and
+  // importing one of those would leave the surface with an unused import.
+  const code = chunk.replaceAll(/\/\*[\s\S]*?\*\//g, ' ').replaceAll(/\/\/[^\n]*/g, ' ')
+  const needed = [...sectionSixNames]
+    .filter((name) => !own.has(name))
+    .filter((name) => new RegExp(`\\b${name}\\b`).test(code))
+    .sort()
+  if (needed.length === 0) return ''
+  return `import type { ${needed.join(', ')} } from './spec-surface'\n\n`
+}
+
+/** Splits the §6b fence at its subpath markers, keeping each marker with its declarations. */
+function splitSubpaths(fence, problems) {
+  const found = []
+  for (const [entry, marker] of Object.entries(SUBPATH_MARKERS)) {
+    const at = fence.indexOf(marker)
+    if (at === -1) {
+      problems.push(`the §6b fence has no '${marker}' marker`)
+      continue
+    }
+    if (fence.indexOf(marker, at + marker.length) !== -1) {
+      problems.push(`the §6b fence has more than one '${marker}' marker`)
+    }
+    found.push({ entry, at })
+  }
+  if (problems.length > 0) return null
+  found.sort((a, b) => a.at - b.at)
+
+  const first = found[0]
+  if (first === undefined) return null
+  if (fence.slice(0, first.at).trim() !== '') {
+    problems.push('the §6b fence has declarations above its first `// subpath:` marker')
+    return null
+  }
+
+  const chunks = {}
+  for (const [index, { entry, at }] of found.entries()) {
+    const next = found[index + 1]
+    chunks[entry] =
+      fence.slice(at, next === undefined ? fence.length : next.at).trimEnd() + '\n'
+  }
+
+  // A name that landed in no chunk would be a published export nothing ever compares against.
+  const placed = new Set()
+  for (const chunk of Object.values(chunks))
+    for (const name of declaredNames(chunk)) placed.add(name)
+  for (const name of declaredNames(fence)) {
+    if (!placed.has(name)) problems.push(`§6b declares ${name}, which no subpath marker claims`)
+  }
+  return problems.length > 0 ? null : chunks
+}
+
+/** What every entry point's surface should contain, generated from the spec. */
+function generateSurfaces(problems) {
+  const markdown = readFileSync(SPEC, 'utf8')
+  const sixSection = sectionAfter(markdown, '\n## 6. Public API', problems)
+  const sixBSection = sectionAfter(markdown, '\n## 6b. Packaged operational surfaces', problems)
+  if (sixSection === null || sixBSection === null) return null
+
+  const sectionSix = soleFence(sixSection, 'spec §6', problems)
+  const sectionSixB = soleFence(sixBSection, 'spec §6b', problems)
+  if (sectionSix === null || sectionSixB === null) return null
+
+  const chunks = splitSubpaths(sectionSixB, problems)
+  if (chunks === null) return null
+
+  const sectionSixNames = declaredNames(sectionSix)
+  const surfaces = { index: HEADER + sectionSix }
+  for (const [entry, chunk] of Object.entries(chunks)) {
+    surfaces[entry] = HEADER + importPrelude(chunk, sectionSixNames) + chunk
+  }
+  return surfaces
+}
+
+/** Writes the generated surfaces, or reports the ones that have drifted. */
+function reconcileSurfaces(surfaces, update, problems) {
+  for (const { entry, surface } of ENTRY_POINTS) {
+    const path = join(TYPES_DIR, surface)
+    const expected = surfaces[entry]
+    if (expected === undefined) {
+      problems.push(`no surface was generated for '${entry}'`)
+      continue
+    }
+    if (update) {
+      writeFileSync(path, expected)
+      continue
+    }
+    const recorded = existsSync(path) ? readFileSync(path, 'utf8') : null
+    if (recorded !== expected) {
+      problems.push(
+        `test/types/${surface} no longer matches docs/spec.md — run \`npm run surface:update\``,
+      )
+    }
+  }
+}
+
+/** The options the compile fixtures use, so the surfaces are held to the same bar. */
+function fixtureOptions() {
+  const configPath = join(TYPES_DIR, 'tsconfig.json')
+  const read = ts.readConfigFile(configPath, (path) => readFileSync(path, 'utf8'))
+  if (read.error !== undefined) {
+    throw new Error(ts.flattenDiagnosticMessageText(read.error.messageText, '\n'))
+  }
+  const parsed = ts.parseJsonConfigFileContent(read.config, ts.sys, TYPES_DIR)
+  if (parsed.errors.length > 0) {
+    throw new Error(
+      parsed.errors
+        .map((error) => ts.flattenDiagnosticMessageText(error.messageText, '\n'))
+        .join('\n'),
+    )
+  }
+  return parsed.options
+}
+
+/**
+ * Compiles the three surfaces together.
+ *
+ * A misspelt type would otherwise generate a surface that resolves to `any` wherever it is
+ * used, and every fixture would still pass.
+ */
+function compileSurfaces(problems) {
+  const paths = ENTRY_POINTS.map(({ surface }) => join(TYPES_DIR, surface))
+  const program = ts.createProgram(paths, fixtureOptions())
+  for (const diagnostic of ts.getPreEmitDiagnostics(program)) {
+    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ')
+    const file = diagnostic.file
+    if (file === undefined || diagnostic.start === undefined) {
+      problems.push(`the generated surfaces: TS${String(diagnostic.code)}: ${message}`)
+      continue
+    }
+    const { line } = file.getLineAndCharacterOfPosition(diagnostic.start)
+    problems.push(
+      `${relative(ROOT, file.fileName)}:${String(line + 1)} TS${String(diagnostic.code)}: ${message}`,
+    )
+  }
+  return program
+}
+
+/**
+ * The names an entry file publishes type-only, however that is written.
+ *
+ * `export type * from './dep'` leaves no `ExportSpecifier` behind, so the class it re-exports
+ * still looks like a value to anyone who asks the symbol.
+ */
+function typeOnlyExports(checker, source) {
+  const names = new Set()
+  for (const statement of source.statements) {
+    if (!ts.isExportDeclaration(statement) || !statement.isTypeOnly) continue
+    const clause = statement.exportClause
+    if (clause !== undefined) {
+      if (ts.isNamespaceExport(clause)) names.add(clause.name.text)
+      else for (const element of clause.elements) names.add(element.name.text)
+      continue
+    }
+    const specifier = statement.moduleSpecifier
+    if (specifier === undefined) continue
+    const module = checker.getSymbolAtLocation(specifier)
+    if (module === undefined) continue
+    for (const exported of checker.getExportsOfModule(module)) names.add(exported.name)
+  }
+  return names
+}
+
+/** Whether a name is exported as a value or only as a type; the syntax has the first word. */
+function exportedKind(checker, symbol, typeOnly) {
+  const target =
+    (symbol.flags & ts.SymbolFlags.Alias) === 0 ? symbol : checker.getAliasedSymbol(symbol)
+  if ((target.flags & ts.SymbolFlags.Value) === 0) return 'type'
+  // A named export overrides a star export of the same name, so it decides on its own.
+  const specifiers = (symbol.declarations ?? []).filter((node) => ts.isExportSpecifier(node))
+  if (specifiers.length > 0) {
+    return specifiers.some((node) => !node.isTypeOnly && !node.parent.parent.isTypeOnly)
+      ? 'value'
+      : 'type'
+  }
+  return typeOnly.has(symbol.name) ? 'type' : 'value'
+}
+
+/** Every name a declaration file exports, with whether it is a value or only a type. */
+function inventory(program, path) {
+  const source = program.getSourceFile(path)
+  if (source === undefined) throw new Error(`could not read ${path}`)
+  const checker = program.getTypeChecker()
+  const moduleSymbol = checker.getSymbolAtLocation(source)
+  if (moduleSymbol === undefined) throw new Error(`${path} is not a module`)
+  const typeOnly = typeOnlyExports(checker, source)
+  const found = new Map()
+  for (const symbol of checker.getExportsOfModule(moduleSymbol)) {
+    found.set(symbol.name, exportedKind(checker, symbol, typeOnly))
+  }
+  return found
+}
+
+/** Every way a name can be exported, and what each one publishes. */
+const KIND_PROOF = {
+  '/kind-proof-dep.d.ts':
+    'export declare class ReExportedAsTypeOnly {}\n' +
+    'export declare class ReExportedBothWays {}\n' +
+    'export interface ReExportedInterface {\n  a: string\n}\n',
+  '/kind-proof.d.ts':
+    'declare class ExportedInPlace {}\n' +
+    'declare class ExportedBySpecifier {}\n' +
+    'declare class ExportedAsTypeOnly {}\n' +
+    'declare class ExportedInATypeClause {}\n' +
+    'interface PlainInterface {\n  a: string\n}\n' +
+    'export declare function exportedDirectly(): void\n' +
+    'export { ExportedInPlace }\n' +
+    'export { ExportedBySpecifier, type ExportedAsTypeOnly, PlainInterface }\n' +
+    'export type { ExportedInATypeClause }\n' +
+    "export type * from './kind-proof-dep'\n" +
+    "export { ReExportedBothWays } from './kind-proof-dep'\n",
+}
+
+/** What `inventory` has to say about each of them. */
+const KIND_PROOF_EXPECTED = {
+  exportedDirectly: 'value',
+  ExportedInPlace: 'value',
+  ExportedBySpecifier: 'value',
+  ExportedAsTypeOnly: 'type',
+  ExportedInATypeClause: 'type',
+  PlainInterface: 'type',
+  ReExportedAsTypeOnly: 'type',
+  ReExportedBothWays: 'value',
+  ReExportedInterface: 'type',
+}
+
+/**
+ * Proves the type-versus-value decision on a file written for the purpose, every run.
+ *
+ * Getting it wrong is silent: every name would still be present, so the inventory would agree
+ * with itself while the package published something else.
+ */
+function proveKindDecision(problems) {
+  const host = {
+    fileExists: (name) => Object.hasOwn(KIND_PROOF, name),
+    readFile: (name) => KIND_PROOF[name],
+    getSourceFile: (name) => {
+      const text = KIND_PROOF[name]
+      return text === undefined
+        ? undefined
+        : ts.createSourceFile(name, text, ts.ScriptTarget.ES2022, true, ts.ScriptKind.TS)
+    },
+    getDefaultLibFileName: () => 'lib.d.ts',
+    writeFile: () => undefined,
+    getCurrentDirectory: () => '/',
+    getCanonicalFileName: (name) => name,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => '\n',
+  }
+  const program = ts.createProgram(
+    Object.keys(KIND_PROOF),
+    {
+      noEmit: true,
+      noLib: true,
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.Preserve,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+    },
+    host,
+  )
+  const found = inventory(program, '/kind-proof.d.ts')
+  for (const [name, kind] of Object.entries(KIND_PROOF_EXPECTED)) {
+    const reported = found.get(name)
+    if (reported !== kind) {
+      problems.push(
+        `this script reports ${name} as ${reported ?? 'nothing'} when it is exported as a ${kind}; ` +
+          'the inventory below cannot be trusted',
+      )
+    }
+  }
+  for (const name of found.keys()) {
+    if (!Object.hasOwn(KIND_PROOF_EXPECTED, name)) {
+      problems.push(`this script found an unexpected export ${name} in its own proof file`)
+    }
+  }
+}
+
+/** Both declaration files of every entry point, as the package publishes them. */
+function distPaths() {
+  const paths = []
+  for (const { entry } of ENTRY_POINTS) {
+    paths.push(join(ROOT, 'dist', `${entry}.d.ts`), join(ROOT, 'dist', `${entry}.d.cts`))
+  }
+  return paths
+}
+
+/** What each entry point declares in the spec and publishes in each of the two builds. */
+function readInventories(specProgram) {
+  const distProgram = ts.createProgram(distPaths(), {
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  })
+
+  const inventories = new Map()
+  for (const { entry, surface } of ENTRY_POINTS) {
+    inventories.set(entry, {
+      spec: inventory(specProgram, join(TYPES_DIR, surface)),
+      esm: inventory(distProgram, join(ROOT, 'dist', `${entry}.d.ts`)),
+      cjs: inventory(distProgram, join(ROOT, 'dist', `${entry}.d.cts`)),
+    })
+  }
+  return inventories
+}
+
+/** Reads the list of spec names that are not implemented yet. */
+function readPending() {
+  const raw = JSON.parse(readFileSync(PENDING, 'utf8'))
+  const pending = new Map()
+  for (const { entry } of ENTRY_POINTS) {
+    const listed = raw[entry]
+    if (listed === undefined) throw new Error(`spec-pending.json has no '${entry}' entry`)
+    const names = new Map()
+    for (const kind of ['value', 'type']) {
+      const list = listed[kind]
+      if (!Array.isArray(list))
+        throw new Error(`spec-pending.json '${entry}.${kind}' is not a list`)
+      for (const name of list) names.set(name, kind)
+    }
+    pending.set(entry, names)
+  }
+  return pending
+}
+
+/** Compares one entry point's spec surface with what the two builds publish. */
+function comparePublished(entry, found, pending, problems) {
+  const { spec, esm, cjs } = found
+  for (const [name, kind] of esm) {
+    if (cjs.get(name) !== kind) {
+      problems.push(
+        `${entry}: the ESM build exports ${name} as a ${kind}, the CommonJS build does not`,
+      )
+    }
+  }
+  for (const name of cjs.keys()) {
+    if (!esm.has(name))
+      problems.push(`${entry}: the CommonJS build exports ${name}, the ESM build does not`)
+  }
+
+  for (const [name, kind] of pending) {
+    if (!spec.has(name))
+      problems.push(`${entry}: ${name} is listed as pending but the spec does not declare it`)
+    if (esm.has(name)) {
+      problems.push(
+        `${entry}: ${name} is published but still listed in spec-pending.json — remove it there`,
+      )
+    }
+    if (spec.get(name) !== kind) {
+      problems.push(
+        `${entry}: ${name} is listed as a pending ${kind} but the spec declares it otherwise`,
+      )
+    }
+  }
+
+  for (const [name, kind] of spec) {
+    if (pending.has(name)) continue
+    const published = esm.get(name)
+    if (published === undefined)
+      problems.push(`${entry}: the spec declares ${name} but dist does not export it`)
+    else if (published !== kind) {
+      problems.push(
+        `${entry}: the spec declares ${name} as a ${kind}, dist publishes it as a ${published}`,
+      )
+    }
+  }
+
+  for (const name of esm.keys()) {
+    if (!spec.has(name))
+      problems.push(`${entry}: dist exports ${name}, which the spec does not declare`)
+  }
+}
+
+/** Prints whatever went wrong and fails. */
+function report(problems) {
+  for (const problem of problems) process.stderr.write(`${problem}\n`)
+  return 1
+}
+
+/** The flags, or `null` when they do not make sense. */
+function readArguments(argv) {
+  let update = false
+  for (const argument of argv) {
+    if (argument !== '--update') {
+      process.stderr.write(`unknown argument '${argument}'\n${USAGE}`)
+      return null
+    }
+    if (update) {
+      process.stderr.write(`'--update' was given twice\n${USAGE}`)
+      return null
+    }
+    update = true
+  }
+  return { update }
+}
+
+function main() {
+  const parsed = readArguments(process.argv.slice(2))
+  if (parsed === null) return 2
+  const { update } = parsed
+  const problems = []
+
+  proveKindDecision(problems)
+  if (problems.length > 0) return report(problems)
+
+  const surfaces = generateSurfaces(problems)
+  if (surfaces === null) return report(problems)
+
+  reconcileSurfaces(surfaces, update, problems)
+  if (problems.length > 0) return report(problems)
+
+  const specProgram = compileSurfaces(problems)
+  if (problems.length > 0) return report(problems)
+
+  // `--update` has to work on a checkout that was never built, or a spec edit could not be
+  // taken up without a build first.
+  const missing = distPaths().filter((path) => !existsSync(path))
+  if (missing.length > 0) {
+    if (!update) {
+      problems.push(
+        `${relative(ROOT, missing[0] ?? '')} is missing — run \`npm run build\` first`,
+      )
+      return report(problems)
+    }
+    process.stdout.write(
+      'spec surfaces regenerated and compiled; dist is not built, so the exports were not compared\n',
+    )
+    return 0
+  }
+
+  const inventories = readInventories(specProgram)
+  const pending = readPending()
+  for (const { entry } of ENTRY_POINTS) {
+    const found = inventories.get(entry)
+    const listed = pending.get(entry)
+    if (found === undefined || listed === undefined)
+      throw new Error(`no inventory for '${entry}'`)
+    comparePublished(entry, found, listed, problems)
+  }
+  if (problems.length > 0) return report(problems)
+
+  const counted = [...inventories.values()].reduce((total, found) => total + found.spec.size, 0)
+  process.stdout.write(
+    `${update ? 'spec surfaces regenerated' : 'spec surfaces current'} and compiled; ` +
+      `${String(counted)} declared names checked against dist\n`,
+  )
+  return 0
+}
+
+process.exitCode = main()

--- a/scripts/check-types-fixtures.mjs
+++ b/scripts/check-types-fixtures.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+/**
+ * Compiles every fixture under `test/types/` in a program of its own — one at a time, since
+ * the negative ones are meant to fail — and checks that each behaves as it says it will.
+ *
+ * Line one is `// @targets spec[, package]`: `spec` is what docs/spec.md declares, `package`
+ * what the build ships, and every fixture must target `spec`, the only run that happens
+ * before a build. Positive fixtures compile silently; negative ones carry `// @expect TS####`
+ * on the line above the offending one and must produce exactly that and nothing else. A
+ * suppression or an `any` is refused: either would let a fixture compile proving nothing.
+ *
+ * Usage: node scripts/check-types-fixtures.mjs [--target spec|package]
+ * Exit codes: 0 all behaved, 1 one did not, 2 bad arguments.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import ts from 'typescript'
+
+const ROOT = join(import.meta.dirname, '..')
+const TYPES_DIR = join(ROOT, 'test', 'types')
+const SCAFFOLD = join(TYPES_DIR, 'scaffold.d.ts')
+const USAGE = 'usage: check-types-fixtures.mjs [--target spec|package]\n'
+
+/** Where `llmswitch` and its subpaths point for each target. */
+const TARGETS = {
+  spec: {
+    llmswitch: './spec-surface.d.ts',
+    'llmswitch/postgres': './spec-surface-postgres.d.ts',
+    'llmswitch/conformance': './spec-surface-conformance.d.ts',
+  },
+  package: {
+    llmswitch: '../../dist/index.d.ts',
+    'llmswitch/postgres': '../../dist/postgres.d.ts',
+    'llmswitch/conformance': '../../dist/conformance.d.ts',
+  },
+}
+
+/** Anything that could hide a diagnostic. */
+const SUPPRESSIONS = ['@ts-expect-error', '@ts-ignore', '@ts-nocheck', 'eslint-disable']
+
+/** The options the fixtures are compiled with, read from their own tsconfig. */
+function readBaseOptions() {
+  const configPath = join(TYPES_DIR, 'tsconfig.json')
+  const read = ts.readConfigFile(configPath, (path) => readFileSync(path, 'utf8'))
+  if (read.error !== undefined) {
+    throw new Error(ts.flattenDiagnosticMessageText(read.error.messageText, '\n'))
+  }
+  const parsed = ts.parseJsonConfigFileContent(read.config, ts.sys, TYPES_DIR)
+  if (parsed.errors.length > 0) {
+    throw new Error(
+      parsed.errors
+        .map((error) => ts.flattenDiagnosticMessageText(error.messageText, '\n'))
+        .join('\n'),
+    )
+  }
+  return parsed.options
+}
+
+/** Comments as the compiler sees them, so a `//` inside a string literal is not one. */
+function scanComments(text) {
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.ES2022,
+    false,
+    ts.LanguageVariant.Standard,
+    text,
+  )
+  const found = []
+  for (
+    let token = scanner.scan();
+    token !== ts.SyntaxKind.EndOfFileToken;
+    token = scanner.scan()
+  ) {
+    const single = token === ts.SyntaxKind.SingleLineCommentTrivia
+    if (!single && token !== ts.SyntaxKind.MultiLineCommentTrivia) continue
+    found.push({ single, start: scanner.getTokenStart(), text: scanner.getTokenText() })
+  }
+  return found
+}
+
+/** Every position at which a fixture writes the `any` type. */
+function anyKeywords(source) {
+  const found = []
+  const visit = (node) => {
+    if (node.kind === ts.SyntaxKind.AnyKeyword) found.push(node.getStart(source))
+    ts.forEachChild(node, visit)
+  }
+  ts.forEachChild(source, visit)
+  return found
+}
+
+/** The `@targets` header and `@expect` markers, read only from comments the scanner found. */
+function readHeader(fixture, problems) {
+  const { kind, name, text, source, comments } = fixture
+  const lineOf = (position) => source.getLineAndCharacterOfPosition(position)
+
+  const opening = comments.find((comment) => comment.start === 0)
+  const header =
+    opening?.single === true ? /^\/\/ @targets (.+)$/.exec(opening.text.trim()) : null
+  if (header?.[1] === undefined) {
+    problems.push(`${name}:1: the first line must be '// @targets spec[, package]'`)
+    return null
+  }
+  const targets = header[1].split(',').map((target) => target.trim())
+  for (const target of targets) {
+    if (!Object.hasOwn(TARGETS, target)) {
+      problems.push(`${name}:1: unknown target '${target}'`)
+      return null
+    }
+  }
+  if (!targets.includes('spec')) {
+    problems.push(
+      `${name}:1: every fixture must target 'spec'; this one targets ${targets.join(', ')}`,
+    )
+    return null
+  }
+
+  const expected = []
+  let malformed = false
+  for (const comment of comments) {
+    if (!comment.single || !comment.text.trim().startsWith('// @expect')) continue
+    const { line, character } = lineOf(comment.start)
+    if (text.slice(comment.start - character, comment.start).trim() !== '') {
+      problems.push(
+        `${name}:${String(line + 1)}: an '@expect' marker must be alone on its line`,
+      )
+      malformed = true
+      continue
+    }
+    const marker = /^\/\/ @expect (TS\d+(?: TS\d+)*)$/.exec(comment.text.trim())
+    if (marker?.[1] === undefined) {
+      problems.push(
+        `${name}:${String(line + 1)}: a marker must read '// @expect TS####', further codes separated by single spaces`,
+      )
+      malformed = true
+      continue
+    }
+    for (const code of marker[1].split(' ')) {
+      expected.push({ line: line + 2, code: Number(code.slice(2)) })
+    }
+  }
+  if (malformed) return null
+
+  // A negative fixture with no marker would pass by compiling cleanly, the exact opposite of
+  // what it claims; a positive one with a marker claims two things and is checked for one.
+  if (kind === 'negative' && expected.length === 0) {
+    problems.push(
+      `${name}: a negative fixture must carry at least one '// @expect TS####' marker`,
+    )
+    return null
+  }
+  if (kind === 'positive' && expected.length > 0) {
+    problems.push(
+      `${name}: a positive fixture compiles cleanly, so it carries no '@expect' marker`,
+    )
+    return null
+  }
+  return { targets, expected }
+}
+
+/** Every fixture that declares itself properly; the rest are reported and left out. */
+function readFixtures(problems) {
+  const fixtures = []
+  for (const kind of ['positive', 'negative']) {
+    for (const file of readdirSync(join(TYPES_DIR, kind)).sort()) {
+      if (!file.endsWith('.ts')) continue
+      const path = join(TYPES_DIR, kind, file)
+      const text = readFileSync(path, 'utf8')
+      const fixture = {
+        kind,
+        path,
+        name: `test/types/${kind}/${file}`,
+        text,
+        source: ts.createSourceFile(path, text, ts.ScriptTarget.ES2022, true, ts.ScriptKind.TS),
+        comments: scanComments(text),
+      }
+      const header = readHeader(fixture, problems)
+      if (header !== null) fixtures.push({ ...fixture, ...header })
+    }
+  }
+  return fixtures
+}
+
+/** Refuses a fixture that hides a diagnostic or writes `any`; either would void the proof. */
+function readableSource(fixture, problems) {
+  const before = problems.length
+  const at = (position) =>
+    String(fixture.source.getLineAndCharacterOfPosition(position).line + 1)
+
+  for (const comment of fixture.comments) {
+    for (const suppression of SUPPRESSIONS) {
+      if (!comment.text.includes(suppression)) continue
+      problems.push(
+        `${fixture.name}:${at(comment.start)}: contains '${suppression}', which would hide the diagnostic it exists to prove`,
+      )
+    }
+  }
+  for (const position of anyKeywords(fixture.source)) {
+    problems.push(
+      `${fixture.name}:${at(position)}: writes \`any\`, so whatever it compiles proves nothing`,
+    )
+  }
+  return problems.length === before
+}
+
+/** `{ line, code }` for every diagnostic, split into the fixture's own and everything else. */
+function collectDiagnostics(program, fixturePath) {
+  const own = []
+  const foreign = []
+  for (const diagnostic of ts.getPreEmitDiagnostics(program)) {
+    const file = diagnostic.file
+    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ')
+    if (file === undefined || diagnostic.start === undefined) {
+      foreign.push({ where: 'the compiler options', line: 0, code: diagnostic.code, message })
+      continue
+    }
+    const { line } = file.getLineAndCharacterOfPosition(diagnostic.start)
+    const entry = {
+      where: relative(ROOT, file.fileName),
+      line: line + 1,
+      code: diagnostic.code,
+      message,
+    }
+    if (file.fileName === fixturePath.replaceAll('\\', '/') || file.fileName === fixturePath)
+      own.push(entry)
+    else foreign.push(entry)
+  }
+  return { own, foreign }
+}
+
+/** Diagnostics as a sorted, comparable list of `line:code` pairs. */
+function asPairs(entries) {
+  return entries.map(({ line, code }) => `${String(line)}:TS${String(code)}`).sort()
+}
+
+/** Compiles one fixture against one target and reports whatever did not match. */
+function checkFixture(fixture, target, baseOptions, problems) {
+  const paths = {}
+  for (const [specifier, location] of Object.entries(TARGETS[target]))
+    paths[specifier] = [location]
+  const program = ts.createProgram([SCAFFOLD, fixture.path], { ...baseOptions, paths })
+  const { own, foreign } = collectDiagnostics(program, fixture.path)
+
+  for (const entry of foreign) {
+    problems.push(
+      `${fixture.name} [${target}]: ${entry.where}:${String(entry.line)} TS${String(entry.code)}: ${entry.message}`,
+    )
+  }
+
+  const actual = asPairs(own)
+  const expected = asPairs(fixture.expected)
+  if (actual.join('|') === expected.join('|')) return
+
+  problems.push(
+    `${fixture.name} [${target}]: expected ${expected.length === 0 ? 'no diagnostics' : expected.join(', ')}, ` +
+      `got ${actual.length === 0 ? 'none' : actual.join(', ')}\n` +
+      own
+        .map(
+          (entry) => `    line ${String(entry.line)} TS${String(entry.code)}: ${entry.message}`,
+        )
+        .join('\n'),
+  )
+}
+
+/** The target to compile against, or `null` when the arguments do not make sense. */
+function readArguments(argv) {
+  let target = null
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument !== '--target') {
+      process.stderr.write(`unknown argument '${String(argument)}'\n${USAGE}`)
+      return null
+    }
+    if (target !== null) {
+      process.stderr.write(`'--target' was given twice\n${USAGE}`)
+      return null
+    }
+    index += 1
+    const value = argv[index]
+    if (value === undefined || !Object.hasOwn(TARGETS, value)) {
+      process.stderr.write(
+        `'--target' needs one of ${Object.keys(TARGETS).join(', ')}\n${USAGE}`,
+      )
+      return null
+    }
+    target = value
+  }
+  return target ?? 'spec'
+}
+
+function main() {
+  const target = readArguments(process.argv.slice(2))
+  if (target === null) return 2
+
+  const baseOptions = readBaseOptions()
+  const problems = []
+  const fixtures = readFixtures(problems)
+  let checked = 0
+  for (const fixture of fixtures) {
+    if (!readableSource(fixture, problems)) continue
+    if (!fixture.targets.includes(target)) continue
+    checkFixture(fixture, target, baseOptions, problems)
+    checked += 1
+  }
+
+  if (problems.length > 0) {
+    for (const problem of problems) process.stderr.write(`${problem}\n`)
+    return 1
+  }
+  process.stdout.write(
+    `${String(checked)} of ${String(fixtures.length)} compile fixtures behave as documented against the ${target} surface\n`,
+  )
+  return 0
+}
+
+process.exitCode = main()

--- a/scripts/test-consumers.mjs
+++ b/scripts/test-consumers.mjs
@@ -237,7 +237,10 @@ function main() {
   for (const problem of problems) process.stdout.write(`${problem}\n`)
   process.stdout.write(
     problems.length === 0
-      ? `all fixtures import ${String(SUBPATHS.length)} entry points from sha256 ${before}\n`
+      ? `all fixtures reached ${String(SUBPATHS.length)} entry points, recognised a ProviderError ` +
+          'across the ESM and CommonJS builds in both directions, rejected the values that only ' +
+          'look like one, and narrowed LLMSwitchError by code — ' +
+          `from sha256 ${before}\n`
       : `${String(problems.length)} problem(s)\n`,
   )
   return problems.length === 0 ? 0 : 1

--- a/src/errors/README.md
+++ b/src/errors/README.md
@@ -1,10 +1,16 @@
 # `src/errors`
 
-The error surface adopters catch: one error class with a closed `code` union, the
-literal `retryable` flag that goes with each code, and the typed factories every throw
-site uses. Messages are stable and carry no prompt, model output, or raw provider
-error.
+The two error classes adopters see. `LLMSwitchError` is what a classified failure raises: a
+closed `code` union, a private constructor, and a `retryable` flag that is the literal of the
+spec §5b classification row rather than of the code — `PROVIDER_FAILED` is retryable for a
+`transient` failure and not for a `refused` one, which is why there is one typed factory per
+classification. `ProviderError` is what an adapter throws to say how a call failed; it is
+recognised by a brand on its prototype, never by `instanceof`, so it still classifies
+correctly when the thrower and the reader loaded different copies of the package.
 
-May import: `src/errors`, the public types, and `zod`. This is the bottom layer —
-nothing else in `src` may be imported from here, so every other folder can depend on
-it without creating a cycle.
+The factories stay internal. Messages are stable and carry no prompt, model output, or raw
+provider error.
+
+May import: the public types in `src/types.ts`, `src/errors` itself, and `zod`. This is the
+bottom layer of behaviour — nothing else in `src` may be imported from here, so every other
+folder can depend on it without creating a cycle.

--- a/src/errors/factories.ts
+++ b/src/errors/factories.ts
@@ -1,0 +1,192 @@
+/**
+ * The typed constructors for every `LLMSwitchError` the package raises.
+ *
+ * One factory per classification, not per code: spec §5b makes `retryable` a function of the
+ * classification, so `PROVIDER_FAILED` is retryable for a `transient` failure and not for a
+ * `refused` one. Taking the classification and looking the literal up is what stops a throw
+ * site disagreeing with the table. Messages carry an operation, a field or a classification —
+ * never a prompt, a model's output, or a raw provider error (spec §4).
+ *
+ * @module
+ */
+
+import type { AttemptRecord } from '../types'
+import { constructLLMSwitchError } from './llmswitch-error'
+import type { LLMSwitchError } from './llmswitch-error'
+import type { ProviderError } from './provider-error'
+
+/** The classifications that end a run as `PROVIDER_FAILED` (spec §5b). */
+export type ProviderFailureKind =
+  | 'transient'
+  | 'rate_limit'
+  | 'malformed_response'
+  | 'timeout'
+  | 'refused'
+  | 'invalid_request'
+  | 'provider_unclassified'
+
+/** The classifications that end a run as `OUTPUT_REJECTED` (spec §5b). */
+export type OutputRejectionKind = 'truncated' | 'output_rejected'
+
+/** The `retryable` column of the §5b rows that end `PROVIDER_FAILED`. */
+const providerFailureRetryable: Readonly<Record<ProviderFailureKind, boolean>> = {
+  transient: true,
+  rate_limit: true,
+  malformed_response: true,
+  timeout: true,
+  refused: false,
+  invalid_request: false,
+  provider_unclassified: false,
+}
+
+/** The `retryable` column of the §5b rows that end `OUTPUT_REJECTED`. */
+const outputRejectionRetryable: Readonly<Record<OutputRejectionKind, boolean>> = {
+  truncated: true,
+  output_rejected: true,
+}
+
+/** The input failed the operation's schema, or the operation name is not one of ours. */
+export function invalidInput(operation: string, field: string): LLMSwitchError {
+  return constructLLMSwitchError({
+    code: 'INVALID_INPUT',
+    message: `invalid input for "${operation}": ${field}`,
+    operation,
+    retryable: false,
+  })
+}
+
+/** The operation has an effective quota, so it cannot run without a subject. */
+export function missingSubject(operation: string): LLMSwitchError {
+  return constructLLMSwitchError({
+    code: 'MISSING_SUBJECT',
+    message: `"${operation}" has an effective quota, so it requires a subjectId`,
+    operation,
+    retryable: false,
+  })
+}
+
+/** The subject has used its allowance for the store's current UTC day. */
+export function quotaExceeded(operation: string, resetsAt: string): LLMSwitchError {
+  return constructLLMSwitchError({
+    code: 'QUOTA_EXCEEDED',
+    message: `"${operation}" is over its daily quota until ${resetsAt}`,
+    operation,
+    retryable: false,
+    resetsAt,
+  })
+}
+
+/** The usage store did not answer, so the run is refused rather than risked. */
+export function usageStoreUnavailable(operation: string, cause: unknown): LLMSwitchError {
+  return constructLLMSwitchError({
+    code: 'USAGE_STORE_UNAVAILABLE',
+    message: `the usage store did not answer, so "${operation}" was refused`,
+    operation,
+    retryable: true,
+    cause,
+  })
+}
+
+/** The config store did not answer and no fresh route was cached. */
+export function configStoreUnavailable(operation: string, cause: unknown): LLMSwitchError {
+  return constructLLMSwitchError({
+    code: 'CONFIG_STORE_UNAVAILABLE',
+    message: `the config store did not answer, so "${operation}" was refused`,
+    operation,
+    retryable: true,
+    cause,
+  })
+}
+
+/**
+ * The configuration is wrong here, before anything was dispatched.
+ *
+ * @param opts Pass `cause` when a `prepare()` threw something that is not a transient
+ *   `ProviderError`. An options object, so chaining a caught `undefined` stays distinguishable
+ *   from having nothing to chain.
+ */
+export function invalidConfigLocal(
+  operation: string,
+  field: string,
+  opts: { cause?: unknown } = {},
+): LLMSwitchError {
+  return constructLLMSwitchError({
+    code: 'INVALID_CONFIG',
+    message: `invalid configuration for "${operation}": ${field}`,
+    operation,
+    retryable: false,
+    detectedAt: 'local',
+    ...('cause' in opts ? { cause: opts.cause } : {}),
+  })
+}
+
+/** A `prepare()` threw `ProviderError('transient')`, so the same call may work later (§5a). */
+export function invalidConfigTransientPrepare(
+  operation: string,
+  cause: ProviderError,
+): LLMSwitchError {
+  return constructLLMSwitchError({
+    code: 'INVALID_CONFIG',
+    message: `a provider for "${operation}" could not be prepared; the failure is transient`,
+    operation,
+    retryable: true,
+    detectedAt: 'local',
+    cause,
+  })
+}
+
+/** The provider rejected the credentials or the model, after the slot was committed. */
+export function invalidConfigProvider(
+  operation: string,
+  attempts: AttemptRecord[],
+): LLMSwitchError {
+  return constructLLMSwitchError({
+    code: 'INVALID_CONFIG',
+    message: `the provider rejected the credentials or model configured for "${operation}"`,
+    operation,
+    retryable: false,
+    detectedAt: 'provider',
+    attempts,
+  })
+}
+
+/** The caller's signal fired; `attempts` only when the run had already dispatched. */
+export function aborted(operation: string, attempts?: AttemptRecord[]): LLMSwitchError {
+  return constructLLMSwitchError({
+    code: 'ABORTED',
+    message: `"${operation}" was aborted by its caller`,
+    operation,
+    retryable: false,
+    ...(attempts === undefined ? {} : { attempts }),
+  })
+}
+
+/** The final attempt failed at the provider; `kind` is the §5b row that decides `retryable`. */
+export function providerFailed(
+  operation: string,
+  kind: ProviderFailureKind,
+  attempts: AttemptRecord[],
+): LLMSwitchError {
+  return constructLLMSwitchError({
+    code: 'PROVIDER_FAILED',
+    message: `"${operation}" failed at the provider: ${kind}`,
+    operation,
+    retryable: providerFailureRetryable[kind],
+    attempts,
+  })
+}
+
+/** The final attempt produced output the pipeline rejected (spec §3). */
+export function outputRejected(
+  operation: string,
+  kind: OutputRejectionKind,
+  attempts: AttemptRecord[],
+): LLMSwitchError {
+  return constructLLMSwitchError({
+    code: 'OUTPUT_REJECTED',
+    message: `"${operation}" produced output that was rejected: ${kind}`,
+    operation,
+    retryable: outputRejectionRetryable[kind],
+    attempts,
+  })
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,24 @@
+/**
+ * The error layer: the two classes adopters see, and the factories the package throws through.
+ *
+ * Only the classes reach the published surface. Letting an adopter build an `LLMSwitchError`
+ * would make its code mean "someone said so" rather than "the package classified it".
+ *
+ * @module
+ */
+
+export { LLMSwitchError } from './llmswitch-error'
+export { ProviderError } from './provider-error'
+export {
+  aborted,
+  configStoreUnavailable,
+  invalidConfigLocal,
+  invalidConfigProvider,
+  invalidConfigTransientPrepare,
+  invalidInput,
+  missingSubject,
+  outputRejected,
+  providerFailed,
+  quotaExceeded,
+  usageStoreUnavailable,
+} from './factories'

--- a/src/errors/llmswitch-error.ts
+++ b/src/errors/llmswitch-error.ts
@@ -1,0 +1,89 @@
+/**
+ * The error every classified llmswitch failure raises.
+ *
+ * Adopters catch it and branch on `code`; they never construct it, which is why the
+ * constructor is private (spec §6). Inside the package it is reached through `./factories`,
+ * so `retryable` is always the literal of the §5a/§5b classification row.
+ *
+ * @module
+ */
+
+import type { AttemptRecord } from '../types'
+
+/** The fields a factory supplies. Not public: the shape an adopter sees is the class. */
+interface LLMSwitchErrorInit {
+  code: LLMSwitchError['code']
+  message: string
+  operation: string
+  retryable: boolean
+  resetsAt?: string
+  detectedAt?: 'local' | 'provider'
+  attempts?: AttemptRecord[]
+  cause?: unknown
+}
+
+/**
+ * The private constructor, reachable from `./factories` and nowhere else.
+ *
+ * A class's static block runs with the class's own privileges, so it can hand the constructor
+ * to this module without widening it for anyone.
+ */
+let construct: (init: LLMSwitchErrorInit) => LLMSwitchError
+
+/** A classified llmswitch failure: a stable `code`, a literal `retryable`, no content. */
+export class LLMSwitchError extends Error {
+  private constructor(init: LLMSwitchErrorInit) {
+    // Presence, not value: `new Error(m, { cause: undefined })` carries a `cause`, and a
+    // caught `undefined` is still something the caller chose to chain.
+    super(init.message, 'cause' in init ? { cause: init.cause } : {})
+    this.name = 'LLMSwitchError'
+    this.code = init.code
+    this.operation = init.operation
+    this.retryable = init.retryable
+    if (init.resetsAt !== undefined) this.resetsAt = init.resetsAt
+    if (init.detectedAt !== undefined) this.detectedAt = init.detectedAt
+    if (init.attempts !== undefined) this.attempts = init.attempts
+  }
+
+  /** What went wrong, as a closed set (spec §5b). */
+  declare readonly code:
+    | 'INVALID_INPUT'
+    | 'MISSING_SUBJECT'
+    | 'QUOTA_EXCEEDED'
+    | 'USAGE_STORE_UNAVAILABLE'
+    | 'CONFIG_STORE_UNAVAILABLE'
+    | 'INVALID_CONFIG'
+    | 'ABORTED'
+    | 'PROVIDER_FAILED'
+    | 'OUTPUT_REJECTED'
+
+  /** The operation that failed. */
+  declare readonly operation?: string
+
+  /** Literal per §5a/§5b. */
+  declare readonly retryable: boolean
+
+  /** When the daily allowance resets, as an ISO instant. `QUOTA_EXCEEDED` carries it. */
+  declare readonly resetsAt?: string
+
+  /** Whether an `INVALID_CONFIG` was found locally or reported by the provider. */
+  declare readonly detectedAt?: 'local' | 'provider'
+
+  /** Every dispatched attempt, in dispatch order. */
+  declare readonly attempts?: AttemptRecord[]
+
+  // Sanitized: no prompts, no model output, no raw provider errors.
+
+  static {
+    construct = (init) => new LLMSwitchError(init)
+  }
+}
+
+/**
+ * Builds an `LLMSwitchError`.
+ *
+ * @internal Only `./factories` calls this; it is not part of the published surface.
+ */
+export function constructLLMSwitchError(init: LLMSwitchErrorInit): LLMSwitchError {
+  return construct(init)
+}

--- a/src/errors/provider-error.ts
+++ b/src/errors/provider-error.ts
@@ -1,0 +1,82 @@
+/**
+ * The error a provider adapter throws to say how a call failed.
+ *
+ * Its `kind` drives the fallback matrix (spec §5b), so recognising one must work even when
+ * the thrower and the reader loaded different copies of this module — the dual-package
+ * hazard. Recognition is therefore brand-based, and `ProviderError.is()` is the only
+ * supported check; bare `instanceof` is never used.
+ *
+ * @module
+ */
+
+import type { ProviderErrorKind } from '../types'
+
+/** The recognition brand: one symbol per process, whichever copy or realm asks for it. */
+const brand: unique symbol = Symbol.for('llmswitch.ProviderError')
+
+/** The closed set from spec §6; `satisfies` makes a kind added to the union a compile error. */
+const kinds = {
+  transient: true,
+  rate_limit: true,
+  auth: true,
+  model_not_found: true,
+  invalid_request: true,
+  aborted: true,
+  malformed_response: true,
+} satisfies Record<ProviderErrorKind, true>
+
+/** A provider failure, classified by the adapter that saw it (spec §5b). */
+export class ProviderError extends Error {
+  /**
+   * Classifies a failed provider call.
+   *
+   * @param kind The §5b row that describes what happened; it decides whether the run falls back.
+   * @param opts `status` when the provider returned one; `message` replaces the default, which
+   *   is the classification itself. Keep any message free of prompt and model output (§4).
+   */
+  constructor(kind: ProviderErrorKind, opts?: { status?: number; message?: string }) {
+    super(opts?.message ?? `provider error: ${kind}`)
+    this.name = 'ProviderError'
+    this.kind = kind
+    if (opts?.status !== undefined) this.status = opts.status
+  }
+
+  /** How the call failed. The classification, not the wire detail. */
+  declare readonly kind: ProviderErrorKind
+
+  /** The HTTP status, when the provider returned one. */
+  declare readonly status?: number
+
+  /**
+   * Reports whether a value is a `ProviderError`, from any copy of this package.
+   *
+   * Total by construction: every read is inside the `try`, so a throwing getter or a hostile
+   * `Proxy` answers `false` rather than escaping into the caller's classification path. The
+   * shape is checked as well as the brand.
+   */
+  static is(value: unknown): value is ProviderError {
+    try {
+      if (typeof value !== 'object' || value === null) return false
+      const candidate = value as Record<PropertyKey, unknown>
+      if (candidate[brand] !== true) return false
+      const kind = candidate.kind
+      if (typeof kind !== 'string' || !Object.hasOwn(kinds, kind)) return false
+      if (typeof candidate.message !== 'string') return false
+      const status = candidate.status
+      return status === undefined || typeof status === 'number'
+    } catch {
+      return false
+    }
+  }
+
+  static {
+    // On the prototype and non-enumerable, so it costs nothing per error and never shows up
+    // in a spread or a log line. A class member would change the published declaration.
+    Object.defineProperty(this.prototype, brand, {
+      value: true,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    })
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,43 @@
 /**
  * Root entry point — `import { … } from 'llmswitch'`.
  *
- * This is the only module that assembles the pieces: it will export the factory that
- * turns providers, operation definitions and stores into a working switch, the
- * built-in provider adapters, the in-memory stores, the error type every failed run
- * raises, and the types describing all of them.
- *
- * The exact surface is specified in `docs/spec.md` §6. Nothing is exported yet — the
- * package is pre-release and the implementation lands before the first publish.
+ * The only module that assembles the pieces: the factory that turns providers, operations
+ * and stores into a working switch, the built-in adapters, the in-memory stores, the errors,
+ * and the types describing them. The surface is spec §6, listed name by name rather than
+ * re-exported wholesale so a new declaration cannot reach adopters by accident. The package
+ * is pre-release; the remaining values land before the first publish.
  *
  * @module
  */
 
-export {}
+export type {
+  OperationsMap,
+  Switch,
+  CreateSwitchConfig,
+  SettlementFailure,
+  StorePair,
+  Logger,
+  OperationDefinition,
+  QualityVerdict,
+  OperationRoute,
+  RouteTarget,
+  OperationConfigView,
+  QuotaView,
+  RunResult,
+  AttemptOutcome,
+  AttemptRecord,
+  TokenUsage,
+  ModelPrice,
+  Provider,
+  PreparedProvider,
+  ProviderRequest,
+  ProviderResponse,
+  ProviderErrorKind,
+  ApiKeyResolver,
+  ConfigStore,
+  QuotaKey,
+  ReservationEnvelope,
+  UsageStore,
+} from './types'
+
+export { LLMSwitchError, ProviderError } from './errors'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,265 @@
+/**
+ * The public type surface, transcribed from `docs/spec.md` §6 in the order it declares them.
+ *
+ * Shapes only: the file imports nothing but Zod, so every other folder can depend on it
+ * without inheriting anything, and a public shape is never declared twice. Ranges and
+ * defaults stay in the comments the spec gives them — they are enforced at runtime, since a
+ * `number` cannot say "safe integer, 0 to 1 000 000".
+ *
+ * @module
+ */
+
+import type { z } from 'zod'
+
+// ——— entry point ———
+
+/** The operations a switch is built from; every entry MUST be wrapped in `defineOperation`. */
+export type OperationsMap = Record<string, OperationDefinition<z.ZodType, z.ZodType>>
+
+/** A configured switch: one `run` method plus the admin surface for its runtime config. */
+export interface Switch<Ops extends OperationsMap> {
+  /**
+   * Runs one operation end to end and resolves with its validated result.
+   *
+   * @throws `LLMSwitchError` with the code the final classification maps to (spec §5b).
+   */
+  run<K extends keyof Ops & string>(
+    operation: K,
+    args: { input: z.input<Ops[K]['input']>; subjectId?: string },
+    options?: { signal?: AbortSignal },
+  ): Promise<RunResult<z.output<Ops[K]['output']>>>
+  getConfig(): Promise<Record<keyof Ops & string, OperationConfigView>>
+  setConfig(operation: keyof Ops & string, route: OperationRoute): Promise<void>
+  resetConfig(operation: keyof Ops & string): Promise<void>
+  // Resolves config first (§2), so it may also fail CONFIG_STORE_UNAVAILABLE/INVALID_CONFIG;
+  // no effective quota → INVALID_INPUT; requires non-empty subjectId
+  getQuota(operation: keyof Ops & string, subjectId: string): Promise<QuotaView>
+}
+
+/** Everything `createSwitch` needs: who can be called, what the app does, where state lives. */
+export interface CreateSwitchConfig<Ops extends OperationsMap> {
+  providers: Record<string, Provider>
+  operations: Ops
+  stores: StorePair
+  pricing?: Record<string, Record<string, ModelPrice>>
+  configTtlMs?: number // default 5_000; 0–300_000
+  treatUnclassifiedAsTransient?: boolean // default false
+  fallbackOnAuthOrModelNotFound?: boolean // default false; primary attempt only (§5a/§5b)
+  onSettlementError?: (error: unknown, record: SettlementFailure) => void | Promise<void>
+  logger?: Logger
+}
+
+/** What `onSettlementError` is handed: the accounting that could not be written. */
+export interface SettlementFailure {
+  reservation: ReservationEnvelope
+  outcome: 'succeeded' | 'failed'
+  attempts: AttemptRecord[]
+}
+
+/** The two stores a switch runs on, handed over together. */
+export interface StorePair {
+  config: ConfigStore
+  usage: UsageStore
+}
+
+/** A sink for the package's diagnostics; invoked through caught promise chains. */
+export interface Logger {
+  info(message: string, data?: unknown): void | Promise<void>
+  warn(message: string, data?: unknown): void | Promise<void>
+  error(message: string, data?: unknown): void | Promise<void>
+}
+
+// ——— operations ———
+
+/** One operation: its schemas, its prompt, and the optional gates around them. */
+export interface OperationDefinition<In extends z.ZodType, Out extends z.ZodType> {
+  input: In
+  output: Out
+  prompt: (input: z.output<In>) => string | Promise<string>
+  format?: 'json' | 'json-any' | 'text' // default 'json' (§3)
+  quality?: (ctx: {
+    input: z.output<In>
+    data: z.output<Out>
+  }) => QualityVerdict | Promise<QualityVerdict>
+  quota?: { perDay: number } // safe integer, 0–1_000_000 (0 = halted)
+  timeoutMs?: number // provider I/O timeout; default 60_000; 1_000–600_000
+  defaultRoute?: OperationRoute
+}
+
+/** What a `quality` gate answers: accepted, or rejected with an optional reason. */
+export type QualityVerdict = { ok: true } | { ok: false; reason?: string }
+
+// ——— routing / views ———
+
+/** One operation's stored route: who answers, with what, under which limit. */
+export interface OperationRoute {
+  provider: string // non-empty registered provider ID
+  model: string // non-empty
+  maxOutputTokens?: number // safe integer ≥ 1
+  temperature?: number // finite, 0–2 (profiles may clamp; §5c)
+  quota?: { perDay: number } // safe integer, 0–1_000_000; overrides the declared quota (§2)
+  fallback?: RouteTarget | null
+}
+
+/** Where a fallback attempt goes: a route without a quota or a fallback of its own. */
+export interface RouteTarget {
+  provider: string
+  model: string
+  maxOutputTokens?: number
+  temperature?: number
+}
+
+/** What `getConfig` reports per operation: what is stored, and what that resolves to. */
+export interface OperationConfigView {
+  stored: OperationRoute | null | 'malformed'
+  effective: OperationRoute | null
+}
+
+/** One subject's standing against one operation's daily limit. */
+export interface QuotaView {
+  limit: number // the effective limit: route override, else declared
+  used: number
+  remaining: number // max(0, limit - used)
+  resetsAt: string
+}
+
+// ——— run results ———
+
+/** What a successful `run` resolves with. */
+export interface RunResult<Out> {
+  data: Out
+  route: { provider: string; model: string }
+  usedFallback: boolean
+  attempts: AttemptRecord[]
+  usage: TokenUsage
+  usageComplete: boolean
+  cost: number | null
+}
+
+/** How one dispatched attempt ended, per the §5b classification table. */
+export type AttemptOutcome =
+  | 'succeeded'
+  | 'timeout'
+  | 'truncated'
+  | 'refused'
+  | 'output_rejected'
+  | 'output_schema_error'
+  | 'quality_error'
+  | 'provider_unclassified'
+  | ProviderErrorKind
+
+/** One dispatched attempt, as it is reported and as it is persisted. */
+export interface AttemptRecord {
+  provider: string
+  model: string
+  outcome: AttemptOutcome
+  status?: number
+  usage: TokenUsage | null
+  costUsd: number | null
+  durationMs: number
+}
+
+/** Provider-reported token counts. Non-negative SAFE integers. */
+export interface TokenUsage {
+  inputTokens: number
+  outputTokens: number
+}
+
+/** One model's price, per million tokens. Finite, ≥ 0. */
+export interface ModelPrice {
+  inputPerM: number
+  outputPerM: number
+}
+
+// ——— providers ———
+
+/** What a provider adapter implements: one call out, optionally with a readiness step. */
+export interface Provider {
+  prepare?(): PreparedProvider | Promise<PreparedProvider> // §5a; memoized per run per provider ID
+  complete(req: ProviderRequest): Promise<ProviderResponse> // used directly when prepare absent
+}
+
+/** What `prepare()` hands back: a dispatcher scoped to one run. */
+export interface PreparedProvider {
+  complete(req: ProviderRequest): Promise<ProviderResponse>
+}
+
+/** One attempt, as the adapter receives it. */
+export interface ProviderRequest {
+  prompt: string
+  model: string
+  responseFormat: { type: 'text' } | { type: 'json'; topLevel: 'object' | 'any' }
+  maxOutputTokens?: number // omitted from the wire body when unset — never defaulted (§5c)
+  temperature?: number // omitted from the wire body when unset — never defaulted (§5c)
+  signal: AbortSignal
+}
+
+/**
+ * What an attempt returned, discriminated by how the provider terminated.
+ *
+ * Truncation and refusal are billable HTTP-200 terminations, so they travel on the RESPONSE
+ * (usage retained), not as thrown errors. `kind: 'complete'` proceeds to the output pipeline;
+ * `'truncated'` classifies `truncated`; `'refused'` classifies `refused`.
+ */
+export type ProviderResponse =
+  | { kind: 'complete'; text: string; usage: TokenUsage | null }
+  | { kind: 'truncated'; text: string; usage: TokenUsage | null } // text may be partial
+  | { kind: 'refused'; text: string; usage: TokenUsage | null } // text may be empty
+
+/** How an adapter classifies a failure; the classification drives fallback (§5b). */
+export type ProviderErrorKind =
+  | 'transient'
+  | 'rate_limit'
+  | 'auth'
+  | 'model_not_found'
+  | 'invalid_request'
+  | 'aborted'
+  | 'malformed_response'
+
+/** How a built-in adapter reaches its API key, resolved lazily on every run. */
+export type ApiKeyResolver = () => string | undefined | Promise<string | undefined>
+
+// ——— stores ———
+
+/** Where routes live. Rows come back verbatim; validating them is the core's job. */
+export interface ConfigStore {
+  getAll(): Promise<Record<string, unknown>>
+  set(operation: string, route: OperationRoute): Promise<void>
+  delete(operation: string): Promise<void>
+}
+
+/** What a daily allowance is counted against: one operation, one subject. */
+// An alias rather than an interface because that is how spec §6 declares it, and the
+// published declaration is the one adopters read against the spec.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type QuotaKey = { operation: string; subjectId: string }
+
+/** The store-created handle for one reserved slot. `day`: 'YYYY-MM-DD' UTC, store-chosen. */
+export interface ReservationEnvelope {
+  reservationId: string
+  key: QuotaKey
+  day: string
+}
+
+/** Where quota slots are counted. The store's clock owns the UTC day (§4). */
+export interface UsageStore {
+  reserve(
+    key: QuotaKey,
+    limit: number,
+  ): Promise<
+    | { ok: true; reservation: ReservationEnvelope; expiresAt: string }
+    | { ok: false; used: number; resetsAt: string }
+  >
+  commit(reservationId: string): Promise<'committed' | 'expired' | 'missing'>
+  settle(
+    reservation: ReservationEnvelope,
+    outcome: 'succeeded' | 'failed',
+    attempts: AttemptRecord[],
+  ): Promise<void>
+  snapshot(key: QuotaKey): Promise<{ used: number; resetsAt: string }>
+}
+
+// ——— packaged operational surfaces (spec §6b) ———
+//
+// The shapes `llmswitch/postgres` and `llmswitch/conformance` publish are declared below this
+// line and re-exported by those entry points alone, so the root surface stays exactly §6.

--- a/test/consumers/cjs/index.cjs
+++ b/test/consumers/cjs/index.cjs
@@ -1,4 +1,6 @@
-// Reaches every advertised entry point the way a CommonJS application does.
+// Reaches every advertised entry point the way a CommonJS application does, then checks the
+// same recognition claim from this side: this build's error is recognised by the ESM build,
+// and the ESM build's error by this one.
 const conformance = require('llmswitch/conformance')
 const postgres = require('llmswitch/postgres')
 const root = require('llmswitch')
@@ -9,4 +11,60 @@ for (const [name, entry] of Object.entries({ root, postgres, conformance })) {
   }
 }
 
-console.log('cjs consumer reached all three entry points')
+/** Fails the fixture with the claim that did not hold. */
+function check(claim, held) {
+  if (!held) throw new Error(claim)
+}
+
+async function main() {
+  // `import()` from CommonJS resolves the `import` condition, so this is the other build.
+  const esm = await import('llmswitch')
+
+  const fromCjs = new root.ProviderError('rate_limit', { status: 429 })
+  const fromEsm = new esm.ProviderError('auth', { status: 401 })
+
+  check(
+    'the two builds turned out to be the same class, so this proves nothing',
+    root.ProviderError !== esm.ProviderError,
+  )
+  check(
+    'bare instanceof already recognised it, so this proves nothing',
+    !(fromEsm instanceof root.ProviderError),
+  )
+  check(
+    'the ESM build did not recognise an error from the CommonJS build',
+    esm.ProviderError.is(fromCjs),
+  )
+  check(
+    'the CommonJS build did not recognise an error from the ESM build',
+    root.ProviderError.is(fromEsm),
+  )
+
+  for (const value of [
+    undefined,
+    null,
+    0,
+    'transient',
+    new Error('failed'),
+    { kind: 'transient' },
+  ]) {
+    check(`${String(value)} was mistaken for a provider error`, !root.ProviderError.is(value))
+  }
+
+  const brand = Symbol.for('llmswitch.ProviderError')
+  check(
+    'an object carrying the brand with an unknown kind was accepted',
+    !root.ProviderError.is({ [brand]: true, kind: 'overloaded', message: 'x' }),
+  )
+  check(
+    'an object carrying the brand with no message was accepted',
+    !root.ProviderError.is({ [brand]: true, kind: 'auth' }),
+  )
+
+  console.log('cjs consumer reached all three entry points and recognised errors across builds')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/test/consumers/esm/index.mjs
+++ b/test/consumers/esm/index.mjs
@@ -1,7 +1,15 @@
-// Reaches every advertised entry point the way an ESM application does.
+// Reaches every advertised entry point the way an ESM application does, then checks the one
+// thing only an installed package can check: an error thrown by the ESM build is recognised
+// by the CommonJS build, and the other way round. That is the dual-package hazard, and it is
+// why recognition is brand-based rather than `instanceof`.
+import { createRequire } from 'node:module'
+
 import * as conformance from 'llmswitch/conformance'
 import * as postgres from 'llmswitch/postgres'
 import * as root from 'llmswitch'
+
+const requireFromHere = createRequire(import.meta.url)
+const commonjs = requireFromHere('llmswitch')
 
 for (const [name, entry] of Object.entries({ root, postgres, conformance })) {
   if (typeof entry !== 'object' || entry === null) {
@@ -9,4 +17,50 @@ for (const [name, entry] of Object.entries({ root, postgres, conformance })) {
   }
 }
 
-console.log('esm consumer reached all three entry points')
+/** Fails the fixture with the claim that did not hold. */
+function check(claim, held) {
+  if (!held) throw new Error(claim)
+}
+
+const fromEsm = new root.ProviderError('rate_limit', { status: 429 })
+const fromCjs = new commonjs.ProviderError('auth', { status: 401 })
+
+check(
+  'the two builds turned out to be the same class, so this proves nothing',
+  root.ProviderError !== commonjs.ProviderError,
+)
+check(
+  'bare instanceof already recognised it, so this proves nothing',
+  !(fromCjs instanceof root.ProviderError),
+)
+check(
+  'the CommonJS build did not recognise an error from the ESM build',
+  commonjs.ProviderError.is(fromEsm),
+)
+check(
+  'the ESM build did not recognise an error from the CommonJS build',
+  root.ProviderError.is(fromCjs),
+)
+
+for (const value of [
+  undefined,
+  null,
+  0,
+  'transient',
+  new Error('failed'),
+  { kind: 'transient' },
+]) {
+  check(`${String(value)} was mistaken for a provider error`, !root.ProviderError.is(value))
+}
+
+const forged = {
+  [Symbol.for('llmswitch.ProviderError')]: true,
+  kind: 'overloaded',
+  message: 'x',
+}
+check(
+  'an object carrying the brand with an unknown kind was accepted',
+  !root.ProviderError.is(forged),
+)
+
+console.log('esm consumer reached all three entry points and recognised errors across builds')

--- a/test/consumers/ts/a.mts
+++ b/test/consumers/ts/a.mts
@@ -2,5 +2,50 @@
 import * as conformance from 'llmswitch/conformance'
 import * as postgres from 'llmswitch/postgres'
 import * as root from 'llmswitch'
+import { LLMSwitchError, ProviderError, type OperationRoute } from 'llmswitch'
 
 export const reached = [root, postgres, conformance].length
+
+// The codes are a closed set, and this is what says so from outside the package: every one
+// of them is handled, and the `never` in the default arm refuses anything that is not on
+// the list. A code added to — or removed from — the union stops this file compiling.
+export function httpStatus(error: LLMSwitchError): number {
+  switch (error.code) {
+    case 'INVALID_INPUT':
+      return 400
+    case 'MISSING_SUBJECT':
+      return 500
+    case 'QUOTA_EXCEEDED':
+      return 429
+    case 'CONFIG_STORE_UNAVAILABLE':
+    case 'USAGE_STORE_UNAVAILABLE':
+      return 503
+    case 'INVALID_CONFIG':
+      return 500
+    case 'ABORTED':
+      return 499
+    case 'PROVIDER_FAILED':
+    case 'OUTPUT_REJECTED':
+      return 502
+    default: {
+      const unhandled: never = error.code
+      return unhandled
+    }
+  }
+}
+
+// `resetsAt` is optional on the class as a whole rather than tied to a code — the error is
+// not a discriminated union — so it is still `string | undefined` after this narrowing, and
+// the caller has to say what to do when it is absent.
+export function retryAfter(error: unknown): string | null {
+  if (error instanceof LLMSwitchError && error.code === 'QUOTA_EXCEEDED') {
+    return error.resetsAt ?? null
+  }
+  return null
+}
+
+export function classify(error: unknown): string {
+  return ProviderError.is(error) ? error.kind : 'unclassified'
+}
+
+export const route: OperationRoute = { provider: 'claude', model: 'claude-sonnet-4-6' }

--- a/test/consumers/ts/b.cts
+++ b/test/consumers/ts/b.cts
@@ -4,3 +4,45 @@ import postgres = require('llmswitch/postgres')
 import conformance = require('llmswitch/conformance')
 
 export const reached = [root, postgres, conformance].length
+
+// The same closed set, reached through the `require` declarations rather than the `import`
+// ones: a consumer whose types resolved to the wrong half would not compile this.
+export function httpStatus(error: root.LLMSwitchError): number {
+  switch (error.code) {
+    case 'INVALID_INPUT':
+      return 400
+    case 'MISSING_SUBJECT':
+      return 500
+    case 'QUOTA_EXCEEDED':
+      return 429
+    case 'CONFIG_STORE_UNAVAILABLE':
+    case 'USAGE_STORE_UNAVAILABLE':
+      return 503
+    case 'INVALID_CONFIG':
+      return 500
+    case 'ABORTED':
+      return 499
+    case 'PROVIDER_FAILED':
+    case 'OUTPUT_REJECTED':
+      return 502
+    default: {
+      const unhandled: never = error.code
+      return unhandled
+    }
+  }
+}
+
+// `resetsAt` is optional on the class as a whole rather than tied to a code — the error is
+// not a discriminated union — so it is still `string | undefined` after this narrowing.
+export function retryAfter(error: unknown): string | null {
+  if (error instanceof root.LLMSwitchError && error.code === 'QUOTA_EXCEEDED') {
+    return error.resetsAt ?? null
+  }
+  return null
+}
+
+export function classify(error: unknown): string {
+  return root.ProviderError.is(error) ? error.kind : 'unclassified'
+}
+
+export const route: root.OperationRoute = { provider: 'claude', model: 'claude-sonnet-4-6' }

--- a/test/types/negative/prompt-input.ts
+++ b/test/types/negative/prompt-input.ts
@@ -1,0 +1,14 @@
+// @targets spec
+// The typo the README promises is a compile error: `prompt` reads a field the input schema
+// does not declare.
+import { defineOperation, defineOperations } from 'llmswitch'
+import { z } from 'zod'
+
+export const operations = defineOperations({
+  summarize: defineOperation({
+    input: z.object({ text: z.string() }),
+    output: z.object({ summary: z.string() }),
+    // @expect TS2339
+    prompt: ({ txt }) => String(txt),
+  }),
+})

--- a/test/types/negative/provider-error-kind.ts
+++ b/test/types/negative/provider-error-kind.ts
@@ -1,0 +1,10 @@
+// @targets spec, package
+// The classification set is closed: an adapter cannot invent a kind, because the fallback
+// matrix has no row for one.
+import { ProviderError } from 'llmswitch'
+
+// @expect TS2345
+export const invented = new ProviderError('overloaded')
+
+// @expect TS2345
+export const wrongCase = new ProviderError('RATE_LIMIT', { status: 429 })

--- a/test/types/negative/provider-response.ts
+++ b/test/types/negative/provider-response.ts
@@ -1,0 +1,10 @@
+// @targets spec, package
+// The response union is discriminated, so an adapter that invents a termination kind or
+// mistypes the payload is rejected rather than classified.
+import type { ProviderResponse } from 'llmswitch'
+
+// @expect TS2322
+export const unknownKind: ProviderResponse = { kind: 'partial', text: '', usage: null }
+
+// @expect TS2322
+export const wrongPayload: ProviderResponse = { kind: 'complete', text: 42, usage: null }

--- a/test/types/negative/quality-data.ts
+++ b/test/types/negative/quality-data.ts
@@ -1,0 +1,15 @@
+// @targets spec
+// The quality gate sees the output schema's type, so a field that schema does not declare
+// cannot be read from `data`.
+import { defineOperation, defineOperations } from 'llmswitch'
+import { z } from 'zod'
+
+export const operations = defineOperations({
+  summarize: defineOperation({
+    input: z.object({ text: z.string() }),
+    output: z.object({ summary: z.string() }),
+    prompt: ({ text }) => text,
+    // @expect TS2339
+    quality: ({ data }) => (data.wordCount === 0 ? { ok: false } : { ok: true }),
+  }),
+})

--- a/test/types/negative/quality-input.ts
+++ b/test/types/negative/quality-input.ts
@@ -1,0 +1,15 @@
+// @targets spec
+// The other half of the same rule: `input` in a quality gate is the input schema's parsed
+// type, not whatever the caller happened to pass.
+import { defineOperation, defineOperations } from 'llmswitch'
+import { z } from 'zod'
+
+export const operations = defineOperations({
+  summarize: defineOperation({
+    input: z.object({ text: z.string() }),
+    output: z.object({ summary: z.string() }),
+    prompt: ({ text }) => text,
+    // @expect TS2339
+    quality: ({ input }) => (input.article === '' ? { ok: false } : { ok: true }),
+  }),
+})

--- a/test/types/negative/quality-verdict.ts
+++ b/test/types/negative/quality-verdict.ts
@@ -1,0 +1,15 @@
+// @targets spec
+// A quality gate answers `{ ok: true }` or `{ ok: false, reason? }`. Anything else is a
+// malformed verdict, and the type system says so before a run ever can.
+import { defineOperation, defineOperations } from 'llmswitch'
+import { z } from 'zod'
+
+export const operations = defineOperations({
+  summarize: defineOperation({
+    input: z.object({ text: z.string() }),
+    output: z.object({ summary: z.string() }),
+    prompt: ({ text }) => text,
+    // @expect TS2322
+    quality: () => ({ ok: 'yes' }),
+  }),
+})

--- a/test/types/negative/route-shape.ts
+++ b/test/types/negative/route-shape.ts
@@ -1,0 +1,13 @@
+// @targets spec, package
+// A route names a registered provider and a model. A missing half, a misspelt field, or a
+// field the shape does not have is a configuration bug worth catching where it is written.
+import type { OperationRoute } from 'llmswitch'
+
+// @expect TS2741
+export const missingModel: OperationRoute = { provider: 'claude' }
+
+// @expect TS2561
+export const misspelt: OperationRoute = { provider: 'c', model: 'm', temperture: 1 }
+
+// @expect TS2353
+export const unknown: OperationRoute = { provider: 'c', model: 'm', retries: 3 }

--- a/test/types/negative/run-input.ts
+++ b/test/types/negative/run-input.ts
@@ -1,0 +1,20 @@
+// @targets spec
+// `run` accepts the input schema's `z.input`, so a wrongly typed field is caught at the
+// call site rather than by the parse at stage 2.
+import { createSwitch, defineOperation, defineOperations, memoryStores } from 'llmswitch'
+import { z } from 'zod'
+
+const ai = createSwitch({
+  providers: {},
+  operations: defineOperations({
+    summarize: defineOperation({
+      input: z.object({ text: z.string() }),
+      output: z.object({ summary: z.string() }),
+      prompt: ({ text }) => text,
+    }),
+  }),
+  stores: memoryStores(),
+})
+
+// @expect TS2322
+export const pending = ai.run('summarize', { input: { text: 123 } })

--- a/test/types/negative/unknown-operation.ts
+++ b/test/types/negative/unknown-operation.ts
@@ -1,0 +1,20 @@
+// @targets spec
+// Operation names are typed: a misspelt one does not compile, which is why INVALID_INPUT
+// for an unknown name is documented as a JavaScript caller's failure.
+import { createSwitch, defineOperation, defineOperations, memoryStores } from 'llmswitch'
+import { z } from 'zod'
+
+const ai = createSwitch({
+  providers: {},
+  operations: defineOperations({
+    summarize: defineOperation({
+      input: z.object({ text: z.string() }),
+      output: z.object({ summary: z.string() }),
+      prompt: ({ text }) => text,
+    }),
+  }),
+  stores: memoryStores(),
+})
+
+// @expect TS2345
+export const pending = ai.run('sumarize', { input: { text: 'hello' } })

--- a/test/types/positive/custom-provider.ts
+++ b/test/types/positive/custom-provider.ts
@@ -1,0 +1,15 @@
+// @targets spec, package
+// The README's custom provider adapter, compiled as it is printed there. It is the shape
+// every adopter writing their own transport starts from, so both the interface it
+// implements and the error it throws have to be reachable from the package root.
+import { ProviderError, type Provider } from 'llmswitch'
+
+export const myProvider: Provider = {
+  async complete(req) {
+    const res = await callMyBackend(req) // req.responseFormat tells you text vs JSON
+    if (res.status === 429) throw new ProviderError('rate_limit', { status: 429 })
+    if (res.status === 401) throw new ProviderError('auth', { status: 401 })
+    if (res.cutOff) return { kind: 'truncated', text: res.body, usage: res.tokens ?? null }
+    return { kind: 'complete', text: res.body, usage: res.tokens ?? null } // usage null if unreported
+  },
+}

--- a/test/types/positive/quickstart.ts
+++ b/test/types/positive/quickstart.ts
@@ -1,0 +1,59 @@
+// @targets spec
+// The README quickstart, compiled as it is printed there. If the inference ever stops
+// working — a schema that no longer reaches `prompt`, a `run` that no longer types its
+// input — the README is wrong, and this is where that shows up.
+import {
+  createSwitch,
+  defineOperation,
+  defineOperations,
+  anthropic,
+  openaiCompatible,
+  memoryStores,
+} from 'llmswitch'
+import { z } from 'zod'
+
+const ai = createSwitch({
+  // 1. Register providers in code. Credentials and endpoints live HERE,
+  //    never in runtime config or the database.
+  providers: {
+    claude: anthropic({ apiKey: () => process.env.ANTHROPIC_API_KEY }),
+    openai: openaiCompatible({ apiKey: () => process.env.OPENAI_API_KEY }),
+  },
+
+  // 2. Declare operations: typed input, expected output, and how to build the prompt.
+  //    Wrap each operation in defineOperation — that's what ties your schemas to your
+  //    callbacks, so a typo inside `prompt` is a compile error, not a runtime surprise.
+  operations: defineOperations({
+    summarize: defineOperation({
+      input: z.object({ text: z.string().max(50_000) }),
+      output: z.object({ summary: z.string(), keyPoints: z.array(z.string()) }),
+      prompt: ({ text }) =>
+        `Summarize the following article as JSON with "summary" and "keyPoints".\n\n${text}`,
+      quota: { perDay: 10 },
+      // Used when the config store has no row for this operation (bootstrap-friendly).
+      defaultRoute: {
+        provider: 'claude',
+        model: 'claude-sonnet-4-6',
+        fallback: { provider: 'openai', model: 'gpt-4.1-mini' },
+      },
+    }),
+  }),
+
+  // 3. Wire storage: runtime config (routes and limits) + quota counters.
+  //    Memory for dev, Postgres for prod.
+  stores: memoryStores(),
+})
+
+const result = await ai.run('summarize', {
+  input: { text: articleText },
+  subjectId: user.id, // required whenever the operation has an effective quota
+})
+
+// The result fields, with the types the README claims for them.
+export const data: { summary: string; keyPoints: string[] } = result.data
+export const route: { provider: string; model: string } = result.route
+export const usedFallback: boolean = result.usedFallback
+export const attempts: number = result.attempts.length
+export const usage: { inputTokens: number; outputTokens: number } = result.usage
+export const usageComplete: boolean = result.usageComplete
+export const cost: number | null = result.cost

--- a/test/types/positive/results.ts
+++ b/test/types/positive/results.ts
@@ -1,0 +1,35 @@
+// @targets spec, package
+// What a caller can do with the shapes a run hands back: read a typed result, walk the
+// attempt records, read a quota view, and switch over a provider response without a
+// default arm. The last one is the check that matters — an added `ProviderResponse` member
+// has to break this file rather than fall through it silently.
+import type { AttemptRecord, ProviderResponse, QuotaView, RunResult } from 'llmswitch'
+
+export function summaryOf(result: RunResult<{ summary: string }>): string {
+  const suffix = result.usedFallback ? ' (fallback)' : ''
+  return `${result.route.provider}/${result.route.model}${suffix}: ${result.data.summary}`
+}
+
+export function tokensOf(attempt: AttemptRecord): number {
+  if (attempt.usage === null) return 0
+  return attempt.usage.inputTokens + attempt.usage.outputTokens
+}
+
+export function statusOf(attempt: AttemptRecord): number | null {
+  return attempt.status ?? null
+}
+
+export function headroom(view: QuotaView): string {
+  return `${String(view.remaining)} of ${String(view.limit)} until ${view.resetsAt}`
+}
+
+export function textOf(response: ProviderResponse): string {
+  switch (response.kind) {
+    case 'complete':
+      return response.text
+    case 'truncated':
+      return `${response.text}…`
+    case 'refused':
+      return ''
+  }
+}

--- a/test/types/positive/transformed-schema.ts
+++ b/test/types/positive/transformed-schema.ts
@@ -1,0 +1,27 @@
+// @targets spec
+// A schema that transforms, which is where the three sides of an operation are easiest to
+// get wrong: `run` takes what the caller writes (`z.input`), while `prompt`, `quality` and
+// `result.data` all see what the schema produced (`z.output`).
+import { createSwitch, defineOperation, defineOperations, memoryStores } from 'llmswitch'
+import { z } from 'zod'
+
+const ai = createSwitch({
+  providers: {},
+  operations: defineOperations({
+    wordcount: defineOperation({
+      input: z.object({ text: z.string().transform((value) => value.split(' ')) }),
+      output: z.object({ total: z.string().transform((value) => Number(value)) }),
+      // `text` arrives as the transformed value, not as the string the caller passed.
+      prompt: ({ text }) => `Count the words in ${String(text.length)} tokens.`,
+      quality: ({ input, data }) =>
+        data.total === input.text.length ? { ok: true } : { ok: false },
+    }),
+  }),
+  stores: memoryStores(),
+})
+
+// The caller writes a string…
+const result = await ai.run('wordcount', { input: { text: 'one two three' } })
+
+// …and reads a number back.
+export const total: number = result.data.total

--- a/test/types/scaffold.d.ts
+++ b/test/types/scaffold.d.ts
@@ -1,0 +1,22 @@
+// The values the README examples use without introducing them: the article being
+// summarized, the signed-in user, and the backend a custom provider adapter calls.
+// Declaring them here is what lets those examples be compiled exactly as they are printed,
+// rather than as a paraphrase with the missing pieces filled in.
+
+import type { ProviderRequest, TokenUsage } from 'llmswitch'
+
+declare global {
+  /** The text passed to the quickstart's `summarize` operation. */
+  const articleText: string
+
+  /** The signed-in user, whose ID is the quota subject. */
+  const user: { id: string }
+
+  /** The backend the README's custom provider adapter calls. */
+  function callMyBackend(req: ProviderRequest): Promise<{
+    status: number
+    body: string
+    cutOff: boolean
+    tokens: TokenUsage | null
+  }>
+}

--- a/test/types/spec-pending.json
+++ b/test/types/spec-pending.json
@@ -1,0 +1,27 @@
+{
+  "index": {
+    "value": [
+      "anthropic",
+      "createSwitch",
+      "defineOperation",
+      "defineOperations",
+      "gemini",
+      "memoryStores",
+      "openaiCompatible",
+      "postgresStores"
+    ],
+    "type": []
+  },
+  "postgres": {
+    "value": ["MIGRATIONS", "migrationSql"],
+    "type": []
+  },
+  "conformance": {
+    "value": [
+      "runConfigStoreConformance",
+      "runProviderConformance",
+      "runUsageStoreConformance"
+    ],
+    "type": ["ConformanceResult"]
+  }
+}

--- a/test/types/spec-surface-conformance.d.ts
+++ b/test/types/spec-surface-conformance.d.ts
@@ -1,0 +1,36 @@
+// Generated from the code fences of docs/spec.md by scripts/check-spec-surface.mjs.
+// Edit the spec, then run `npm run surface:update`.
+
+import type { AttemptRecord, ConfigStore, Provider, ProviderRequest, ReservationEnvelope, UsageStore } from './spec-surface'
+
+// subpath: llmswitch/conformance
+export interface ConformanceResult { passed: boolean; failures: string[]; skipped: string[] }
+export declare function runUsageStoreConformance(opts: {
+  // create returns the store under test plus REQUIRED test controls:
+  // setTime drives the STORE's authoritative clock (for Postgres: a session/test hook the
+  // adapter documents) and is called with non-decreasing instants between reset() calls;
+  // reset wipes state; readSettled exposes what settle() persisted so
+  // duplicate/conflict/unknown-reservation behavior is observable.
+  create(): Promise<{
+    store: UsageStore
+    setTime(date: Date): Promise<void>
+    reset(): Promise<void>
+    readSettled(reservationId: string): Promise<{ reservation: ReservationEnvelope; outcome: string; attempts: AttemptRecord[] } | null>
+  }>
+}): Promise<ConformanceResult>
+export declare function runConfigStoreConformance(opts: {
+  // seedRaw writes an arbitrary raw value for an operation, enabling malformed-row cases.
+  create(): Promise<{ store: ConfigStore; reset(): Promise<void>; seedRaw(operation: string, value: unknown): Promise<void> }>
+}): Promise<ConformanceResult>
+export declare function runProviderConformance(opts: {
+  provider: Provider
+  // Produces a dispatchable request for the provider's backend (model, prompt).
+  requestFactory: () => ProviderRequest
+  // 'success' is MANDATORY; each other scenario puts the adopter's backend into the named
+  // condition and resolves when ready; the harness dispatches and asserts the resulting
+  // ProviderResponse.kind or ProviderError classification. Absent optional scenarios are
+  // reported in `skipped` — a skipped scenario means that classification is UNVERIFIED.
+  scenarios: { success: () => Promise<void> } & Partial<Record<
+    'auth' | 'rate_limit' | 'model_not_found' | 'invalid_request' | 'transient'
+    | 'malformed_response' | 'truncated' | 'refused', () => Promise<void>>>
+}): Promise<ConformanceResult>  // passed === (failures.length === 0); skipped is informational

--- a/test/types/spec-surface-postgres.d.ts
+++ b/test/types/spec-surface-postgres.d.ts
@@ -1,0 +1,12 @@
+// Generated from the code fences of docs/spec.md by scripts/check-spec-surface.mjs.
+// Edit the spec, then run `npm run surface:update`.
+
+// subpath: llmswitch/postgres
+export declare const MIGRATIONS: ReadonlyArray<{
+  version: number
+  templateSha256: string                                  // hash of the canonical template (schema placeholder form)
+  render(opts?: { schema?: string }): { sql: string; sha256: string }  // hash of the exact rendered bytes
+}>
+// All versions concatenated in order, idempotent, schema-rendered; sha256 covers the
+// exact aggregate sql bytes.
+export declare function migrationSql(opts?: { schema?: string }): { sql: string; sha256: string }

--- a/test/types/spec-surface.d.ts
+++ b/test/types/spec-surface.d.ts
@@ -1,0 +1,194 @@
+// Generated from the code fences of docs/spec.md by scripts/check-spec-surface.mjs.
+// Edit the spec, then run `npm run surface:update`.
+
+import { z } from 'zod'
+
+// ——— entry point ———
+export declare function createSwitch<Ops extends OperationsMap>(
+  config: CreateSwitchConfig<Ops>
+): Switch<Ops>
+
+// Inference builders. defineOperation correlates each operation's schemas with its
+// callbacks; **every entry in defineOperations MUST be wrapped in defineOperation** —
+// defineOperations is an identity collector and does not itself restore inference.
+// The README quickstart uses exactly this shape; negative compile fixtures assert that
+// invalid `prompt` input and `quality.data` accesses FAIL to compile in that shape.
+export declare function defineOperation<In extends z.ZodType, Out extends z.ZodType>(
+  def: OperationDefinition<In, Out>
+): OperationDefinition<In, Out>
+export declare function defineOperations<Ops extends OperationsMap>(ops: Ops): Ops
+export type OperationsMap = Record<string, OperationDefinition<z.ZodType, z.ZodType>>
+
+export interface Switch<Ops extends OperationsMap> {
+  run<K extends keyof Ops & string>(
+    operation: K,
+    args: { input: z.input<Ops[K]['input']>; subjectId?: string },
+    options?: { signal?: AbortSignal }
+  ): Promise<RunResult<z.output<Ops[K]['output']>>>
+  getConfig(): Promise<Record<keyof Ops & string, OperationConfigView>>
+  setConfig(operation: keyof Ops & string, route: OperationRoute): Promise<void>
+  resetConfig(operation: keyof Ops & string): Promise<void>
+  getQuota(operation: keyof Ops & string, subjectId: string): Promise<QuotaView> // resolves config first (§2), so it may also fail CONFIG_STORE_UNAVAILABLE/INVALID_CONFIG; no effective quota → INVALID_INPUT
+}
+
+export interface CreateSwitchConfig<Ops extends OperationsMap> {
+  providers: Record<string, Provider>
+  operations: Ops
+  stores: StorePair
+  pricing?: Record<string, Record<string, ModelPrice>>
+  configTtlMs?: number                                   // default 5_000; 0–300_000
+  treatUnclassifiedAsTransient?: boolean                 // default false
+  fallbackOnAuthOrModelNotFound?: boolean                // default false; primary attempt only (§5a/§5b)
+  onSettlementError?: (error: unknown, record: SettlementFailure) => void | Promise<void>
+  logger?: Logger
+}
+export interface SettlementFailure {
+  reservation: ReservationEnvelope
+  outcome: 'succeeded' | 'failed'
+  attempts: AttemptRecord[]
+}
+export interface StorePair { config: ConfigStore; usage: UsageStore }
+export interface Logger {                                // invoked through caught promise chains
+  info(message: string, data?: unknown): void | Promise<void>
+  warn(message: string, data?: unknown): void | Promise<void>
+  error(message: string, data?: unknown): void | Promise<void>
+}
+
+// ——— operations ———
+export interface OperationDefinition<In extends z.ZodType, Out extends z.ZodType> {
+  input: In
+  output: Out
+  prompt: (input: z.output<In>) => string | Promise<string>
+  format?: 'json' | 'json-any' | 'text'                  // default 'json' (§3)
+  quality?: (ctx: { input: z.output<In>; data: z.output<Out> }) => QualityVerdict | Promise<QualityVerdict>
+  quota?: { perDay: number }                             // safe integer, 0–1_000_000 (0 = halted)
+  timeoutMs?: number                                     // provider I/O timeout; default 60_000; 1_000–600_000
+  defaultRoute?: OperationRoute
+}
+export type QualityVerdict = { ok: true } | { ok: false; reason?: string }
+
+// ——— routing / views ———
+export interface OperationRoute {
+  provider: string                                       // non-empty registered provider ID
+  model: string                                          // non-empty
+  maxOutputTokens?: number                               // safe integer ≥ 1
+  temperature?: number                                   // finite, 0–2 (profiles may clamp; §5c)
+  quota?: { perDay: number }                             // safe integer, 0–1_000_000; overrides the declared quota (§2)
+  fallback?: RouteTarget | null
+}
+export interface RouteTarget {
+  provider: string; model: string; maxOutputTokens?: number; temperature?: number
+}
+export interface OperationConfigView {
+  stored: OperationRoute | null | 'malformed'
+  effective: OperationRoute | null
+}
+export interface QuotaView { limit: number; used: number; remaining: number; resetsAt: string } // limit = the effective limit (route override, else declared); remaining = max(0, limit - used); getQuota requires non-empty subjectId
+
+// ——— run results ———
+export interface RunResult<Out> {
+  data: Out
+  route: { provider: string; model: string }
+  usedFallback: boolean
+  attempts: AttemptRecord[]
+  usage: TokenUsage
+  usageComplete: boolean
+  cost: number | null
+}
+export type AttemptOutcome = 'succeeded' | 'timeout' | 'truncated' | 'refused'
+  | 'output_rejected' | 'output_schema_error' | 'quality_error' | 'provider_unclassified'
+  | ProviderErrorKind
+export interface AttemptRecord {
+  provider: string
+  model: string
+  outcome: AttemptOutcome
+  status?: number
+  usage: TokenUsage | null
+  costUsd: number | null
+  durationMs: number
+}
+export interface TokenUsage { inputTokens: number; outputTokens: number }  // non-negative SAFE integers
+export interface ModelPrice { inputPerM: number; outputPerM: number }      // finite, ≥ 0
+
+// ——— providers ———
+export interface Provider {
+  prepare?(): PreparedProvider | Promise<PreparedProvider>  // §5a; memoized per run per provider ID
+  complete(req: ProviderRequest): Promise<ProviderResponse> // used directly when prepare absent
+}
+export interface PreparedProvider {
+  complete(req: ProviderRequest): Promise<ProviderResponse>
+}
+export interface ProviderRequest {
+  prompt: string
+  model: string
+  responseFormat: { type: 'text' } | { type: 'json'; topLevel: 'object' | 'any' }
+  maxOutputTokens?: number
+  temperature?: number
+  signal: AbortSignal
+}
+// Discriminated: truncation and refusal are billable HTTP-200 terminations, so they travel
+// on the RESPONSE (usage retained), not as thrown errors. `kind: 'complete'` proceeds to
+// the output pipeline; 'truncated' classifies `truncated`; 'refused' classifies `refused`.
+// `text` may be partial or empty for the non-complete kinds.
+export type ProviderResponse =
+  | { kind: 'complete';  text: string; usage: TokenUsage | null }
+  | { kind: 'truncated'; text: string; usage: TokenUsage | null }  // text may be partial
+  | { kind: 'refused';   text: string; usage: TokenUsage | null }  // text may be empty
+export type ProviderErrorKind = 'transient' | 'rate_limit' | 'auth' | 'model_not_found'
+  | 'invalid_request' | 'aborted' | 'malformed_response'
+export declare class ProviderError extends Error {
+  constructor(kind: ProviderErrorKind, opts?: { status?: number; message?: string })
+  readonly kind: ProviderErrorKind
+  readonly status?: number
+  // Brand-based recognition (dual-package safe). The core NEVER uses bare instanceof.
+  static is(value: unknown): value is ProviderError
+}
+
+// built-in factories (fetch-based, zero dependencies; implement prepare(); wire contracts §5c)
+export declare function anthropic(opts: { apiKey: ApiKeyResolver }): Provider
+export declare function openaiCompatible(opts: {
+  apiKey: ApiKeyResolver
+  baseUrl?: string
+  jsonMode?: 'native' | 'prompt-only'                    // overrides the §5c host capability rule
+  tokenParam?: 'max_tokens' | 'max_completion_tokens'    // overrides the §5c host token-param rule
+}): Provider
+export declare function gemini(opts: { apiKey: ApiKeyResolver }): Provider
+export type ApiKeyResolver = () => string | undefined | Promise<string | undefined>
+
+// ——— stores ———
+export interface ConfigStore {
+  getAll(): Promise<Record<string, unknown>>
+  set(operation: string, route: OperationRoute): Promise<void>
+  delete(operation: string): Promise<void>
+}
+export type QuotaKey = { operation: string; subjectId: string }
+export interface ReservationEnvelope { reservationId: string; key: QuotaKey; day: string } // day: 'YYYY-MM-DD' UTC, store-chosen
+export interface UsageStore {
+  reserve(key: QuotaKey, limit: number): Promise<
+    | { ok: true; reservation: ReservationEnvelope; expiresAt: string }
+    | { ok: false; used: number; resetsAt: string }
+  >
+  commit(reservationId: string): Promise<'committed' | 'expired' | 'missing'>
+  settle(reservation: ReservationEnvelope, outcome: 'succeeded' | 'failed', attempts: AttemptRecord[]): Promise<void>
+  snapshot(key: QuotaKey): Promise<{ used: number; resetsAt: string }>
+}
+export declare function memoryStores(): StorePair
+export declare function postgresStores(opts: {
+  pool: { query(sql: string, params?: unknown[]): Promise<{ rows: unknown[] }> }
+  schema?: string                                        // default 'llmswitch'; validated identifier
+  leaseMs?: number                                       // default 120_000; 5_000–600_000
+}): StorePair
+
+// ——— errors ———
+export declare class LLMSwitchError extends Error {
+  private constructor()                                  // instances come from the package; narrow on `code`
+  readonly code: 'INVALID_INPUT' | 'MISSING_SUBJECT' | 'QUOTA_EXCEEDED'
+    | 'USAGE_STORE_UNAVAILABLE' | 'CONFIG_STORE_UNAVAILABLE' | 'INVALID_CONFIG'
+    | 'ABORTED' | 'PROVIDER_FAILED' | 'OUTPUT_REJECTED'
+  readonly operation?: string
+  readonly retryable: boolean                            // literal per §5a/§5b
+  readonly resetsAt?: string
+  readonly detectedAt?: 'local' | 'provider'
+  readonly attempts?: AttemptRecord[]
+  // Sanitized: no prompts, no model output, no raw provider errors.
+}

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  // The compile fixtures. They are checked by `scripts/check-types-fixtures.mjs`, which
+  // builds one program per fixture with these options, because the negative ones are meant
+  // to fail and a single program would simply report their errors as build errors.
+  //
+  // The `paths` below point at the generated spec surfaces. That is what an editor and
+  // ESLint resolve `llmswitch` to; the runner substitutes `dist/*.d.ts` in memory when it
+  // checks a fixture against the built package instead.
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "types": ["node"],
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "useUnknownInCatchVariables": true,
+
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "erasableSyntaxOnly": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": false,
+
+    "noEmit": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "llmswitch": ["./spec-surface.d.ts"],
+      "llmswitch/postgres": ["./spec-surface-postgres.d.ts"],
+      "llmswitch/conformance": ["./spec-surface-conformance.d.ts"]
+    }
+  },
+  "include": ["."]
+}

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -1,0 +1,347 @@
+import { runInNewContext } from 'node:vm'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  LLMSwitchError,
+  ProviderError,
+  aborted,
+  configStoreUnavailable,
+  invalidConfigLocal,
+  invalidConfigProvider,
+  invalidConfigTransientPrepare,
+  invalidInput,
+  missingSubject,
+  outputRejected,
+  providerFailed,
+  quotaExceeded,
+  usageStoreUnavailable,
+} from '../../src/errors'
+import type { OutputRejectionKind, ProviderFailureKind } from '../../src/errors/factories'
+import type { AttemptRecord, ProviderErrorKind } from '../../src/types'
+
+/** The brand is looked up the same way the class installs it: from the global registry. */
+const brand = Symbol.for('llmswitch.ProviderError')
+
+const attempts: AttemptRecord[] = [
+  {
+    provider: 'claude',
+    model: 'claude-sonnet-4-6',
+    outcome: 'transient',
+    status: 503,
+    usage: null,
+    costUsd: null,
+    durationMs: 120,
+  },
+]
+
+describe('the codes raised before dispatch', () => {
+  // Spec §5b, "Pre-dispatch codes". One row per code, with the literal the table gives it.
+  const rows = [
+    { code: 'INVALID_INPUT', retryable: false, error: () => invalidInput('summarize', 'text') },
+    { code: 'MISSING_SUBJECT', retryable: false, error: () => missingSubject('summarize') },
+    {
+      code: 'QUOTA_EXCEEDED',
+      retryable: false,
+      error: () => quotaExceeded('summarize', '2026-01-16T00:00:00.000Z'),
+    },
+    {
+      code: 'USAGE_STORE_UNAVAILABLE',
+      retryable: true,
+      error: () => usageStoreUnavailable('summarize', new Error('connection reset')),
+    },
+    {
+      code: 'CONFIG_STORE_UNAVAILABLE',
+      retryable: true,
+      error: () => configStoreUnavailable('summarize', new Error('connection reset')),
+    },
+    {
+      code: 'INVALID_CONFIG',
+      retryable: false,
+      error: () => invalidConfigLocal('summarize', 'route.provider'),
+    },
+    {
+      code: 'INVALID_CONFIG',
+      retryable: true,
+      error: () => invalidConfigTransientPrepare('summarize', new ProviderError('transient')),
+    },
+    { code: 'ABORTED', retryable: false, error: () => aborted('summarize') },
+  ] as const
+
+  for (const row of rows) {
+    it(`reports ${row.code} as retryable ${String(row.retryable)}`, () => {
+      const error = row.error()
+      expect(error).toBeInstanceOf(LLMSwitchError)
+      expect(error.code).toBe(row.code)
+      expect(error.retryable).toBe(row.retryable)
+      expect(error.operation).toBe('summarize')
+    })
+  }
+
+  it('names every pre-dispatch code the classification table lists', () => {
+    expect(new Set(rows.map((row) => row.code))).toEqual(
+      new Set([
+        'INVALID_INPUT',
+        'MISSING_SUBJECT',
+        'QUOTA_EXCEEDED',
+        'USAGE_STORE_UNAVAILABLE',
+        'CONFIG_STORE_UNAVAILABLE',
+        'INVALID_CONFIG',
+        'ABORTED',
+      ]),
+    )
+  })
+})
+
+describe('the classification table for a dispatched attempt', () => {
+  // Spec §5b, one entry per row that ends a run as PROVIDER_FAILED.
+  const providerRows: readonly (readonly [ProviderFailureKind, boolean])[] = [
+    ['transient', true],
+    ['rate_limit', true],
+    ['malformed_response', true],
+    ['timeout', true],
+    ['refused', false],
+    ['invalid_request', false],
+    ['provider_unclassified', false],
+  ]
+
+  for (const [kind, retryable] of providerRows) {
+    it(`classifies ${kind} as PROVIDER_FAILED, retryable ${String(retryable)}`, () => {
+      const error = providerFailed('summarize', kind, attempts)
+      expect(error.code).toBe('PROVIDER_FAILED')
+      expect(error.retryable).toBe(retryable)
+      expect(error.attempts).toBe(attempts)
+      expect(error.message).toContain(kind)
+    })
+  }
+
+  // Spec §5b, the two rows that end a run as OUTPUT_REJECTED. Both are retryable.
+  const outputRows: readonly (readonly [OutputRejectionKind, boolean])[] = [
+    ['truncated', true],
+    ['output_rejected', true],
+  ]
+
+  for (const [kind, retryable] of outputRows) {
+    it(`classifies ${kind} as OUTPUT_REJECTED, retryable ${String(retryable)}`, () => {
+      const error = outputRejected('summarize', kind, attempts)
+      expect(error.code).toBe('OUTPUT_REJECTED')
+      expect(error.retryable).toBe(retryable)
+      expect(error.attempts).toBe(attempts)
+    })
+  }
+
+  it('reports a credential or model rejection as detected by the provider', () => {
+    const error = invalidConfigProvider('summarize', attempts)
+    expect(error.code).toBe('INVALID_CONFIG')
+    expect(error.retryable).toBe(false)
+    expect(error.detectedAt).toBe('provider')
+    expect(error.attempts).toBe(attempts)
+  })
+
+  it('carries the attempts of a run aborted after it had dispatched', () => {
+    expect(aborted('summarize', attempts).attempts).toBe(attempts)
+  })
+})
+
+describe('the fields an error carries', () => {
+  it('marks a local configuration failure as detected locally', () => {
+    expect(invalidConfigLocal('summarize', 'route.model').detectedAt).toBe('local')
+    expect(
+      invalidConfigTransientPrepare('summarize', new ProviderError('transient')).detectedAt,
+    ).toBe('local')
+  })
+
+  it('attaches resetsAt to a quota denial and to nothing else', () => {
+    expect(quotaExceeded('summarize', '2026-01-16T00:00:00.000Z').resetsAt).toBe(
+      '2026-01-16T00:00:00.000Z',
+    )
+    expect('resetsAt' in invalidInput('summarize', 'text')).toBe(false)
+  })
+
+  it('leaves out the fields a failure has nothing to say about', () => {
+    const error = missingSubject('summarize')
+    expect('resetsAt' in error).toBe(false)
+    expect('detectedAt' in error).toBe(false)
+    expect('attempts' in error).toBe(false)
+    expect('cause' in error).toBe(false)
+  })
+
+  it('chains the failure that caused a store to be unreachable', () => {
+    const reset = new Error('connection reset')
+    expect(usageStoreUnavailable('summarize', reset).cause).toBe(reset)
+    expect(configStoreUnavailable('summarize', reset).cause).toBe(reset)
+  })
+
+  it('chains a thrown readiness failure and omits the chain when there was none', () => {
+    const thrown = new ProviderError('transient', { status: 503 })
+    expect(invalidConfigTransientPrepare('summarize', thrown).cause).toBe(thrown)
+    expect(invalidConfigLocal('summarize', 'apiKey', { cause: thrown }).cause).toBe(thrown)
+    expect('cause' in invalidConfigLocal('summarize', 'route.provider')).toBe(false)
+  })
+
+  it('chains what the caller passed even when that is undefined, as Error does', () => {
+    // `new Error(m, { cause: undefined })` carries a `cause`; a caught value that turned out
+    // to be undefined is still a chain the caller asked for, and losing it hides the throw.
+    const store = usageStoreUnavailable('summarize', undefined)
+    expect('cause' in store).toBe(true)
+    expect(store.cause).toBeUndefined()
+
+    const local = invalidConfigLocal('summarize', 'apiKey', { cause: undefined })
+    expect('cause' in local).toBe(true)
+    expect(local.cause).toBeUndefined()
+  })
+
+  it('names itself so a log line says which error it is', () => {
+    expect(missingSubject('summarize').name).toBe('LLMSwitchError')
+    expect(new ProviderError('auth').name).toBe('ProviderError')
+  })
+
+  it('says nothing about the input beyond the operation and the field', () => {
+    const error = invalidInput('summarize', 'text')
+    expect(error.message).toBe('invalid input for "summarize": text')
+  })
+})
+
+describe('a provider error', () => {
+  it('describes itself from the classification when the caller supplies no message', () => {
+    expect(new ProviderError('rate_limit').message).toBe('provider error: rate_limit')
+  })
+
+  it('prefers a message the caller supplies', () => {
+    expect(new ProviderError('rate_limit', { message: 'slow down' }).message).toBe('slow down')
+  })
+
+  it('keeps the status when the provider returned one', () => {
+    expect(new ProviderError('rate_limit', { status: 429 }).status).toBe(429)
+    expect('status' in new ProviderError('rate_limit')).toBe(false)
+    expect('status' in new ProviderError('rate_limit', { message: 'slow down' })).toBe(false)
+  })
+
+  it('carries its brand on the prototype, where nothing enumerating an instance sees it', () => {
+    const error = new ProviderError('auth', { status: 401 })
+    expect(Object.getOwnPropertySymbols(error)).toEqual([])
+    // Object.assign copies own enumerable properties, symbols included: a brand that was
+    // enumerable, or on the instance rather than the prototype, would come across here.
+    expect(Object.getOwnPropertySymbols(Object.assign({}, error))).toEqual([])
+
+    const installed = Object.getOwnPropertyDescriptor(ProviderError.prototype, brand)
+    expect(installed?.value).toBe(true)
+    expect(installed?.enumerable).toBe(false)
+  })
+})
+
+describe('recognising a provider error', () => {
+  /** A plain object carrying the brand, so the shape checks can be exercised one at a time. */
+  function forge(overrides: Record<string | symbol, unknown>): unknown {
+    return { [brand]: true, kind: 'transient', message: 'failed', ...overrides }
+  }
+
+  /** The same object, but reading one property throws the way a hostile value would. */
+  function hostileAt(property: string | symbol): unknown {
+    const base: Record<string | symbol, unknown> = {
+      [brand]: true,
+      kind: 'transient',
+      message: 'failed',
+      status: 503,
+    }
+    return Object.defineProperty(base, property, {
+      get() {
+        throw new Error('this property refuses to be read')
+      },
+      configurable: true,
+    })
+  }
+
+  it('recognises one it made itself', () => {
+    expect(ProviderError.is(new ProviderError('transient'))).toBe(true)
+    expect(ProviderError.is(new ProviderError('auth', { status: 401 }))).toBe(true)
+  })
+
+  it('recognises every classification the union declares', () => {
+    // An exhaustive record rather than a list: a kind added to the union without being added
+    // here stops this file compiling, which is the only way the walk stays complete.
+    const table = {
+      transient: true,
+      rate_limit: true,
+      auth: true,
+      model_not_found: true,
+      invalid_request: true,
+      aborted: true,
+      malformed_response: true,
+    } satisfies Record<ProviderErrorKind, true>
+
+    const everyKind = Object.keys(table) as (keyof typeof table)[]
+    expect(everyKind).toHaveLength(7)
+    for (const kind of everyKind) {
+      expect(ProviderError.is(new ProviderError(kind))).toBe(true)
+      expect(ProviderError.is(forge({ kind }))).toBe(true)
+    }
+  })
+
+  it('recognises one thrown from another realm, where instanceof cannot', () => {
+    const foreign: object = runInNewContext(`
+      const brand = Symbol.for('llmswitch.ProviderError')
+      class ForeignProviderError extends Error {
+        constructor(kind, status) {
+          super('the other realm failed')
+          this.kind = kind
+          this.status = status
+        }
+      }
+      Object.defineProperty(ForeignProviderError.prototype, brand, {
+        value: true,
+        enumerable: false,
+      })
+      new ForeignProviderError('rate_limit', 429)
+    `) as object
+
+    expect(foreign instanceof Error).toBe(false)
+    expect(foreign instanceof ProviderError).toBe(false)
+    expect(ProviderError.is(foreign)).toBe(true)
+  })
+
+  it('rejects primitives', () => {
+    for (const value of [undefined, null, 0, 429, '', 'transient', true, Symbol('transient')]) {
+      expect(ProviderError.is(value)).toBe(false)
+    }
+  })
+
+  it('rejects an ordinary error', () => {
+    expect(ProviderError.is(new Error('failed'))).toBe(false)
+    expect(ProviderError.is(new TypeError('failed'))).toBe(false)
+  })
+
+  it('rejects an object that copied the brand but not the shape', () => {
+    expect(ProviderError.is(forge({ kind: 'overloaded' }))).toBe(false)
+    expect(ProviderError.is(forge({ kind: 42 }))).toBe(false)
+    expect(ProviderError.is(forge({ message: 42 }))).toBe(false)
+    expect(ProviderError.is(forge({ status: '429' }))).toBe(false)
+    expect(ProviderError.is({ kind: 'transient', message: 'failed' })).toBe(false)
+    expect(ProviderError.is(forge({ [brand]: 'yes' }))).toBe(false)
+  })
+
+  it('accepts an object that carries the brand and the shape, with or without a status', () => {
+    expect(ProviderError.is(forge({}))).toBe(true)
+    expect(ProviderError.is(forge({ status: 429 }))).toBe(true)
+  })
+
+  it('answers false rather than throwing when a property refuses to be read', () => {
+    for (const property of [brand, 'kind', 'message', 'status']) {
+      expect(() => ProviderError.is(hostileAt(property))).not.toThrow()
+      expect(ProviderError.is(hostileAt(property))).toBe(false)
+    }
+  })
+
+  it('answers false rather than throwing for a proxy that refuses everything', () => {
+    const hostile = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('this proxy refuses to be read')
+        },
+      },
+    )
+    expect(() => ProviderError.is(hostile)).not.toThrow()
+    expect(ProviderError.is(hostile)).toBe(false)
+  })
+})

--- a/test/unit/smoke.test.ts
+++ b/test/unit/smoke.test.ts
@@ -6,7 +6,9 @@ import * as postgres from '../../src/postgres'
 
 describe('entry points', () => {
   it('loads every entry module the manifest advertises', () => {
-    expect(Object.keys(index)).toEqual([])
+    // A module namespace lists its names in sorted order, so this is the published set of
+    // runtime exports and not an artefact of how the entry file happens to be written.
+    expect(Object.keys(index)).toEqual(['LLMSwitchError', 'ProviderError'])
     expect(Object.keys(postgres)).toEqual([])
     expect(Object.keys(conformance)).toEqual([])
   })

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -12,5 +12,9 @@
     "skipLibCheck": true
   },
   "include": ["test", "scripts", "*.config.ts", "eslint.config.js"],
-  "exclude": ["test/consumers"]
+  // `test/types` holds the compile fixtures, half of which are meant to fail. They carry
+  // their own tsconfig and are checked one program at a time by
+  // `scripts/check-types-fixtures.mjs`; compiling them here would simply report their
+  // intended errors as build errors.
+  "exclude": ["test/consumers", "test/types"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,7 +27,9 @@ export default defineConfig({
       provider: 'v8',
       // The two folders held to a threshold: what decides, and what is thrown.
       include: ['src/core/**/*.ts', 'src/errors/**/*.ts'],
-      reporter: ['text', 'lcov'],
+      // `text` prints nothing at all when every measured file is fully covered, so
+      // `text-summary` is what makes a green run say a number out loud.
+      reporter: ['text', 'text-summary', 'lcov'],
       thresholds: { lines: 90, branches: 90 },
     },
   },


### PR DESCRIPTION
## What's in it

The public type surface from spec §6, transcribed into `src/types.ts` and re-exported name by name from the root, plus the two error classes. `LLMSwitchError` has a private constructor — instances come from the package, callers narrow on `code` — and a set of internal, classification-keyed factories that derive `retryable` and `detectedAt` from the §5b table rather than taking them as arguments. `ProviderError` is what a provider adapter throws; recognition goes through `ProviderError.is()`, which checks a `Symbol.for` brand and the object's shape and never throws, so an error from the CommonJS build is recognised by the ESM build and vice versa.

Two new checks. `scripts/check-types-fixtures.mjs` compiles the fixtures under `test/types/` — the README quickstart and custom-provider example, result narrowing, a transformed-schema case, and nine documented wrong shapes — against the spec's own declarations and against the built `dist`; a negative fixture must fail with exactly the diagnostic it names on the marked line, and no fixture may contain a suppression or an `any`. `scripts/check-spec-surface.mjs` regenerates `test/types/spec-surface*.d.ts` from the spec's §6 and §6b fences, type-checks them, and compares the export inventory of all six `dist/*.d.ts`/`.d.cts` files with the spec, minus the names listed in `test/types/spec-pending.json` (which only shrinks as the rest of the package lands). Both run in CI after the build.

The spec gains the string-domain rule for every string a store persists and the boundaries where the core enforces it, `OperationsMap` and the `postgresStores` pool type lose their `any`s, `LLMSwitchError` declares its private constructor, and the conformance `setTime` and limit-zero bullets say precisely what a runner can observe. The README follows in two sentences. Also: Dependabot now ignores major bumps of `typescript` (pinned to 5.9 until typescript-eslint supports newer) and `@types/node` (tracks the Node 20 floor).

## How to check it

`npm ci && npm run check` runs everything, including both new scripts. To see the fixtures bite: add a wrong field to `test/types/positive/quickstart.ts` and run `node scripts/check-types-fixtures.mjs --target spec`; change a marker code in any negative fixture and run it again. To see the surface check bite: remove a name from `test/types/spec-pending.json` and run `node scripts/check-spec-surface.mjs` after `npm run build`. `npm pack && npm run test:consumers -- llmswitch-0.1.0.tgz` installs the tarball into ESM, CJS and TypeScript fixtures and asserts `ProviderError.is()` across the two builds in both directions.

## Acceptance

- [x] every §6 name published with the right kind or listed as pending, nothing extra (`check-spec-surface`)
- [x] README examples and documented wrong shapes compile / fail as documented against the spec surface and, where their imports exist, against `dist`
- [x] `src/errors/**` at 100 % coverage; every §5b row and pre-dispatch code checked through the factories
- [x] `ProviderError.is()` recognises instances across the ESM and CJS builds and rejects forgeries without throwing
- [ ] `npm run check` green on Node 24, unit tests on Node 20
