### PR TITLE
Composition matrix, concurrency under load, and the vertical slice

### DIFF
--- a/test/unit/composition/concurrency.test.ts
+++ b/test/unit/composition/concurrency.test.ts
@@ -2,9 +2,9 @@
  * Prepared-dispatcher concurrency under load (spec §5a): N overlapping runs over one
  * shared provider registered as both primary and fallback, each run resolving its own
  * credential — proof that nothing prepared leaks across runs — plus store reconciliation
- * at quiescence, admin mutations racing in-flight runs, and a seeded stochastic smoke
- * over shuffled settlement orders. The scripted interleavings are the gate; the seeded
- * shuffle is evidence.
+ * at quiescence, admin writes interleaved with in-flight runs, and a seeded stochastic
+ * smoke over shuffled settlement orders. The scripted interleavings are the gate; the
+ * seeded shuffle is evidence.
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -66,7 +66,10 @@ describe('the alternating-credentials race', () => {
         return currentKey
       },
     })
-    const internal = createMemoryStores({})
+    // Pinned clock: no UTC-midnight straddle, and time moves only when the test says so —
+    // the zero-pending proof at the end depends on that.
+    let nowMs = Date.parse('2026-08-26T12:00:00.000Z')
+    const internal = createMemoryStores({ now: () => new Date(nowMs), leaseMs: 60_000 })
     const recorded = recordingStores(internal.stores)
     const ai = createSwitch({
       providers: { shared: provider },
@@ -107,6 +110,9 @@ describe('the alternating-credentials race', () => {
       call.respond(openaiSuccess(`rescued-${String(runIndexOf(call))}`))
     }
     await until(() => runs.every((run) => run.state !== 'pending'), 'all runs settled')
+    // Still exactly one preparation per run: a core that redundantly prepared again for
+    // the fallback wave would have moved this counter after the first assertion above.
+    expect(resolverCalls).toBe(N)
 
     // The named oracle: every dispatched request — primary and fallback alike — carries
     // exactly the key its run resolved.
@@ -130,10 +136,13 @@ describe('the alternating-credentials race', () => {
       }
     })
 
-    // Quiescence reconciliation: committed slots == runs that dispatched (the fallback
-    // shares its run's slot, so attempts != slots), every committed slot observed settled,
-    // and the public snapshot agrees — which also means zero reservations are left pending.
+    // Quiescence reconciliation. What each line pins: N grants observed, N commit acks
+    // observed (committed == runs that dispatched — the fallback shares its run's slot,
+    // so attempts != slots), every granted slot settled with its run's attempt count,
+    // and the public snapshot agreeing with the committed count.
     expect(recorded.envelopes).toHaveLength(N)
+    expect(recorded.commits).toHaveLength(N)
+    expect(new Set(recorded.commits).size).toBe(N)
     const key = { operation: 'echo', subjectId: 'load' }
     const snapshot = await recorded.stores.usage.snapshot(key)
     expect(snapshot.used).toBe(N)
@@ -150,10 +159,19 @@ describe('the alternating-credentials race', () => {
       attemptTotal += settled?.attempts.length ?? 0
     }
     expect(attemptTotal).toBe(N + N / 2)
+
+    // Zero pending, proven directly: a reservation left pending would lapse once the
+    // lease ran out and drop from the snapshot; only committed rows survive the jump.
+    nowMs += 90_000
+    expect((await recorded.stores.usage.snapshot(key)).used).toBe(N)
   })
 })
 
