### PR TITLE
Release runbook, audit-only publish runs, contributor ground rules

### DIFF
--- a/.changeset/readme-security-policy.md
+++ b/.changeset/readme-security-policy.md
@@ -1,0 +1,7 @@
+---
+'llmswitch': patch
+---
+
+Docs: the README's Contributing section now points at the security policy — security
+problems go through GitHub's private vulnerability reporting, described in `SECURITY.md`,
+rather than an issue or a pull request.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,11 @@ on:
         description: The reviewed commit on main this release must be built from
         required: true
         type: string
+      audit_only:
+        description: Produce the audited tarball and stop, leaving no publish to approve
+        required: false
+        default: false
+        type: boolean
 
 # Workflow level is read-only on purpose: the ungated audit job must never hold
 # publish-capable authority.
@@ -78,12 +83,16 @@ jobs:
   # here: after the audit, immediately before the registry is changed.
   publish:
     needs: audit
+    # An audit-only run never reaches this job, so no approval is left pending on it.
+    if: ${{ !inputs.audit_only }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: release
     permissions:
       contents: read
-      # The only job that can mint a provenance token.
+      # How this job proves to npm which repository, workflow and run it is — both the
+      # OIDC credential it authenticates with and what the provenance is minted from.
+      # This is the only job that holds the permission.
       id-token: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,25 @@ section.
 The last two take a tarball you produced with `npm pack`; they never pack one themselves,
 so what you audit is what you test.
 
+## How changes land
+
+**Commit messages follow Conventional Commits** — `feat:`, `fix:`, `docs:`, and the rest.
+That is the convention the history is written in; the changelog itself is generated from
+changesets, not from commit messages, so the prefix is for the reader of `git log`.
+
+**A pull request lands rebased**, as a small set of coherent commits with the fixups squashed
+away before the final review. The history is linear and there are no merge commits, so
+`git log` reads as the order things actually happened.
+
+**Never a live API key** — not in a pull request, not in a fixture, not in continuous
+integration. Fixtures are synthetic, or recorded from a real response and then redacted; CI
+runs without provider keys by construction rather than by anyone remembering. `npm run scan`
+is part of reviewing a change, and secret hygiene is checked before anything is pushed, not
+after.
+
+Getting a version out is a separate procedure with its own preconditions:
+[`RELEASING.md`](RELEASING.md).
+
 ## Pull requests
 
 One coherent change per pull request, with the checks green. Explain what the change does

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ export async function POST(req: Request) {
 
 ## Contributing
 
-Issues and PRs welcome — the project is actively developed and maintained. For API changes, open an issue to discuss before building; [docs/spec.md](./docs/spec.md) is the contract under discussion. A security policy (private vulnerability reporting) and release provenance will be in place at first release.
+Issues and PRs welcome — the project is actively developed and maintained. For API changes, open an issue to discuss before building; [docs/spec.md](./docs/spec.md) is the contract under discussion. Security problems go through private vulnerability reporting instead — see [SECURITY.md](./SECURITY.md). Stable releases will carry provenance.
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,173 @@
+# Releasing
+
+How a version of this package reaches npm. Written so that whoever does it next — including
+me, six months from now — does not have to work out the reasoning again.
+
+## Before any release
+
+- `main` is green: the full continuous-integration run on the exact commit being released.
+- The version and the changelog were produced by changesets (`npx changeset version`), and
+  that bump is its own reviewed commit on `main`.
+- You have that commit's SHA in hand. The workflow refuses to run against anything else.
+- The `release` environment is set to require a manual approval before its jobs run. That
+  is a repository setting, and nothing in the repository can assert it: if the rule is
+  missing, the environment stops being a gate and a dispatch runs straight through to the
+  registry. Check it, do not assume it.
+- No workflow other than `publish` selects the `release` environment. Another workflow
+  naming it would sit behind the same approval and read the same environment-scoped
+  secrets, which quietly widens what that one approval means.
+- The npm account has 2FA enabled and its recovery codes are stored somewhere you can
+  actually reach.
+
+### Release verification
+
+The dispatch workflow does not cover all of it. Two checks run before you dispatch, and a
+release ships only if both pass:
+
+- **Packaged migrations and conformance** (spec §6b, which mandates this). The packaged SQL
+  is applied to a real PostgreSQL, and all three conformance harnesses run from the
+  installed tarball — not from the working tree, so what is verified is what adopters get.
+- **Provider live-check.** The built-in adapters are exercised against the real provider
+  endpoints — the release live-check the specification leans on for the pinned wire
+  contracts (§5c). It needs live keys, so it is run by hand and never in continuous
+  integration.
+
+How these are executed, and how much of either is worth automating, is settled with the
+release audit. What is fixed here is that they are preconditions, not follow-ups.
+
+## How a release runs
+
+Dispatch the `publish` workflow from the Actions tab with `expected_sha` set to the reviewed
+commit. Nothing about a release is automatic: the workflow is manual only.
+
+1. The `audit` job checks it is running on `main` at exactly that SHA, builds, packs, records
+   the tarball's SHA-256, audits what the tarball contains, installs it into ESM, CommonJS
+   and TypeScript projects on the lowest supported Node, and uploads the tarball and its hash
+   as the `release-tarball` artifact. This job holds no credentials.
+2. The `publish` job waits behind the `release` environment's approval. That gate sits after
+   the audit and immediately before the registry changes, so the thing being approved is a
+   set of bytes somebody can already look at.
+3. The publish step rechecks the recorded hash and publishes in the same step, so there is no
+   window between verifying the bytes and sending them.
+
+The workflow also takes an `audit_only` input. With it set, the publish job never becomes
+eligible at all, and the run produces the audited `release-tarball` artifact and stops. Use
+it whenever you want the exact audited bytes without leaving a run parked one approval away
+from a publish. However you dispatch it, look at the run afterwards and confirm the publish
+job shows as skipped — that check costs seconds and does not depend on how the input was
+delivered.
+
+## Every release after the first
+
+The flow above, and nothing else. Once step 7 of the bootstrap below has landed, the workflow
+authenticates to npm over OIDC as the configured trusted publisher and no publish token
+exists in it at all.
+
+## First release: bootstrapping the trusted publisher
+
+npm will only let a trusted publisher be configured on a package that already exists, so the
+very first publish cannot go through the workflow. This section exists once. Follow it in
+order — several steps are ordered for a reason, noted where it matters.
+
+1. **Recheck the name.** Immediately before publishing, confirm `llmswitch` is still
+   unclaimed:
+
+   ```bash
+   npm view llmswitch --registry=https://registry.npmjs.org/
+   ```
+
+   It must fail with `E404`. The registry is named explicitly because a mirror or a corporate
+   proxy will happily return `E404` for a name that is taken on the public registry. If the
+   name has been claimed, **stop**. Moving to a scoped name is not a rename — the import
+   specifier is the package's public contract, and it appears in the README, the type
+   fixtures, the consumer tests, the examples and their lockfiles, and the verification
+   harnesses. That is a migration with every release gate re-run, and it needs planning on
+   its own.
+
+2. **Publish a release candidate.** Set the version to `0.1.0-rc.0` — this one bump is an
+   exception to the changesets rule above, because the RC is not a stable release: edit `version` in
+   `package.json` and in `package-lock.json` (both the root entry and the self-referencing
+   packages entry) by hand, and land it as its own reviewed commit. Run the workflow at that
+   commit with `audit_only`, download the `release-tarball` artifact, and check its hash
+   locally with `sha256sum -c tarball.sha256`.
+
+   Publish that exact tarball from your own terminal. Start from a clean, interactive
+   `npm login` against the public registry, then:
+
+   ```bash
+   npm publish ./llmswitch-0.1.0-rc.0.tgz --tag=next --access=public --ignore-scripts --registry=https://registry.npmjs.org/
+   ```
+
+   You must be presented with a 2FA challenge. If none appears, **stop** and find out why
+   before republishing — an unchallenged publish means the credential in play is not the one
+   this process assumes. The `next` tag keeps the version that bootstraps the registry entry
+   out of what a plain `npm install` gets. No automation token is created for this, here or
+   anywhere else in this document.
+
+3. **Wait.** npm scans a fresh publish before the package page and its settings are usable.
+   Allow minutes, not seconds.
+
+4. **Configure the trusted publisher**, interactively, on the package's settings. The binding
+   is data — copy it character for character:
+
+   | Field             | Value         |
+   | ----------------- | ------------- |
+   | GitHub owner      | `parvezrob`   |
+   | Repository        | `llmswitch`   |
+   | Workflow filename | `publish.yml` |
+   | Environment       | `release`     |
+   | Allowed action    | `npm publish` |
+
+   The workflow field is a filename, not a path. The environment name is case-sensitive. A
+   package gets one trusted publisher, so there is no second entry to fall back on. npm does
+   not validate any of these fields when you save them — a mismatch first shows up as a
+   failed publish, which is why they are copied rather than typed from memory. The
+   `npm trust` command can do this; it is newer than most guides, so check `npm trust --help`
+   for the exact syntax at the time you run it, or use the package settings page.
+
+5. **Preflight.** `repository.url` in `package.json` names this repository exactly, and the
+   trusted-publisher list shows the single entry above and nothing else.
+
+6. **Restore the real version**, as its own reviewed commit. `npx changeset version` run
+   against `0.1.0-rc.0` consumes the pending patch changesets and lands on exactly `0.1.0` —
+   a patch bump of a prerelease drops the prerelease rather than adding to it. Confirm that
+   rather than trusting it; if the tool produces anything else, correct the version by hand
+   in the same commit. The released version is `0.1.0`, not a `0.1.1` that a pending
+   changeset produced by accident. Changesets edits `package.json` and the changelog but not
+   the lockfile, so bring `package-lock.json` along by running
+   `npm install --package-lock-only --ignore-scripts` — continuous integration checks the
+   lockfile is canonical and will fail the commit otherwise.
+
+   The same commit is where the pre-release prose goes, because changesets only ever inserts
+   entries and never removes anything anybody wrote: drop the pre-release banner near the top
+   of the README, and drop the "Nothing has been released yet." line from `CHANGELOG.md`.
+
+   Review the whole result before merging, as with the RC bump: `package.json`,
+   `package-lock.json`, `CHANGELOG.md`, and the changeset files the tool deleted.
+
+7. **Remove `NODE_AUTH_TOKEN` from the publish workflow, and merge that before publishing
+   through it.** npm falls back to token authentication when a token is in scope, so a
+   publish with one still present proves nothing about the trusted-publisher binding.
+
+8. **Publish `0.1.0` through the workflow.** This release is itself the first evidence the
+   OIDC binding works, and it is the first build to carry provenance naming the repository,
+   the workflow, and the run. Verify on the registry: the version, the tarball digest, and
+   the provenance attestation.
+
+9. **Point the dist-tags where they belong.** Publishing `0.1.0` does not touch `next`, which
+   is still on the RC. Either move it —
+   `npm dist-tag add llmswitch@0.1.0 next --registry=https://registry.npmjs.org/` — or remove
+   it with `npm dist-tag rm llmswitch next --registry=https://registry.npmjs.org/`. Then read
+   the result back with `npm dist-tag ls llmswitch --registry=https://registry.npmjs.org/`
+   and check both `latest` and `next` say what you intended. The registry stays pinned for
+   the same reason as everywhere else in this document: a configured mirror would otherwise
+   take these commands silently.
+
+10. **Restrict the package**: require 2FA, and disallow publishing with a token.
+
+No granular access token with Bypass 2FA is used at any point. Besides being one more
+credential to protect, npm has said such tokens lose their direct-publish capability around
+January 2027, so a release process built on one would have to be rebuilt.
+
+Stable releases carry provenance. The bootstrap RC does not — a publish from a laptop has
+nothing to attest with.

--- a/examples/express/README.md
+++ b/examples/express/README.md
@@ -10,7 +10,19 @@ Plain ESM JavaScript. The route is `openaiCompatible`, so it works against OpenA
 OpenAI-compatible endpoint — a gateway, or a local model server — by setting
 `OPENAI_BASE_URL`.
 
-## Run it
+## In your own project
+
+Nothing here is special to this repository except how the dependency is installed (the
+section below). In your own project it is simply:
+
+```bash
+npm install llmswitch zod
+```
+
+Then copy `switch.js` and `server.js` and replace the `demo-user` subject with the user id
+your auth already gives you.
+
+## Run it from this repository
 
 The dependency here is the tarball this repository packs, so the example always runs
 against the bytes that would be published. Two steps:
@@ -54,15 +66,3 @@ than OpenAI.
 `memoryStores()` is for the demo: config and quota counters live in this process, so
 they are not shared between instances and reset on restart. In production use the
 Postgres stores instead.
-
-## In your own project
-
-Nothing here is special to this repository except the tarball. In your own project the
-dependency is simply:
-
-```bash
-npm install llmswitch zod
-```
-
-Then copy `switch.js` and `server.js` and replace the `demo-user` subject with the user id
-your auth already gives you.

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -11,7 +11,19 @@ TypeScript, Node.js runtime. The route is `openaiCompatible`, so it works agains
 or any OpenAI-compatible endpoint — a gateway, or a local model server — by setting
 `OPENAI_BASE_URL`.
 
-## Run it
+## In your own project
+
+Nothing here is special to this repository except how the dependency is installed (the
+section below). In your own project it is simply:
+
+```bash
+npm install llmswitch zod
+```
+
+Then copy `lib/switch.ts` and the route handler, and replace the `demo-user` subject with
+the user id your auth already gives you.
+
+## Run it from this repository
 
 The dependency here is the tarball this repository packs, so the example always runs
 against the bytes that would be published. Two steps:
@@ -56,15 +68,3 @@ handles. `OPENAI_BASE_URL` points the provider somewhere other than OpenAI.
 `memoryStores()` is for the demo: config and quota counters live in this process, so
 they are not shared between instances and reset on restart. In production use the
 Postgres stores instead.
-
-## In your own project
-
-Nothing here is special to this repository except the tarball. In your own project the
-dependency is simply:
-
-```bash
-npm install llmswitch zod
-```
-
-Then copy `lib/switch.ts` and the route handler, and replace the `demo-user` subject with
-the user id your auth already gives you.


### PR DESCRIPTION
**What's in it**

`RELEASING.md`: how a version of this package reaches npm. The normal flow is short — dispatch the publish workflow at a reviewed SHA, the audit job rebuilds and hashes the exact bytes, the release environment approval stands between the audit and the publish, and the hash is rechecked in the step that publishes. Most of the document is the one-time bootstrap, since a package that is not on npm yet cannot use a trusted publisher: release candidate under the `next` tag first, published interactively from the audited tarball, then the trusted publisher is configured, the token line leaves the workflow, and `0.1.0` itself is the first publish through the OIDC binding, with provenance. Every command is written out with the registry pinned, and the preconditions include the verification the workflow deliberately does not do.

`publish.yml` gains an `audit_only` input: with it set, the publish job is skipped outright, so a run can produce the audited tarball artifact without leaving anything parked one approval away from the registry. The token reference stays for now — removing it is a step in the runbook, in order, for a reason.

`CONTRIBUTING.md` gains a short section on how changes land: conventional commit messages, rebased coherent commits, never a live key anywhere, and the scan as part of review. The README's security sentence is present tense now that private vulnerability reporting is enabled — that one-line change ships in the tarball, hence the changeset.

The example READMEs also flip their order: the normal `npm install llmswitch zod` path first, the repository-tarball path second, since that is the order a visitor needs them in.

**How to check it**

`npm run check` covers the links and formatting. Read `RELEASING.md` top to bottom as the person who would have to follow it — that is the review that matters here. For the workflow change, dispatch with `audit_only` and confirm the publish job shows as skipped.

**Acceptance**

- [ ] SECURITY.md with private vulnerability reporting enabled on the repo
- [ ] CONTRIBUTING covering commit conventions, key hygiene, fixtures, and the scan
- [ ] README makes no absolute reply-time promises
- [ ] A release procedure exists that a future maintainer can follow without reconstructing decisions