-describe('admin mutations racing in-flight runs', () => {
+describe('admin writes interleaved with in-flight runs', () => {
+  // What this proves is invalidation-on-write while earlier runs are still in flight —
+  // every run resolves exactly the write before it, never a stale cache entry. The
+  // generation guard against a *read* racing a write is owned by the config suite
+  // (test/unit/core/config.test.ts), whose scripted store can hold a read open.
   it('every run resolves the write before it; nothing serves a stale cache entry', async () => {
     const wire = wireFetch()
     const provider = openaiCompatible({ apiKey: () => 'sk-admin' })
@@ -197,11 +215,12 @@ describe('admin mutations racing in-flight runs', () => {
 
 describe('seeded stochastic smoke', () => {
   it('shuffled settlement over a mixed outcome draw: results coherent, store reconciled', async () => {
-    // The seed is the whole reproduction recipe; the draw and both shuffles derive from it.
+    // The seed pins the outcome draw and both shuffles; which run receives which drawn
+    // outcome follows dispatch arrival order.
     const random = mulberry32(0x2105)
     const wire = wireFetch()
     const provider = openaiCompatible({ apiKey: () => 'sk-load' })
-    const internal = createMemoryStores({})
+    const internal = createMemoryStores({ now: () => new Date('2026-08-26T12:00:00.000Z') })
     const recorded = recordingStores(internal.stores)
     const N = 32
     const ai = createSwitch({
@@ -250,6 +269,9 @@ describe('seeded stochastic smoke', () => {
         call.respond(jsonResponse(503, { error: { message: 'still overloaded' } }))
       }
     }
+    // Both fallback outcomes must occur, or the terminal-failure branch below goes
+    // silently unexercised after a seed or threshold change.
+    expect(new Set(fallbackOutcome.values())).toEqual(new Set(['success', 'transient']))
     await until(() => runs.every((run) => run.state !== 'pending'), 'all runs settled')
 
     runs.forEach((run, i) => {
@@ -272,9 +294,10 @@ describe('seeded stochastic smoke', () => {
       }
     })
 
-    // Reconciliation holds regardless of the draw: one slot per run, every slot settled,
-    // and the settlement outcomes match the run results one for one.
+    // Reconciliation holds regardless of the draw: one granted and committed slot per
+    // run, every slot settled, and the settlement outcomes match the run results.
     expect(recorded.envelopes).toHaveLength(N)
+    expect(recorded.commits).toHaveLength(N)
     const snapshot = await recorded.stores.usage.snapshot({
       operation: 'echo',
       subjectId: 'smoke',

--- a/test/unit/composition/concurrency.test.ts
+++ b/test/unit/composition/concurrency.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Prepared-dispatcher concurrency under load (spec §5a): N overlapping runs over one
+ * shared provider registered as both primary and fallback, each run resolving its own
+ * credential — proof that nothing prepared leaks across runs — plus store reconciliation
+ * at quiescence, admin mutations racing in-flight runs, and a seeded stochastic smoke
+ * over shuffled settlement orders. The scripted interleavings are the gate; the seeded
+ * shuffle is evidence.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import { LLMSwitchError } from '../../../src/errors'
+import { createSwitch } from '../../../src/index'
+import { openaiCompatible } from '../../../src/providers/openai-compatible'
+import { createMemoryStores } from '../../../src/stores/memory'
+import type { OperationsMap, RunResult } from '../../../src/types'
+import type { Observed } from '../core/helpers'
+import { observe } from '../core/helpers'
+import { jsonResponse } from '../providers/helpers'
+import {
+  mulberry32,
+  openaiSuccess,
+  recordingStores,
+  runIndexOf,
+  shuffled,
+  until,
+  wireFetch,
+} from './helpers'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/** One `echo` operation whose primary and fallback both route to provider `shared`. */
+function loadOperations(perDay: number): OperationsMap {
+  return {
+    echo: {
+      input: z.object({ text: z.string() }),
+      output: z.string(),
+      prompt: ({ text }: { text: string }) => `PROMPT:${text}`,
+      format: 'text',
+      quota: { perDay },
+      defaultRoute: {
+        provider: 'shared',
+        model: 'primary-model',
+        fallback: { provider: 'shared', model: 'fallback-model' },
+      },
+    },
+  } as unknown as OperationsMap
+}
+
+describe('the alternating-credentials race', () => {
+  const N = 32
+
+  it('every request carries exactly its own run’s key; the store reconciles at quiescence', async () => {
+    const wire = wireFetch()
+    let currentKey = ''
+    let resolverCalls = 0
+    // One provider object shared by the primary and the fallback route: a factory or core
+    // that memoizes the key or dispatcher on this object leaks a key across runs and fails
+    // the per-request assertion below.
+    const provider = openaiCompatible({
+      apiKey: () => {
+        resolverCalls += 1
+        return currentKey
+      },
+    })
+    const internal = createMemoryStores({})
+    const recorded = recordingStores(internal.stores)
+    const ai = createSwitch({
+      providers: { shared: provider },
+      operations: loadOperations(N),
+      stores: recorded.stores,
+    })
+
+    // The interleaving script: each run is launched with its own key and held at its
+    // dispatched request, so all N overlap at the attempt stage while the resolver order
+    // stays deterministic.
+    const runs: Observed<RunResult<unknown>>[] = []
+    for (let i = 0; i < N; i += 1) {
+      currentKey = `key-${String(i)}`
+      runs.push(
+        observe(ai.run('echo', { input: { text: `run-${String(i)}` }, subjectId: 'load' })),
+      )
+      await until(() => wire.calls.length === i + 1, `primary request ${String(i)}`)
+    }
+    expect(wire.calls).toHaveLength(N)
+    // Once per run despite the primary and fallback sharing the provider: memoized within
+    // a run (§5a), never cached across runs.
+    expect(resolverCalls).toBe(N)
+
+    // Even runs succeed on the primary; odd runs fail transient and go to the fallback.
+    for (const [i, call] of wire.calls.slice(0, N).entries()) {
+      expect(runIndexOf(call)).toBe(i)
+      expect(call.body.model).toBe('primary-model')
+      if (i % 2 === 0) call.respond(openaiSuccess(`answer-${String(i)}`))
+      else call.respond(jsonResponse(503, { error: { message: 'overloaded' } }))
+    }
+    await until(() => wire.calls.length === N + N / 2, 'fallback requests')
+
+    const fallbacks = wire.calls.slice(N)
+    const oddIndexes = Array.from({ length: N / 2 }, (_, k) => 2 * k + 1)
+    expect(fallbacks.map(runIndexOf).sort((a, b) => a - b)).toEqual(oddIndexes)
+    for (const call of fallbacks) {
+      expect(call.body.model).toBe('fallback-model')
+      call.respond(openaiSuccess(`rescued-${String(runIndexOf(call))}`))
+    }
+    await until(() => runs.every((run) => run.state !== 'pending'), 'all runs settled')
+
+    // The named oracle: every dispatched request — primary and fallback alike — carries
+    // exactly the key its run resolved.
+    for (const call of wire.calls) {
+      expect(call.headers.authorization).toBe(`Bearer key-${String(runIndexOf(call))}`)
+    }
+
+    runs.forEach((run, i) => {
+      expect(run.state).toBe('resolved')
+      const result = run.value
+      if (i % 2 === 0) {
+        expect(result?.data).toBe(`answer-${String(i)}`)
+        expect(result?.usedFallback).toBe(false)
+        expect(result?.route).toEqual({ provider: 'shared', model: 'primary-model' })
+        expect(result?.attempts.map((a) => a.outcome)).toEqual(['succeeded'])
+      } else {
+        expect(result?.data).toBe(`rescued-${String(i)}`)
+        expect(result?.usedFallback).toBe(true)
+        expect(result?.route).toEqual({ provider: 'shared', model: 'fallback-model' })
+        expect(result?.attempts.map((a) => a.outcome)).toEqual(['transient', 'succeeded'])
+      }
+    })
+
+    // Quiescence reconciliation: committed slots == runs that dispatched (the fallback
+    // shares its run's slot, so attempts != slots), every committed slot observed settled,
+    // and the public snapshot agrees — which also means zero reservations are left pending.
+    expect(recorded.envelopes).toHaveLength(N)
+    const key = { operation: 'echo', subjectId: 'load' }
+    const snapshot = await recorded.stores.usage.snapshot(key)
+    expect(snapshot.used).toBe(N)
+    const day = recorded.envelopes[0]?.day ?? ''
+    const inspection = await internal.controls.inspect(key, day)
+    expect(inspection.reservations).toBe(N)
+    expect(inspection.counter?.used).toBe(N)
+    let attemptTotal = 0
+    for (const [i, envelope] of recorded.envelopes.entries()) {
+      const settled = await internal.controls.readSettled(envelope.reservationId)
+      expect(settled).not.toBeNull()
+      expect(settled?.outcome).toBe('succeeded')
+      expect(settled?.attempts).toHaveLength(i % 2 === 0 ? 1 : 2)
+      attemptTotal += settled?.attempts.length ?? 0
+    }
+    expect(attemptTotal).toBe(N + N / 2)
+  })
+})
+
+describe('admin mutations racing in-flight runs', () => {
+  it('every run resolves the write before it; nothing serves a stale cache entry', async () => {
+    const wire = wireFetch()
+    const provider = openaiCompatible({ apiKey: () => 'sk-admin' })
+    const internal = createMemoryStores({})
+    const operations = {
+      echo: {
+        input: z.object({ text: z.string() }),
+        output: z.string(),
+        prompt: ({ text }: { text: string }) => `PROMPT:${text}`,
+        format: 'text',
+        defaultRoute: { provider: 'shared', model: 'm-default' },
+      },
+    } as unknown as OperationsMap
+    const ai = createSwitch({
+      providers: { shared: provider },
+      operations,
+      stores: internal.stores,
+    })
+
+    const K = 16
+    const runs: Observed<RunResult<unknown>>[] = []
+    for (let i = 0; i < K; i += 1) {
+      await ai.setConfig('echo', { provider: 'shared', model: `m-${String(i)}` })
+      runs.push(observe(ai.run('echo', { input: { text: `run-${String(i)}` } })))
+      await until(() => wire.calls.length === i + 1, `request ${String(i)}`)
+      // The mutation's invalidation must beat the cache: without it this run would read
+      // the entry the previous run installed and dispatch the previous model.
+      expect(wire.calls[i]?.body.model).toBe(`m-${String(i)}`)
+    }
+    for (const call of wire.calls) call.respond(openaiSuccess('ok'))
+    await until(() => runs.every((run) => run.state !== 'pending'), 'all runs settled')
+
+    runs.forEach((run, i) => {
+      expect(run.state).toBe('resolved')
+      expect(run.value?.route.model).toBe(`m-${String(i)}`)
+    })
+    const view = await ai.getConfig()
+    expect(view.echo?.effective?.model).toBe(`m-${String(K - 1)}`)
+  })
+})
+
+describe('seeded stochastic smoke', () => {
+  it('shuffled settlement over a mixed outcome draw: results coherent, store reconciled', async () => {
+    // The seed is the whole reproduction recipe; the draw and both shuffles derive from it.
+    const random = mulberry32(0x2105)
+    const wire = wireFetch()
+    const provider = openaiCompatible({ apiKey: () => 'sk-load' })
+    const internal = createMemoryStores({})
+    const recorded = recordingStores(internal.stores)
+    const N = 32
+    const ai = createSwitch({
+      providers: { shared: provider },
+      operations: loadOperations(N),
+      stores: recorded.stores,
+    })
+
+    const runs: Observed<RunResult<unknown>>[] = []
+    for (let i = 0; i < N; i += 1) {
+      runs.push(
+        observe(ai.run('echo', { input: { text: `run-${String(i)}` }, subjectId: 'smoke' })),
+      )
+    }
+    await until(() => wire.calls.length === N, 'all primary requests')
+
+    const primaryOutcome = new Map<number, 'success' | 'transient' | 'rate_limit'>()
+    for (const call of shuffled(wire.calls.slice(0, N), random)) {
+      const i = runIndexOf(call)
+      const roll = random()
+      if (roll < 0.5) {
+        primaryOutcome.set(i, 'success')
+        call.respond(openaiSuccess(`answer-${String(i)}`))
+      } else if (roll < 0.75) {
+        primaryOutcome.set(i, 'transient')
+        call.respond(jsonResponse(503, { error: { message: 'overloaded' } }))
+      } else {
+        primaryOutcome.set(i, 'rate_limit')
+        call.respond(jsonResponse(429, { error: { message: 'slow down' } }))
+      }
+    }
+    const failed = [...primaryOutcome].filter(([, o]) => o !== 'success').map(([i]) => i)
+    // The chosen seed must exercise both waves, or the smoke proves less than it claims.
+    expect(failed.length).toBeGreaterThan(0)
+    expect(failed.length).toBeLessThan(N)
+    await until(() => wire.calls.length === N + failed.length, 'fallback requests')
+
+    const fallbackOutcome = new Map<number, 'success' | 'transient'>()
+    for (const call of shuffled(wire.calls.slice(N), random)) {
+      const i = runIndexOf(call)
+      if (random() < 0.7) {
+        fallbackOutcome.set(i, 'success')
+        call.respond(openaiSuccess(`rescued-${String(i)}`))
+      } else {
+        fallbackOutcome.set(i, 'transient')
+        call.respond(jsonResponse(503, { error: { message: 'still overloaded' } }))
+      }
+    }
+    await until(() => runs.every((run) => run.state !== 'pending'), 'all runs settled')
+
+    runs.forEach((run, i) => {
+      const primary = primaryOutcome.get(i)
+      if (primary === 'success') {
+        expect(run.state).toBe('resolved')
+        expect(run.value?.usedFallback).toBe(false)
+        expect(run.value?.data).toBe(`answer-${String(i)}`)
+      } else if (fallbackOutcome.get(i) === 'success') {
+        expect(run.state).toBe('resolved')
+        expect(run.value?.usedFallback).toBe(true)
+        expect(run.value?.attempts.map((a) => a.outcome)).toEqual([primary, 'succeeded'])
+      } else {
+        expect(run.state).toBe('rejected')
+        expect(run.error).toBeInstanceOf(LLMSwitchError)
+        const error = run.error as LLMSwitchError
+        expect(error.code).toBe('PROVIDER_FAILED')
+        expect(error.retryable).toBe(true)
+        expect(error.attempts?.map((a) => a.outcome)).toEqual([primary, 'transient'])
+      }
+    })
+
+    // Reconciliation holds regardless of the draw: one slot per run, every slot settled,
+    // and the settlement outcomes match the run results one for one.
+    expect(recorded.envelopes).toHaveLength(N)
+    const snapshot = await recorded.stores.usage.snapshot({
+      operation: 'echo',
+      subjectId: 'smoke',
+    })
+    expect(snapshot.used).toBe(N)
+    const settledOutcomes = { succeeded: 0, failed: 0 }
+    for (const envelope of recorded.envelopes) {
+      const settled = await internal.controls.readSettled(envelope.reservationId)
+      expect(settled).not.toBeNull()
+      if (settled?.outcome === 'succeeded') settledOutcomes.succeeded += 1
+      else settledOutcomes.failed += 1
+    }
+    const resolved = runs.filter((run) => run.state === 'resolved').length
+    expect(settledOutcomes).toEqual({ succeeded: resolved, failed: N - resolved })
+  })
+})

--- a/test/unit/composition/helpers.ts
+++ b/test/unit/composition/helpers.ts
@@ -1,0 +1,139 @@
+/**
+ * Instruments for the composition suites: a deferred scripted wire (every `fetch` call is
+ * held open until the test answers it, so many runs can overlap at the dispatch stage), an
+ * OpenAI-shaped success body, a reservation-recording store wrapper for reconciliation
+ * assertions, a bounded busy-wait, and a seeded PRNG for the stochastic smoke.
+ */
+
+import { vi } from 'vitest'
+
+import type { ReservationEnvelope, StorePair, UsageStore } from '../../../src/types'
+import { flushMicrotasks } from '../core/helpers'
+import { jsonResponse } from '../providers/helpers'
+
+/** One captured HTTP call, still unanswered until the test calls `respond`. */
+export interface WireCall {
+  url: string
+  method: string
+  headers: Record<string, string>
+  body: Record<string, unknown>
+  respond: (response: Response) => void
+}
+
+export interface Wire {
+  calls: WireCall[]
+}
+
+/**
+ * Stubs global `fetch` so every call parks in `calls` until the test resolves it.
+ *
+ * An already-aborted signal rejects immediately, as the real fetch does. Restore with
+ * `vi.unstubAllGlobals()` in `afterEach`.
+ */
+export function wireFetch(): Wire {
+  const calls: WireCall[] = []
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string, init: RequestInit) => {
+      if (init.signal?.aborted === true) {
+        return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'))
+      }
+      return new Promise<Response>((resolve) => {
+        const headers: Record<string, string> = {}
+        new Headers(init.headers).forEach((value, key) => {
+          headers[key] = value
+        })
+        calls.push({
+          url,
+          method: init.method ?? 'GET',
+          headers,
+          body:
+            typeof init.body === 'string'
+              ? (JSON.parse(init.body) as Record<string, unknown>)
+              : {},
+          respond: resolve,
+        })
+      })
+    }),
+  )
+  return { calls }
+}
+
+/** A 200 chat completion that terminates `stop` with the given text and usage counters. */
+export function openaiSuccess(
+  content: string,
+  usage: { prompt_tokens: number; completion_tokens: number } = {
+    prompt_tokens: 7,
+    completion_tokens: 3,
+  },
+): Response {
+  return jsonResponse(200, {
+    choices: [{ message: { content }, finish_reason: 'stop' }],
+    usage,
+  })
+}
+
+/** Reads the launching run's index back out of a captured request's `run-<n>` prompt. */
+export function runIndexOf(call: WireCall): number {
+  const messages = call.body.messages as { content?: unknown }[]
+  const content = messages[0]?.content
+  const match = typeof content === 'string' ? /run-(\d+)/.exec(content) : null
+  const index = match?.[1]
+  if (index === undefined) throw new Error('wire request carries no run marker')
+  return Number(index)
+}
+
+/** A store pair whose usage store records every granted reservation envelope. */
+export function recordingStores(inner: StorePair): {
+  stores: StorePair
+  envelopes: ReservationEnvelope[]
+} {
+  const envelopes: ReservationEnvelope[] = []
+  const usage: UsageStore = {
+    async reserve(key, limit) {
+      const result = await inner.usage.reserve(key, limit)
+      if (result.ok) envelopes.push(result.reservation)
+      return result
+    },
+    commit: (reservationId) => inner.usage.commit(reservationId),
+    settle: (reservation, outcome, attempts) =>
+      inner.usage.settle(reservation, outcome, attempts),
+    snapshot: (key) => inner.usage.snapshot(key),
+  }
+  return { stores: { config: inner.config, usage }, envelopes }
+}
+
+/** Flushes microtask turns until `predicate` holds; fails loudly instead of hanging. */
+export async function until(predicate: () => boolean, what: string): Promise<void> {
+  for (let turn = 0; turn < 100; turn += 1) {
+    if (predicate()) return
+    await flushMicrotasks()
+  }
+  throw new Error(`timed out waiting for ${what}`)
+}
+
+/** mulberry32: a tiny deterministic PRNG; the seed is the whole reproduction recipe. */
+export function mulberry32(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** Fisher–Yates over a copy, driven by the seeded PRNG. */
+export function shuffled<T>(items: readonly T[], random: () => number): T[] {
+  const copy = [...items]
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(random() * (i + 1))
+    const a = copy[i]
+    const b = copy[j]
+    if (a === undefined || b === undefined) continue
+    copy[i] = b
+    copy[j] = a
+  }
+  return copy
+}

--- a/test/unit/composition/helpers.ts
+++ b/test/unit/composition/helpers.ts
@@ -27,7 +27,9 @@ export interface Wire {
 /**
  * Stubs global `fetch` so every call parks in `calls` until the test resolves it.
  *
- * An already-aborted signal rejects immediately, as the real fetch does. Restore with
+ * An already-aborted signal rejects immediately, as the real fetch does. A signal firing
+ * *after* dispatch is deliberately ignored — no composition test aborts a parked call, and
+ * a future one would need an abort listener here first. Restore with
  * `vi.unstubAllGlobals()` in `afterEach`.
  */
 export function wireFetch(): Wire {
@@ -83,24 +85,33 @@ export function runIndexOf(call: WireCall): number {
   return Number(index)
 }
 
-/** A store pair whose usage store records every granted reservation envelope. */
+/**
+ * A store pair whose usage store records every granted reservation envelope and every
+ * acknowledged commit, so "committed == dispatched runs" is a direct assertion.
+ */
 export function recordingStores(inner: StorePair): {
   stores: StorePair
   envelopes: ReservationEnvelope[]
+  commits: string[]
 } {
   const envelopes: ReservationEnvelope[] = []
+  const commits: string[] = []
   const usage: UsageStore = {
     async reserve(key, limit) {
       const result = await inner.usage.reserve(key, limit)
       if (result.ok) envelopes.push(result.reservation)
       return result
     },
-    commit: (reservationId) => inner.usage.commit(reservationId),
+    async commit(reservationId) {
+      const result = await inner.usage.commit(reservationId)
+      if (result === 'committed') commits.push(reservationId)
+      return result
+    },
     settle: (reservation, outcome, attempts) =>
       inner.usage.settle(reservation, outcome, attempts),
     snapshot: (key) => inner.usage.snapshot(key),
   }
-  return { stores: { config: inner.config, usage }, envelopes }
+  return { stores: { config: inner.config, usage }, envelopes, commits }
 }
 
 /** Flushes microtask turns until `predicate` holds; fails loudly instead of hanging. */
@@ -112,7 +123,10 @@ export async function until(predicate: () => boolean, what: string): Promise<voi
   throw new Error(`timed out waiting for ${what}`)
 }
 
-/** mulberry32: a tiny deterministic PRNG; the seed is the whole reproduction recipe. */
+/**
+ * mulberry32: a tiny deterministic PRNG. The seed pins the draw sequence exactly; which
+ * run receives which drawn outcome also depends on dispatch arrival order.
+ */
 export function mulberry32(seed: number): () => number {
   let state = seed >>> 0
   return () => {

--- a/test/unit/composition/matrix.test.ts
+++ b/test/unit/composition/matrix.test.ts
@@ -274,12 +274,17 @@ function asSwitchError(error: unknown, code: LLMSwitchError['code']): LLMSwitchE
 
 describe('completeness: the switch-built case list against the review-time inventory', () => {
   it('enumerates both unions in full and routes every row to exactly one block', () => {
+    // These two cannot fail at runtime — their type annotations are the actual gate, and
+    // a union change fails `tsc`, not vitest. Kept as documentation of that mechanism.
     expect(outcomesExhaustive).toBe(true)
     expect(kindsExhaustive).toBe(true)
     expect(ATTEMPT_OUTCOMES).toHaveLength(INVENTORY.attemptOutcomes)
     expect(PROVIDER_ERROR_KINDS).toHaveLength(INVENTORY.providerErrorKinds)
     for (const kind of PROVIDER_ERROR_KINDS) expect(ATTEMPT_OUTCOMES).toContain(kind)
 
+    // Only the dispatched-failure partition is mechanically tied to generated cases
+    // (FAILURE_ROWS drives them); the success, abort-timing, and raw-unwrap partitions
+    // are pinned by their named describes below, which this file carries by hand.
     const dispatched = ATTEMPT_OUTCOMES.filter(
       (outcome) => classify(outcome) === 'dispatched-failure',
     )
@@ -329,6 +334,9 @@ describe('dispatched-failure rows over the fallback axis', () => {
         row.arrange(f, 'p2')
         const run = observe(f.ai.run('echo', ARGS))
         await landAttempt(f, row)
+        // Timer rows must still be pending here: the fallback attempt gets a fresh
+        // timeout budget, so one advance cannot land both attempts.
+        if (row.land !== undefined) expect(run.state).toBe('pending')
         await landAttempt(f, row)
         expect(run.state).toBe('rejected')
         const error = asSwitchError(run.error, row.code)
@@ -346,6 +354,7 @@ describe('dispatched-failure rows over the fallback axis', () => {
         const error = asSwitchError(run.error, row.code)
         expect(error.retryable).toBe(row.retryable)
         expect(error.detectedAt).toBe(row.detectedAt)
+        expect(error.attempts?.map((a) => a.outcome)).toEqual([row.outcome])
         expect(f.p2.requests.length).toBe(0)
         expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle failed'])
       })
@@ -383,6 +392,9 @@ describe('the flag axis: fallbackOnAuthOrModelNotFound governs its two rows, pri
       },
       (f) => {
         f.p1.nextReject(new ProviderError('invalid_request', { status: 413 }))
+      },
+      (f) => {
+        f.p1.nextReject(new Error('a plain failure')) // provider_unclassified
       },
     ]
     for (const arrange of arrangements) {
@@ -428,6 +440,16 @@ describe('the aborted row: caller-signal timing at the composition level', () =>
     expect(error.attempts?.map((a) => a.outcome)).toEqual(['aborted'])
     expect(f.p2.requests.length).toBe(0)
     expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle failed'])
+  })
+
+  it("an adapter-reported 'aborted' with no caller signal re-classifies timeout, still fallback-eligible", async () => {
+    // The row's other half (spec §5b): the adapter saw the core's own timeout, not the
+    // caller's abort, so the timeout row's columns govern — including its eligibility.
+    const f = fixture(TABLE)
+    f.p1.nextReject(new ProviderError('aborted'))
+    const result = await f.ai.run('echo', ARGS)
+    expect(result.usedFallback).toBe(true)
+    expect(result.attempts.map((a) => a.outcome)).toEqual(['timeout', 'succeeded'])
   })
 
   it('abort during the fallback attempt -> ABORTED with the primary failure in the trail', async () => {
@@ -477,24 +499,19 @@ describe('raw-unwrap rows: the user error by identity, settled first, no fallbac
   }
 
   for (const name of ['output_schema_error', 'quality_error'] as const) {
-    it(`${name}: identity preserved, settlement observed before the throw, quota log intact`, async () => {
-      const order: string[] = []
+    it(`${name}: identity preserved, and the run holds until settlement completes`, async () => {
       const bug = new Error(`${name} bug`)
       const f = rawFixture(name, bug)
-      f.s.settle.next(() => {
-        order.push('settle')
-        return undefined
-      })
-      const run = observe(
-        f.ai.run('echo', ARGS).catch((error: unknown) => {
-          order.push('thrown')
-          throw error
-        }),
-      )
+      // Falsifiable ordering: settlement is gated open, so a core that stopped awaiting
+      // settle before rethrowing would surface the rejection while the gate still holds.
+      const gate = f.s.settle.nextHang()
+      const run = observe(f.ai.run('echo', ARGS))
+      await flushMicrotasks()
+      expect(run.state).toBe('pending')
+      gate.resolve(undefined)
       await flushMicrotasks()
       expect(run.state).toBe('rejected')
       expect(run.error).toBe(bug)
-      expect(order).toEqual(['settle', 'thrown'])
       expect(f.p2.requests.length).toBe(0)
       expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle failed'])
       expect(f.s.settle.calls[0]?.[2]?.map((a) => a.outcome)).toEqual([name])

--- a/test/unit/composition/matrix.test.ts
+++ b/test/unit/composition/matrix.test.ts
@@ -1,0 +1,571 @@
+/**
+ * The §5b classification table composed end to end (spec 271–308): every attempt-outcome
+ * row driven through `run` over its applicable fallback compositions, the flag axis on
+ * exactly its two rows, per-outcome-shape assertions including the quota-effect call log,
+ * and two-part completeness enforcement — an exhaustive `switch` over the
+ * `ProviderErrorKind` and `AttemptOutcome` unions builds the case list (a union member
+ * added later fails to compile), and the case count is pinned to a review-time inventory
+ * literal a reader diffs against the spec table.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { LLMSwitchError, ProviderError } from '../../../src/errors'
+import type {
+  AttemptOutcome,
+  OperationsMap,
+  ProviderErrorKind,
+  ProviderResponse,
+} from '../../../src/types'
+import type { Fixture } from '../core/helpers'
+import {
+  ECHO_INPUT,
+  ECHO_OUTPUT,
+  expectCode,
+  expectSameRejection,
+  fixture,
+  flushMicrotasks,
+  observe,
+} from '../core/helpers'
+
+const ARGS = { input: { text: 'hi' }, subjectId: 'u' }
+const QUOTA = { perDay: 5 }
+const TIMEOUT_MS = 1_000
+const TABLE = { quota: QUOTA, timeoutMs: TIMEOUT_MS }
+
+// ——— completeness enforcement ———
+
+/**
+ * Review-time inventory: the §5b row counts a reader diffs against the spec table. An aid
+ * for the human pass — the compile-time checks below are what fail when a union moves.
+ */
+const INVENTORY = { attemptOutcomes: 15, providerErrorKinds: 7 }
+
+const ATTEMPT_OUTCOMES = [
+  'succeeded',
+  'transient',
+  'rate_limit',
+  'auth',
+  'model_not_found',
+  'invalid_request',
+  'aborted',
+  'malformed_response',
+  'timeout',
+  'truncated',
+  'refused',
+  'output_rejected',
+  'output_schema_error',
+  'quality_error',
+  'provider_unclassified',
+] as const satisfies readonly AttemptOutcome[]
+
+const PROVIDER_ERROR_KINDS = [
+  'transient',
+  'rate_limit',
+  'auth',
+  'model_not_found',
+  'invalid_request',
+  'aborted',
+  'malformed_response',
+] as const satisfies readonly ProviderErrorKind[]
+
+// `satisfies` rejects an extra member; these aliases reject a missing one.
+type OutcomesExhaustive = [Exclude<AttemptOutcome, (typeof ATTEMPT_OUTCOMES)[number]>] extends [
+  never,
+]
+  ? true
+  : never
+type KindsExhaustive = [
+  Exclude<ProviderErrorKind, (typeof PROVIDER_ERROR_KINDS)[number]>,
+] extends [never]
+  ? true
+  : never
+const outcomesExhaustive: OutcomesExhaustive = true
+const kindsExhaustive: KindsExhaustive = true
+
+/** Where each §5b row is asserted in this file; the switch is the completeness gate. */
+type RowClass = 'success' | 'dispatched-failure' | 'abort-timing' | 'raw-unwrap'
+
+function classify(outcome: AttemptOutcome): RowClass {
+  switch (outcome) {
+    case 'succeeded':
+      return 'success'
+    case 'transient':
+    case 'rate_limit':
+    case 'malformed_response':
+    case 'timeout':
+    case 'truncated':
+    case 'output_rejected':
+    case 'refused':
+    case 'auth':
+    case 'model_not_found':
+    case 'invalid_request':
+    case 'provider_unclassified':
+      return 'dispatched-failure'
+    case 'aborted':
+      return 'abort-timing'
+    case 'output_schema_error':
+    case 'quality_error':
+      return 'raw-unwrap'
+    default: {
+      // A union member added later lands here and fails to compile.
+      const missing: never = outcome
+      throw new Error(`§5b row not in the matrix: ${String(missing)}`)
+    }
+  }
+}
+
+// ——— the dispatched-failure rows ———
+
+interface FailureRow {
+  outcome: AttemptOutcome
+  eligible: boolean
+  code: LLMSwitchError['code']
+  retryable: boolean
+  detectedAt?: 'provider'
+  arrange: (f: Fixture, which: 'p1' | 'p2') => void
+  /** Fires the timers this row needs before the arranged attempt can end. */
+  land?: (f: Fixture) => Promise<void>
+}
+
+const truncatedResponse: ProviderResponse = {
+  kind: 'truncated',
+  text: 'part',
+  usage: { inputTokens: 1, outputTokens: 1 },
+}
+const refusedResponse: ProviderResponse = {
+  kind: 'refused',
+  text: '',
+  usage: { inputTokens: 1, outputTokens: 0 },
+}
+
+/** Each row's literal terminal columns from §5b, plus how to arrange it on an attempt. */
+const FAILURE_ROWS: FailureRow[] = [
+  {
+    outcome: 'transient',
+    eligible: true,
+    code: 'PROVIDER_FAILED',
+    retryable: true,
+    arrange: (f, which) => {
+      f[which].nextReject(new ProviderError('transient', { status: 503 }))
+    },
+  },
+  {
+    outcome: 'rate_limit',
+    eligible: true,
+    code: 'PROVIDER_FAILED',
+    retryable: true,
+    arrange: (f, which) => {
+      f[which].nextReject(new ProviderError('rate_limit', { status: 429 }))
+    },
+  },
+  {
+    outcome: 'malformed_response',
+    eligible: true,
+    code: 'PROVIDER_FAILED',
+    retryable: true,
+    arrange: (f, which) => {
+      f[which].nextReject(new ProviderError('malformed_response'))
+    },
+  },
+  {
+    outcome: 'timeout',
+    eligible: true,
+    code: 'PROVIDER_FAILED',
+    retryable: true,
+    arrange: (f, which) => {
+      f[which].nextHang()
+    },
+    land: (f) => f.runtime.advance(TIMEOUT_MS),
+  },
+  {
+    outcome: 'truncated',
+    eligible: true,
+    code: 'OUTPUT_REJECTED',
+    retryable: true,
+    arrange: (f, which) => {
+      f[which].nextResolve(truncatedResponse)
+    },
+  },
+  {
+    outcome: 'output_rejected',
+    eligible: true,
+    code: 'OUTPUT_REJECTED',
+    retryable: true,
+    arrange: (f, which) => {
+      f[which].nextResolve({ kind: 'complete', text: 'not json', usage: null })
+    },
+  },
+  {
+    outcome: 'refused',
+    eligible: false,
+    code: 'PROVIDER_FAILED',
+    retryable: false,
+    arrange: (f, which) => {
+      f[which].nextResolve(refusedResponse)
+    },
+  },
+  {
+    outcome: 'auth',
+    eligible: false,
+    code: 'INVALID_CONFIG',
+    retryable: false,
+    detectedAt: 'provider',
+    arrange: (f, which) => {
+      f[which].nextReject(new ProviderError('auth', { status: 401 }))
+    },
+  },
+  {
+    outcome: 'model_not_found',
+    eligible: false,
+    code: 'INVALID_CONFIG',
+    retryable: false,
+    detectedAt: 'provider',
+    arrange: (f, which) => {
+      f[which].nextReject(new ProviderError('model_not_found', { status: 404 }))
+    },
+  },
+  {
+    outcome: 'invalid_request',
+    eligible: false,
+    code: 'PROVIDER_FAILED',
+    retryable: false,
+    arrange: (f, which) => {
+      f[which].nextReject(new ProviderError('invalid_request', { status: 413 }))
+    },
+  },
+  {
+    outcome: 'provider_unclassified',
+    eligible: false,
+    code: 'PROVIDER_FAILED',
+    retryable: false,
+    arrange: (f, which) => {
+      f[which].nextReject(new Error('a plain failure'))
+    },
+  },
+]
+
+// ——— instruments ———
+
+/** The quota-effect call log, reduced to its shape: reserve / commit / settle <outcome>. */
+function quotaLog(f: Fixture): string[] {
+  return f.s.log
+    .filter(
+      (line) =>
+        line.startsWith('reserve') || line.startsWith('commit') || line.startsWith('settle'),
+    )
+    .map((line) => (line.startsWith('settle') ? line : (line.split(' ')[0] ?? line)))
+}
+
+/** Fires the row's timers (when it has any) and drains the microtask queue. */
+async function landAttempt(f: Fixture, row: FailureRow): Promise<void> {
+  if (row.land !== undefined) await row.land(f)
+  await flushMicrotasks()
+}
+
+function asSwitchError(error: unknown, code: LLMSwitchError['code']): LLMSwitchError {
+  expect(error).toBeInstanceOf(LLMSwitchError)
+  const typed = error as LLMSwitchError
+  expect(typed.code).toBe(code)
+  return typed
+}
+
+// ——— the matrix ———
+
+describe('completeness: the switch-built case list against the review-time inventory', () => {
+  it('enumerates both unions in full and routes every row to exactly one block', () => {
+    expect(outcomesExhaustive).toBe(true)
+    expect(kindsExhaustive).toBe(true)
+    expect(ATTEMPT_OUTCOMES).toHaveLength(INVENTORY.attemptOutcomes)
+    expect(PROVIDER_ERROR_KINDS).toHaveLength(INVENTORY.providerErrorKinds)
+    for (const kind of PROVIDER_ERROR_KINDS) expect(ATTEMPT_OUTCOMES).toContain(kind)
+
+    const dispatched = ATTEMPT_OUTCOMES.filter(
+      (outcome) => classify(outcome) === 'dispatched-failure',
+    )
+    expect([...FAILURE_ROWS.map((row) => row.outcome)].sort()).toEqual([...dispatched].sort())
+    expect(ATTEMPT_OUTCOMES.filter((o) => classify(o) === 'success')).toEqual(['succeeded'])
+    expect(ATTEMPT_OUTCOMES.filter((o) => classify(o) === 'abort-timing')).toEqual(['aborted'])
+    expect(ATTEMPT_OUTCOMES.filter((o) => classify(o) === 'raw-unwrap')).toEqual([
+      'output_schema_error',
+      'quality_error',
+    ])
+  })
+})
+
+describe('dispatched-failure rows over the fallback axis', () => {
+  for (const row of FAILURE_ROWS) {
+    it(`${row.outcome}: no fallback declared -> terminal shape and quota log`, async () => {
+      const f = fixture({ ...TABLE, fallback: false })
+      row.arrange(f, 'p1')
+      const run = observe(f.ai.run('echo', ARGS))
+      await landAttempt(f, row)
+      expect(run.state).toBe('rejected')
+      const error = asSwitchError(run.error, row.code)
+      expect(error.retryable).toBe(row.retryable)
+      expect(error.detectedAt).toBe(row.detectedAt)
+      expect(error.attempts?.map((a) => a.outcome)).toEqual([row.outcome])
+      expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle failed'])
+    })
+
+    if (row.eligible) {
+      it(`${row.outcome}: fallback declared -> rescued, result shape, one slot`, async () => {
+        const f = fixture(TABLE)
+        row.arrange(f, 'p1')
+        const run = observe(f.ai.run('echo', ARGS))
+        await landAttempt(f, row)
+        expect(run.state).toBe('resolved')
+        const result = run.value
+        expect(result?.data).toEqual({ answer: 'ok' })
+        expect(result?.route).toEqual({ provider: 'p2', model: 'm2' })
+        expect(result?.usedFallback).toBe(true)
+        expect(result?.attempts.map((a) => a.outcome)).toEqual([row.outcome, 'succeeded'])
+        expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle succeeded'])
+      })
+
+      it(`${row.outcome}: the fallback itself fails the same way -> its terminal, both attempts recorded`, async () => {
+        const f = fixture(TABLE)
+        row.arrange(f, 'p1')
+        row.arrange(f, 'p2')
+        const run = observe(f.ai.run('echo', ARGS))
+        await landAttempt(f, row)
+        await landAttempt(f, row)
+        expect(run.state).toBe('rejected')
+        const error = asSwitchError(run.error, row.code)
+        expect(error.retryable).toBe(row.retryable)
+        expect(error.attempts?.map((a) => a.outcome)).toEqual([row.outcome, row.outcome])
+        expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle failed'])
+      })
+    } else {
+      it(`${row.outcome}: fallback declared but ineligible -> terminal, nothing dispatched to it`, async () => {
+        const f = fixture(TABLE)
+        row.arrange(f, 'p1')
+        const run = observe(f.ai.run('echo', ARGS))
+        await landAttempt(f, row)
+        expect(run.state).toBe('rejected')
+        const error = asSwitchError(run.error, row.code)
+        expect(error.retryable).toBe(row.retryable)
+        expect(error.detectedAt).toBe(row.detectedAt)
+        expect(f.p2.requests.length).toBe(0)
+        expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle failed'])
+      })
+    }
+  }
+})
+
+describe('the flag axis: fallbackOnAuthOrModelNotFound governs its two rows, primary only', () => {
+  for (const kind of ['auth', 'model_not_found'] as const) {
+    it(`${kind}: flag on -> the primary is rescued`, async () => {
+      const f = fixture({ ...TABLE, config: { fallbackOnAuthOrModelNotFound: true } })
+      f.p1.nextReject(new ProviderError(kind))
+      const result = await f.ai.run('echo', ARGS)
+      expect(result.usedFallback).toBe(true)
+      expect(result.attempts.map((a) => a.outcome)).toEqual([kind, 'succeeded'])
+      expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle succeeded'])
+    })
+
+    it(`${kind}: flag on, the fallback itself ends ${kind} -> terminal INVALID_CONFIG (provider); no second fallback`, async () => {
+      const f = fixture({ ...TABLE, config: { fallbackOnAuthOrModelNotFound: true } })
+      f.p1.nextReject(new ProviderError('transient', { status: 503 }))
+      f.p2.nextReject(new ProviderError(kind))
+      const error = await expectCode(f.ai.run('echo', ARGS), 'INVALID_CONFIG')
+      expect(error.retryable).toBe(false)
+      expect(error.detectedAt).toBe('provider')
+      expect(error.attempts?.map((a) => a.outcome)).toEqual(['transient', kind])
+      expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle failed'])
+    })
+  }
+
+  it('the flag reaches no other ineligible row', async () => {
+    const arrangements: ((f: Fixture) => void)[] = [
+      (f) => {
+        f.p1.nextResolve(refusedResponse)
+      },
+      (f) => {
+        f.p1.nextReject(new ProviderError('invalid_request', { status: 413 }))
+      },
+    ]
+    for (const arrange of arrangements) {
+      const f = fixture({ ...TABLE, config: { fallbackOnAuthOrModelNotFound: true } })
+      arrange(f)
+      await expectCode(f.ai.run('echo', ARGS), 'PROVIDER_FAILED')
+      expect(f.p2.requests.length).toBe(0)
+    }
+  })
+})
+
+describe("provider_unclassified's one real branch: treatUnclassifiedAsTransient", () => {
+  it('on: reclassifies to transient and the fallback rescues', async () => {
+    const f = fixture({ ...TABLE, config: { treatUnclassifiedAsTransient: true } })
+    f.p1.nextReject(new Error('a plain failure'))
+    const result = await f.ai.run('echo', ARGS)
+    expect(result.usedFallback).toBe(true)
+    expect(result.attempts.map((a) => a.outcome)).toEqual(['transient', 'succeeded'])
+  })
+
+  it("on: both attempts unclassified -> the transient row's terminal (PROVIDER_FAILED, retryable true)", async () => {
+    const f = fixture({ ...TABLE, config: { treatUnclassifiedAsTransient: true } })
+    f.p1.nextReject(new Error('one'))
+    f.p2.nextReject(new Error('two'))
+    const error = await expectCode(f.ai.run('echo', ARGS), 'PROVIDER_FAILED')
+    expect(error.retryable).toBe(true)
+    expect(error.attempts?.map((a) => a.outcome)).toEqual(['transient', 'transient'])
+  })
+})
+
+describe('the aborted row: caller-signal timing at the composition level', () => {
+  it('abort during the primary attempt -> ABORTED, one attempt, the fallback never dispatched', async () => {
+    const f = fixture(TABLE)
+    const controller = new AbortController()
+    f.p1.nextHang()
+    const run = observe(f.ai.run('echo', ARGS, { signal: controller.signal }))
+    await flushMicrotasks()
+    controller.abort()
+    await flushMicrotasks()
+    expect(run.state).toBe('rejected')
+    const error = asSwitchError(run.error, 'ABORTED')
+    expect(error.retryable).toBe(false)
+    expect(error.attempts?.map((a) => a.outcome)).toEqual(['aborted'])
+    expect(f.p2.requests.length).toBe(0)
+    expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle failed'])
+  })
+
+  it('abort during the fallback attempt -> ABORTED with the primary failure in the trail', async () => {
+    const f = fixture(TABLE)
+    const controller = new AbortController()
+    f.p1.nextReject(new ProviderError('transient', { status: 503 }))
+    f.p2.nextHang()
+    const run = observe(f.ai.run('echo', ARGS, { signal: controller.signal }))
+    await flushMicrotasks()
+    expect(f.p2.requests.length).toBe(1)
+    controller.abort()
+    await flushMicrotasks()
+    expect(run.state).toBe('rejected')
+    const error = asSwitchError(run.error, 'ABORTED')
+    expect(error.retryable).toBe(false)
+    expect(error.attempts?.map((a) => a.outcome)).toEqual(['transient', 'aborted'])
+    expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle failed'])
+  })
+})
+
+describe('raw-unwrap rows: the user error by identity, settled first, no fallback', () => {
+  function rawFixture(name: 'output_schema_error' | 'quality_error', bug: unknown): Fixture {
+    if (name === 'quality_error') {
+      return fixture({
+        ...TABLE,
+        quality: () => {
+          throw bug
+        },
+      })
+    }
+    const operations = {
+      echo: {
+        input: ECHO_INPUT,
+        output: ECHO_OUTPUT.transform(() => {
+          throw bug
+        }),
+        prompt: () => 'p',
+        quota: QUOTA,
+        defaultRoute: {
+          provider: 'p1',
+          model: 'm1',
+          fallback: { provider: 'p2', model: 'm2' },
+        },
+      },
+    } as unknown as OperationsMap
+    return fixture({ operations })
+  }
+
+  for (const name of ['output_schema_error', 'quality_error'] as const) {
+    it(`${name}: identity preserved, settlement observed before the throw, quota log intact`, async () => {
+      const order: string[] = []
+      const bug = new Error(`${name} bug`)
+      const f = rawFixture(name, bug)
+      f.s.settle.next(() => {
+        order.push('settle')
+        return undefined
+      })
+      const run = observe(
+        f.ai.run('echo', ARGS).catch((error: unknown) => {
+          order.push('thrown')
+          throw error
+        }),
+      )
+      await flushMicrotasks()
+      expect(run.state).toBe('rejected')
+      expect(run.error).toBe(bug)
+      expect(order).toEqual(['settle', 'thrown'])
+      expect(f.p2.requests.length).toBe(0)
+      expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle failed'])
+      expect(f.s.settle.calls[0]?.[2]?.map((a) => a.outcome)).toEqual([name])
+    })
+  }
+})
+
+describe('the prompt-stage rows stand alone: pre-quota, nothing dispatched', () => {
+  it('a thrown prompt value passes through by identity before any quota call', async () => {
+    const bug = new Error('prompt bug')
+    const operations = {
+      echo: {
+        input: ECHO_INPUT,
+        output: ECHO_OUTPUT,
+        prompt: () => {
+          throw bug
+        },
+        quota: QUOTA,
+        defaultRoute: {
+          provider: 'p1',
+          model: 'm1',
+          fallback: { provider: 'p2', model: 'm2' },
+        },
+      },
+    } as unknown as OperationsMap
+    const f = fixture({ operations })
+    await expectSameRejection(f.ai.run('echo', ARGS), bug)
+    expect(quotaLog(f)).toEqual([])
+    expect(f.p1.requests.length).toBe(0)
+    expect(f.p2.requests.length).toBe(0)
+  })
+
+  it('a non-string prompt return raises a core-created descriptive TypeError, nothing dispatched', async () => {
+    const operations = {
+      echo: {
+        input: ECHO_INPUT,
+        output: ECHO_OUTPUT,
+        prompt: () => 42,
+        quota: QUOTA,
+        defaultRoute: {
+          provider: 'p1',
+          model: 'm1',
+          fallback: { provider: 'p2', model: 'm2' },
+        },
+      },
+    } as unknown as OperationsMap
+    const f = fixture({ operations })
+    const run = observe(f.ai.run('echo', ARGS))
+    await flushMicrotasks()
+    expect(run.state).toBe('rejected')
+    expect(run.error).toBeInstanceOf(TypeError)
+    const message = (run.error as TypeError).message
+    expect(message).toMatch(/must return a string/)
+    expect(message).toContain('echo')
+    expect(message).toContain('number')
+    expect(quotaLog(f)).toEqual([])
+    expect(f.p1.requests.length + f.p2.requests.length).toBe(0)
+    expect(f.s.settle.calls.length).toBe(0)
+  })
+})
+
+describe('the succeeded row', () => {
+  it('primary success: data, route, usedFallback, attempts, aggregated usage, quota log', async () => {
+    const f = fixture(TABLE)
+    const result = await f.ai.run('echo', ARGS)
+    expect(result.data).toEqual({ answer: 'ok' })
+    expect(result.route).toEqual({ provider: 'p1', model: 'm1' })
+    expect(result.usedFallback).toBe(false)
+    expect(result.attempts.map((a) => a.outcome)).toEqual(['succeeded'])
+    expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 5 })
+    expect(result.usageComplete).toBe(true)
+    expect(quotaLog(f)).toEqual(['reserve', 'commit', 'settle succeeded'])
+  })
+})

--- a/test/unit/composition/vertical-slice.test.ts
+++ b/test/unit/composition/vertical-slice.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The vertical slice: one operation end to end through the public surface — `createSwitch`,
+ * the `openaiCompatible` factory over a scripted wire, `memoryStores` — with the fallback
+ * exercised, the output parsed by the operation's schema, and the daily quota enforced.
+ * One green spec demonstrating the assembled whole is fit.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import { createSwitch } from '../../../src/index'
+import { openaiCompatible } from '../../../src/providers/openai-compatible'
+import { memoryStores } from '../../../src/stores/memory'
+import type { OperationsMap } from '../../../src/types'
+import { expectCode } from '../core/helpers'
+import { installFetch, jsonResponse } from '../providers/helpers'
+import { openaiSuccess } from './helpers'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('vertical slice: one operation through the assembled package', () => {
+  it('falls back, parses output, aggregates usage, and enforces the daily quota', async () => {
+    const responses = [
+      jsonResponse(429, { error: { message: 'rate limited' } }),
+      openaiSuccess('{"answer":"from-fallback"}', { prompt_tokens: 11, completion_tokens: 4 }),
+      openaiSuccess('{"answer":"from-primary"}', { prompt_tokens: 9, completion_tokens: 2 }),
+    ]
+    let dispatched = 0
+    installFetch(() => {
+      dispatched += 1
+      return responses.shift() ?? jsonResponse(500, null)
+    })
+
+    const operations = {
+      extract: {
+        input: z.object({ text: z.string() }),
+        output: z.object({ answer: z.string() }),
+        prompt: ({ text }: { text: string }) => `Extract the answer from: ${text}`,
+        quota: { perDay: 2 },
+        defaultRoute: {
+          provider: 'openai',
+          model: 'gpt-primary',
+          fallback: { provider: 'openai', model: 'gpt-fallback' },
+        },
+      },
+    } as unknown as OperationsMap
+    const ai = createSwitch({
+      providers: { openai: openaiCompatible({ apiKey: () => 'sk-slice' }) },
+      operations,
+      stores: memoryStores(),
+    })
+
+    // Run 1: the primary is rate-limited; the fallback answers; the JSON is parsed.
+    const first = await ai.run('extract', { input: { text: 'a' }, subjectId: 'user-1' })
+    expect(first.data).toEqual({ answer: 'from-fallback' })
+    expect(first.usedFallback).toBe(true)
+    expect(first.route).toEqual({ provider: 'openai', model: 'gpt-fallback' })
+    expect(first.attempts.map((a) => a.outcome)).toEqual(['rate_limit', 'succeeded'])
+    expect(first.usage).toEqual({ inputTokens: 11, outputTokens: 4 })
+    expect(first.usageComplete).toBe(false) // the 429 attempt reported no usage
+
+    // Run 2: the primary answers directly.
+    const second = await ai.run('extract', { input: { text: 'b' }, subjectId: 'user-1' })
+    expect(second.data).toEqual({ answer: 'from-primary' })
+    expect(second.usedFallback).toBe(false)
+    expect(second.route).toEqual({ provider: 'openai', model: 'gpt-primary' })
+
+    // Run 3: both daily slots are spent — denied before any dispatch. The fallback shared
+    // its run's slot, so two runs consumed two slots, not three attempts' worth.
+    expect(dispatched).toBe(3)
+    const denied = await expectCode(
+      ai.run('extract', { input: { text: 'c' }, subjectId: 'user-1' }),
+      'QUOTA_EXCEEDED',
+    )
+    expect(denied.retryable).toBe(false)
+    expect(Number.isNaN(new Date(denied.resetsAt ?? '').getTime())).toBe(false)
+    expect(dispatched).toBe(3)
+
+    const quota = await ai.getQuota('extract', 'user-1')
+    expect(quota).toMatchObject({ limit: 2, used: 2, remaining: 0 })
+  })
+})


### PR DESCRIPTION
The final test layer before v0.1 — test-only, no src changes.

**Composition matrix** (`test/unit/composition/matrix.test.ts`): the §5b classification table driven end to end through `run` — every attempt outcome over its applicable fallback compositions, the `fallbackOnAuthOrModelNotFound` axis on exactly its two rows, caller-abort timing on both attempts, the adapter-reported abort re-classified `timeout`, raw user errors unwrapped by identity only after settlement completes, the prompt-stage rows, and the quota-effect call log on every path. Completeness is compile-enforced: an exhaustive switch over `ProviderErrorKind` and `AttemptOutcome` plus an inventory count, so a union member added later fails `tsc` before any test runs.

**Concurrency under load** (`concurrency.test.ts`): 32 overlapping runs over one shared provider registered as both primary and fallback, each run resolving a distinct credential — every dispatched request, fallbacks included, carries exactly its own run's key, and the resolver is invoked exactly once per run. Store reconciliation at quiescence: grants, commit acknowledgements, settlements, and the snapshot all agree at N, and advancing the pinned store clock past the lease proves no reservation was left pending. Plus admin writes interleaved with in-flight runs, and a seeded stochastic smoke over shuffled settlement orders.

**Vertical slice** (`vertical-slice.test.ts`): one operation end to end through the public surface — `createSwitch`, `openaiCompatible` over a scripted wire, `memoryStores` — fallback exercised, output parsed against the operation schema, and the daily quota enforced before dispatch on the third run.

48 new tests, 741 total; the full local battery (typecheck, lint, depcruise, build, publint, attw, api surface, size, coverage thresholds) is green. No live keys anywhere: every wire interaction is a scripted in-memory `fetch`.