### PR TITLE
Release verification: conformance against the installed tarball, live provider checks

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -109,10 +109,16 @@ module.exports = {
     },
     {
       name: 'postgres-entry-is-narrow',
-      comment: 'the SQL entry point exposes the packaged migrations, nothing else.',
+      comment:
+        'the SQL entry point exposes the packaged migrations and the usage-statement marker ' +
+        '(spec §6b), nothing else. `sql.ts` imports nothing, so naming the marker there costs ' +
+        'the entry point one string and brings no store code with it.',
       severity: 'error',
       from: { path: '^src/postgres\\.ts$' },
-      to: { path: '^src/', pathNot: '^src/stores/postgres/migrations/' },
+      to: {
+        path: '^src/',
+        pathNot: ['^src/stores/postgres/migrations/', '^src/stores/postgres/sql\\.ts$'],
+      },
     },
     {
       name: 'conformance-entry-is-narrow',

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,31 +101,46 @@ section.
 
 ## Commands
 
-| Command                                                  | What it does                                                         |
-| -------------------------------------------------------- | -------------------------------------------------------------------- |
-| `npm run check`                                          | everything below that does not need a database or the network        |
-| `npm run build`                                          | the dual ESM + CommonJS build into `dist/`                           |
-| `npm test`                                               | unit tests                                                           |
-| `npm run test:coverage`                                  | unit tests with the coverage thresholds applied                      |
-| `npm run test:integration`                               | tests that need `DATABASE_URL`                                       |
-| `npm run depcruise`                                      | module boundaries                                                    |
-| `npm run api:check` / `api:update`                       | compare or record the public type surface                            |
-| `npm run surface:update`                                 | regenerate the spec surfaces after editing `docs/spec.md`            |
-| `node scripts/check-spec-surface.mjs`                    | compare what `dist/` exports with what the spec declares             |
-| `node scripts/check-types-fixtures.mjs --target spec`    | compile the type fixtures against the spec surfaces                  |
-| `node scripts/check-types-fixtures.mjs --target package` | the fixtures the build can satisfy, against it                       |
-| `npm run size`                                           | gzipped size of the root entry against `sizeBudget`                  |
-| `npm run scan`                                           | scan the tree for addresses, unreviewed links and key-shaped strings |
-| `npm run docs:providers`                                 | regenerate `docs/providers.md` from spec §5c                         |
-| `node scripts/build-provider-reference.mjs --check`      | fail if `docs/providers.md` no longer matches spec §5c               |
-| `node scripts/check-docs-links.mjs`                      | every markdown link and anchor resolves                              |
-| `node scripts/verify-quickstart.mjs [tgz]`               | follow the README quickstart in a clean directory (needs network)    |
-| `node scripts/verify-examples.mjs [tgz]`                 | run both `examples/` end to end against that tarball (needs network) |
-| `npm run audit:tarball -- <tgz>`                         | what a packed tarball contains and whether it would run anything     |
-| `npm run test:consumers -- <tgz>`                        | install that tarball into ESM, CommonJS and TypeScript projects      |
+| Command                                                  | What it does                                                                 |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `npm run check`                                          | everything below that does not need a database or the network                |
+| `npm run build`                                          | the dual ESM + CommonJS build into `dist/`                                   |
+| `npm test`                                               | unit tests                                                                   |
+| `npm run test:coverage`                                  | unit tests with the coverage thresholds applied                              |
+| `npm run test:integration`                               | tests that need `DATABASE_URL`                                               |
+| `npm run depcruise`                                      | module boundaries                                                            |
+| `npm run api:check` / `api:update`                       | compare or record the public type surface                                    |
+| `npm run surface:update`                                 | regenerate the spec surfaces after editing `docs/spec.md`                    |
+| `node scripts/check-spec-surface.mjs`                    | compare what `dist/` exports with what the spec declares                     |
+| `node scripts/check-types-fixtures.mjs --target spec`    | compile the type fixtures against the spec surfaces                          |
+| `node scripts/check-types-fixtures.mjs --target package` | the fixtures the build can satisfy, against it                               |
+| `npm run size`                                           | gzipped size of the root entry against `sizeBudget`                          |
+| `npm run scan`                                           | scan the tree for addresses, unreviewed links and key-shaped strings         |
+| `npm run docs:providers`                                 | regenerate `docs/providers.md` from spec §5c                                 |
+| `node scripts/build-provider-reference.mjs --check`      | fail if `docs/providers.md` no longer matches spec §5c                       |
+| `node scripts/check-docs-links.mjs`                      | every markdown link and anchor resolves                                      |
+| `node scripts/verify-quickstart.mjs [tgz]`               | follow the README quickstart in a clean directory (needs network)            |
+| `node scripts/verify-examples.mjs [tgz]`                 | run both `examples/` end to end against that tarball (needs network)         |
+| `npm run audit:tarball -- <tgz>`                         | what a packed tarball contains and whether it would run anything             |
+| `npm run test:consumers -- <tgz>`                        | install that tarball into ESM, CommonJS and TypeScript projects              |
+| `npm run verify:release -- <tgz>`                        | install that tarball and run all three suites against a throwaway PostgreSQL |
+| `npm run live:providers`                                 | call every built-in adapter's real provider (needs your own keys)            |
 
-The last two take a tarball you produced with `npm pack`; they never pack one themselves,
-so what you audit is what you test.
+Everything that takes a tarball takes one you produced with `npm pack`; they never pack one
+themselves, so what you audit is what you test.
+
+`verify:release` needs `DATABASE_URL` pointing at a throwaway database on this machine — it
+creates a schema, writes to it and drops it, so it takes exactly one shape,
+`postgres://user:password@127.0.0.1:port/database`: an address in 127.0.0.0/8, a port written
+out, and no query string or fragment. The header of `scripts/verify-release.mjs` has a
+container to run it against.
+
+`live:providers` spends money and depends on three services being up, so it is never part of
+`npm run check` and never runs in continuous integration. Each provider is called in a process
+of its own holding only that provider's key; use throwaway keys and revoke them afterwards. Run
+`npm run live:providers -- --release <tgz>` to check a packed tarball rather than your working
+tree — that form requires every adapter to run, so a missing key is a failure instead of a
+skip. (The `--` is what stops npm from eating the arguments.)
 
 ## How changes land
 

--- a/api/postgres.d.ts
+++ b/api/postgres.d.ts
@@ -43,5 +43,23 @@ declare function migrationSql(opts?: {
   sha256: string;
 };
 //#endregion
-export { MIGRATIONS, migrationSql };
+//#region src/stores/postgres/sql.d.ts
+/**
+ * Every statement the PostgreSQL stores send, built once per schema.
+ *
+ * Each one is a single command, so the pool runs it in a transaction of its own — which is
+ * what makes a reserve atomic without the store ever pinning a connection (spec §4). Values
+ * are always bound; the only thing spliced into the text is the validated schema identifier.
+ *
+ * @module
+ */
+/**
+ * What marks a statement whose last parameter is the store's clock override.
+ *
+ * Test harnesses that can only reach the store through an adopter-shaped pool recognise the
+ * four usage statements by this prefix and substitute that trailing `null`.
+ */
+declare const USAGE_STORE_MARKER = "/* llmswitch:usage-store */";
+//#endregion
+export { MIGRATIONS, USAGE_STORE_MARKER, migrationSql };
 //# sourceMappingURL=postgres.d.ts.map

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -648,6 +648,10 @@ export declare const MIGRATIONS: ReadonlyArray<{
 // All versions concatenated in order, idempotent, schema-rendered; sha256 covers the
 // exact aggregate sql bytes.
 export declare function migrationSql(opts?: { schema?: string }): { sql: string; sha256: string }
+// The comment every usage-protocol statement begins with. A harness that reaches the packaged
+// store only through an adopter-shaped pool recognises marked statements by it and substitutes
+// their trailing clock parameter (see the conformance note below).
+export declare const USAGE_STORE_MARKER: string
 
 // subpath: llmswitch/conformance
 export interface ConformanceResult { passed: boolean; failures: string[]; skipped: string[] }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "fast-check": "^4.9.0",
         "license-checker-rseidelsohn": "^5.0.1",
         "pg": "^8.23.0",
+        "pg-connection-string": "^2.14.0",
         "prettier": "^3.9.6",
         "publint": "^0.3.24",
         "tsdown": "^0.22.14",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
     "licenses": "sh scripts/check-licenses.sh",
     "audit:tarball": "node scripts/audit-tarball.mjs",
     "test:consumers": "node scripts/test-consumers.mjs",
+    "verify:release": "node scripts/verify-release.mjs",
+    "live:providers": "node scripts/live-check-providers.mjs",
     "scan": "node scripts/scan-denylist.mjs",
     "docs:providers": "node scripts/build-provider-reference.mjs",
     "check": "npm run format:check && npm run lint && npm run typecheck && npm run depcruise && npm run build && node scripts/check-types-fixtures.mjs --target package && node scripts/check-spec-surface.mjs && npm run publint && npm run attw && npm run api:check && npm run size && node scripts/build-provider-reference.mjs --check && node scripts/check-docs-links.mjs && npm run test:coverage"
@@ -105,6 +107,7 @@
     "fast-check": "^4.9.0",
     "license-checker-rseidelsohn": "^5.0.1",
     "pg": "^8.23.0",
+    "pg-connection-string": "^2.14.0",
     "prettier": "^3.9.6",
     "publint": "^0.3.24",
     "tsdown": "^0.22.14",

--- a/scripts/lib/child-environment.mjs
+++ b/scripts/lib/child-environment.mjs
@@ -5,14 +5,23 @@
  * verification run proves, and a filter only removes the names someone thought of.
  */
 
-/** Every name a child may receive. Anything else is a mistake, not something to pass on. */
+/**
+ * Every name a child may receive. Anything else is a mistake, not something to pass on.
+ *
+ * The three provider keys are here so a live check can hand one child exactly one of them:
+ * the allowlist is what makes "only this provider's credential" a property of the code
+ * rather than of whoever remembered to unset the others.
+ */
 const ALLOWED = new Set([
   'PATH',
   'HOME',
   'CI',
   'NEXT_TELEMETRY_DISABLED',
+  'ANTHROPIC_API_KEY',
+  'GEMINI_API_KEY',
   'OPENAI_API_KEY',
   'OPENAI_BASE_URL',
+  'DATABASE_URL',
   'PORT',
   'HOST',
   'EXAMPLE_READY_TOKEN',

--- a/scripts/lib/consumer-project.mjs
+++ b/scripts/lib/consumer-project.mjs
@@ -1,0 +1,345 @@
+/**
+ * The scratch project a release check installs a tarball into, and how a runner is executed
+ * there.
+ *
+ * Projects are always created outside the repository: one under the working tree would find
+ * the repository's own `node_modules` on the way up, and its resolution of `llmswitch` would
+ * stop being evidence about the tarball.
+ *
+ * @module
+ */
+
+import { spawn, spawnSync } from 'node:child_process'
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { basename, join } from 'node:path'
+
+import { buildChildEnvironment } from './child-environment.mjs'
+import { checkInstalledIsTheTarball, unpackReference } from './installed-package.mjs'
+import { createSecretFilter } from './secret-filter.mjs'
+
+const ROOT = join(import.meta.dirname, '..', '..')
+/** The guard every runner needs, copied in beside it so it resolves from the project. */
+const GUARD = join(import.meta.dirname, 'subpath-resolution.mjs')
+
+/** Enough for any plausible run; more than this is a runaway, and a runaway is a failure. */
+const OUTPUT_LIMIT = 16 * 1024 * 1024
+/** An install has to fetch the peer and the driver; beyond this something is wrong. */
+const INSTALL_DEADLINE = 10 * 60_000
+
+/**
+ * The lockfile entry a package at `fromPath` would reach by importing `name`, following Node
+ * resolution up the `node_modules` chain.
+ *
+ * @param lock The parsed `package-lock.json`.
+ * @param fromPath The lockfile key of the package doing the importing, `''` for the root.
+ * @param name The package being imported.
+ * @returns `{ path, entry }` for the entry that would be reached, or `null` when none is.
+ */
+function resolveFromLock(lock, fromPath, name) {
+  const segments = fromPath === '' ? [] : fromPath.split('/')
+  for (let depth = segments.length; depth >= 0; depth -= 1) {
+    const prefix = segments.slice(0, depth).join('/')
+    const path = prefix === '' ? `node_modules/${name}` : `${prefix}/node_modules/${name}`
+    const entry = lock.packages?.[path]
+    if (entry !== undefined) return { path, entry }
+  }
+  return null
+}
+
+/**
+ * The exact version this repository has installed, as an install specifier.
+ *
+ * From the lockfile rather than the manifest's range, so the scratch project installs the
+ * version this repository is developed against instead of whatever the registry serves today.
+ *
+ * @param name The package to look up.
+ * @returns `name@version`.
+ * @throws `Error` when the repository does not declare it or the lockfile does not record it.
+ */
+export function pinnedDevelopmentVersion(name) {
+  const manifest = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'))
+  if (typeof manifest.devDependencies?.[name] !== 'string') {
+    throw new Error(`the repository does not declare a development version of ${name}`)
+  }
+  const found = resolveFromLock(readLockfile(), '', name)
+  if (found === null || typeof found.entry.version !== 'string') {
+    throw new Error(
+      `package-lock.json records no installed version of ${name} — run \`npm install\``,
+    )
+  }
+  return `${name}@${found.entry.version}`
+}
+
+/** The repository's lockfile, parsed. */
+function readLockfile() {
+  return JSON.parse(readFileSync(join(ROOT, 'package-lock.json'), 'utf8'))
+}
+
+/**
+ * Exact versions for the transitive closure of the named packages, as npm `overrides`.
+ *
+ * Pinning the roots alone leaves their own dependencies — `pg-pool`, `pg-protocol` and the
+ * rest — resolving from the registry at install time, so the check would be unreproducible in
+ * the part of it nobody looks at. Overrides pin every nested resolution without adding
+ * anything to the dependency list: an optional dependency stays optional, so a platform that
+ * cannot install `pg-cloudflare` is not made to.
+ *
+ * @param names The packages whose closure to pin, each of which the repository must declare.
+ * @returns A map of package name to exact version, for the project's `overrides` field.
+ * @throws `Error` when a package is not declared or recorded, when a required dependency
+ * cannot be resolved, or when two nodes reach the same name at different versions — that has
+ * no single answer, so it is refused rather than decided quietly.
+ */
+export function pinnedDevelopmentOverrides(names) {
+  const lock = readLockfile()
+  const pinned = new Map()
+  const queue = []
+  for (const name of names) {
+    pinnedDevelopmentVersion(name)
+    const found = resolveFromLock(lock, '', name)
+    if (found !== null) queue.push(found)
+  }
+
+  while (queue.length > 0) {
+    const next = queue.shift()
+    if (next === undefined) break
+    const { path, entry } = next
+    const name = path.slice(path.lastIndexOf('node_modules/') + 'node_modules/'.length)
+    const already = pinned.get(name)
+    if (already !== undefined) {
+      if (already !== entry.version) {
+        throw new Error(
+          `package-lock.json has ${name} at both ${already} and ${String(entry.version)}; ` +
+            'a single override cannot express that',
+        )
+      }
+      continue
+    }
+    pinned.set(name, entry.version)
+
+    // Optional dependencies are followed only when the lockfile has them. Peer dependencies
+    // are left to npm.
+    for (const [dependency, optional] of [
+      [entry.dependencies, false],
+      [entry.optionalDependencies, true],
+    ]) {
+      for (const wanted of Object.keys(dependency ?? {})) {
+        const found = resolveFromLock(lock, path, wanted)
+        if (found === null || typeof found.entry.version !== 'string') {
+          if (optional) continue
+          throw new Error(
+            `package-lock.json does not resolve ${wanted}, required by ${name} — ` +
+              'run `npm install`',
+          )
+        }
+        queue.push(found)
+      }
+    }
+  }
+
+  return Object.fromEntries([...pinned].sort(([a], [b]) => (a < b ? -1 : 1)))
+}
+
+/**
+ * Creates the project, installs the tarball into it, and checks that what landed is the
+ * tarball's own bytes.
+ *
+ * @param opts `workspace` is the throwaway directory everything is created under; `name` names
+ *   the project directory; `tarballPath` is the packed tarball; `packages` are further install
+ *   specifiers, such as the peer dependency and a driver; `overrides` pin nested resolutions;
+ *   `files` are copied into the project root, the runner among them.
+ * @returns The project directory, the `HOME` its children are given, and the tarball's
+ *   reference digest.
+ * @throws `Error` when the install fails or the installed package is not the tarball.
+ */
+export function createConsumerProject(opts) {
+  const directory = join(opts.workspace, opts.name)
+  const home = join(opts.workspace, `${opts.name}-home`)
+  mkdirSync(directory, { recursive: true })
+  mkdirSync(home, { recursive: true })
+
+  // Named for what it is and never `llmswitch`: a project carrying the package's own name
+  // would resolve the subpaths to itself, which is the one thing the guard exists to catch.
+  writeFileSync(
+    join(directory, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: `llmswitch-${opts.name}`,
+        version: '0.0.0',
+        private: true,
+        type: 'module',
+        overrides: opts.overrides ?? {},
+      },
+      null,
+      2,
+    )}\n`,
+  )
+
+  const reference = unpackReference(opts.tarballPath, join(opts.workspace, `${opts.name}-ref`))
+  const install = spawnSync(
+    'npm',
+    ['install', '--ignore-scripts', '--no-save', opts.tarballPath, ...opts.packages],
+    {
+      cwd: directory,
+      env: buildChildEnvironment(home),
+      encoding: 'utf8',
+      maxBuffer: OUTPUT_LIMIT,
+      timeout: INSTALL_DEADLINE,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+  if (install.status !== 0 || install.error !== undefined) {
+    // `error` is set when npm never started, overran the output limit or hit the deadline —
+    // cases that often produce no output at all.
+    const reason = install.error === undefined ? '' : `\n${install.error.message}`
+    throw new Error(
+      `installing the tarball failed${reason}\n${install.stdout ?? ''}${install.stderr ?? ''}`,
+    )
+  }
+
+  const problems = []
+  checkInstalledIsTheTarball(directory, reference, 'the scratch project', problems)
+  if (problems.length > 0) throw new Error(problems.join('\n'))
+
+  for (const file of [GUARD, ...opts.files]) {
+    copyFileSync(file, join(directory, basename(file)))
+  }
+  return { directory, home, reference }
+}
+
+/**
+ * Runs a copied runner from inside the project, under the child environment allowlist.
+ *
+ * `process.execPath` rather than a shell, so the runner is the same Node and no argument is
+ * ever interpreted.
+ *
+ * @param project What `createConsumerProject` returned.
+ * @param opts `script` is the runner's file name in the project; `args` are its arguments;
+ *   `values` are further allowlisted environment names; `timeout` bounds the run; `redact`
+ *   are values to keep out of the child's output.
+ * @returns A promise for whether it exited zero, and a note about how it ended when it did not.
+ */
+export function runInConsumerProject(project, opts) {
+  return runChild({
+    command: process.execPath,
+    args: [join(project.directory, opts.script), ...opts.args],
+    cwd: project.directory,
+    env: buildChildEnvironment(project.home, opts.values),
+    timeout: opts.timeout,
+    redact: opts.redact ?? [],
+  })
+}
+
+/**
+ * Spawns a child, streams its output through this process's, and waits for it to end.
+ *
+ * Asynchronous because `spawnSync` blocks the event loop, which would leave signals sent to
+ * this process undispatched until the child had finished on its own. Output is streamed so a
+ * long or killed run is still watchable, and passes through `createSecretFilter` on the way.
+ *
+ * @param opts `command`, `args`, `cwd`, `env` and `timeout` are the spawn; `redact` are values
+ *   to remove from the child's output on the way through.
+ * @returns A promise for whether it exited zero, and a note about how it ended when it did not.
+ */
+export function runChild(opts) {
+  // Once a signal has been handled, nothing new starts: a caller looping over children would
+  // otherwise spawn the next one while the handler was tidying up for exit.
+  if (stopping) return Promise.resolve({ ok: false, note: 'not started; the run was stopped' })
+  return new Promise((resolve) => {
+    const child = spawn(opts.command, opts.args, {
+      cwd: opts.cwd,
+      env: opts.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    // Piped rather than pumped by hand: `.pipe` propagates backpressure, so a child that
+    // outruns the terminal is paused instead of buffering without limit. `end: false` keeps
+    // this process's own streams open for the next child.
+    child.stdout.pipe(createSecretFilter(opts.redact)).pipe(process.stdout, { end: false })
+    child.stderr.pipe(createSecretFilter(opts.redact)).pipe(process.stderr, { end: false })
+
+    // A child past its deadline has already failed, and may still hold a credential.
+    let expired = false
+    const deadline = setTimeout(() => {
+      expired = true
+      child.kill('SIGKILL')
+    }, opts.timeout)
+
+    let failure
+    child.on('error', (error) => {
+      failure = error
+    })
+
+    const closed = new Promise((done) => {
+      child.on('close', (status, signal) => {
+        clearTimeout(deadline)
+        running.delete(child)
+        done(undefined)
+        if (expired) {
+          resolve({ ok: false, note: `stopped after ${String(opts.timeout)}ms` })
+          return
+        }
+        resolve(describeRun({ error: failure, status, signal }))
+      })
+    })
+    running.set(child, closed)
+  })
+}
+
+/**
+ * The children this process has running, so a signal handler can reach them.
+ *
+ * @type {Map<import('node:child_process').ChildProcess, Promise<undefined>>}
+ */
+const running = new Map()
+
+/** How long a child gets to stop on its own before it is killed outright. */
+const STOP_GRACE = 5_000
+
+/** Set once the run is being stopped, so no further child is spawned. */
+let stopping = false
+
+/**
+ * Kills every running child and waits for it to go.
+ *
+ * A signal sent to this process is not delivered to a child it spawned, so without this a
+ * handler would tidy up and exit while a keyed runner carried on orphaned — still holding a
+ * credential, still writing to a schema that had just been dropped. Every signal handler must
+ * await this before cleaning up anything else.
+ *
+ * @returns A promise that settles once no child is left running.
+ */
+export async function stopRunningChildren() {
+  stopping = true
+  const active = [...running.entries()]
+  if (active.length === 0) return
+  for (const [child] of active) child.kill('SIGTERM')
+
+  const allClosed = Promise.all(active.map(([, closed]) => closed))
+  let grace
+  const expiry = new Promise((wake) => {
+    grace = setTimeout(wake, STOP_GRACE)
+  })
+  await Promise.race([allClosed, expiry])
+  clearTimeout(grace)
+
+  // Whatever ignored SIGTERM does not get to outlive this process.
+  for (const [child] of active) if (running.has(child)) child.kill('SIGKILL')
+  await allClosed
+}
+
+/**
+ * How a spawned check ended. A spawn error or a killing signal means the run proved nothing,
+ * which is a failure rather than a pass.
+ *
+ * @param result The spawn's outcome: `error`, `status` and `signal`.
+ * @returns Whether it exited zero, and a note about how it ended when it did not.
+ */
+export function describeRun(result) {
+  const failure = result.error
+  if (failure !== undefined) return { ok: false, note: failure.message }
+  if (result.signal !== null && result.signal !== undefined) {
+    return { ok: false, note: `stopped by ${result.signal}` }
+  }
+  return { ok: result.status === 0, note: '' }
+}

--- a/scripts/lib/database-target.mjs
+++ b/scripts/lib/database-target.mjs
@@ -1,0 +1,98 @@
+/**
+ * Guard for the `DATABASE_URL` of a destructive release check, which creates schemas,
+ * truncates tables and drops schemas.
+ *
+ * Accepts one shape only: `postgres://user:password@127.0.0.1:port/database`. The target is
+ * resolved with the driver's own parser because libpq-style parameters (`?host=`,
+ * `?hostaddr=`, `?port=`) override the URL authority.
+ *
+ * @module
+ */
+
+import { parse } from 'pg-connection-string'
+
+/** Every octet of a dotted-quad, or `null` when it is not one. */
+function ipv4Octets(host) {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
+  if (match === null) return null
+  const parts = match.slice(1)
+  // A leading zero is ambiguous: some resolvers read it as octal.
+  if (parts.some((part) => part.length > 1 && part.startsWith('0'))) return null
+  const octets = parts.map((part) => Number(part))
+  return octets.every((octet) => octet <= 255) ? octets : null
+}
+
+/**
+ * Whether a host is a literal address in `127.0.0.0/8`.
+ *
+ * Names are never accepted, `localhost` included: this check does not control what a name
+ * resolves to. `::1` is not accepted either — the parser returns it bracketed as `[::1]`, and
+ * the driver passes that to `net.connect` as a name to resolve, which fails with ENOTFOUND.
+ *
+ * @param {string} host The host as the connection string gives it.
+ * @returns {boolean} Whether it is a literal IPv4 loopback address.
+ */
+export function isLoopbackAddress(host) {
+  const octets = ipv4Octets(host)
+  return octets !== null && octets[0] === 127
+}
+
+/** The accepted shape, quoted back by every rejection. */
+const WANTED = 'a bare postgres://user:password@127.0.0.1:port/database'
+
+/**
+ * Why this database may not be used, or `null` when it may.
+ *
+ * @param {string} url The value of `DATABASE_URL`.
+ * @returns {string | null} A sentence naming the problem, or `null`.
+ */
+export function describeUnusableDatabase(url) {
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch {
+    return 'DATABASE_URL is not a URL'
+  }
+
+  let target
+  try {
+    target = parse(url)
+  } catch {
+    return 'DATABASE_URL is not a connection string the driver can read'
+  }
+
+  // `hostaddr` bypasses the host: the driver connects there and keeps the host name only for
+  // authentication.
+  if ((target.hostaddr ?? '') !== '') {
+    return 'DATABASE_URL sets hostaddr, which decides where the connection actually goes'
+  }
+
+  const host = target.host ?? ''
+  if (host === '') return 'DATABASE_URL names no host'
+  if (!isLoopbackAddress(host)) {
+    return (
+      `DATABASE_URL connects to '${host}'. This check creates and drops schemas and truncates ` +
+      'tables, so it only runs against a throwaway database on this machine: an address in ' +
+      '127.0.0.0/8. A host name is refused even when it is spelt localhost, because what a ' +
+      `name resolves to is not this check to decide. Give it ${WANTED}`
+    )
+  }
+
+  // Checked on the raw string: a `#` makes the rest a fragment, so `…/db#?host=evil` parses
+  // to an empty query.
+  if (url.includes('?') || url.includes('#')) {
+    return (
+      "DATABASE_URL contains '?' or '#'. Several query parameters move the connection " +
+      'somewhere else and a fragment hides them from a parser, so a destructive check refuses ' +
+      `both outright: give it ${WANTED}`
+    )
+  }
+
+  if (parsed.port === '') {
+    return (
+      'DATABASE_URL names no port. Without one the port is whatever PGPORT happens to say, ' +
+      `which is not this check to decide either: give it ${WANTED}`
+    )
+  }
+  return null
+}

--- a/scripts/lib/installed-package.mjs
+++ b/scripts/lib/installed-package.mjs
@@ -14,7 +14,7 @@ export function hashFile(file) {
   return createHash('sha256').update(readFileSync(file)).digest('hex')
 }
 
-/** Every path under `dir`, relative and sorted, so two trees hash the same way. */
+/** Every path under `dir`, relative, so two trees hash the same way. Nothing is skipped. */
 function listFiles(dir, prefix, found) {
   for (const entry of readdirSync(join(dir, prefix), { withFileTypes: true })) {
     const path = prefix === '' ? entry.name : `${prefix}/${entry.name}`
@@ -55,21 +55,39 @@ function entryPoints(manifest) {
   return JSON.stringify(found)
 }
 
+/** A tarball is a few hundred kilobytes; anything slower than this is not unpacking. */
+const UNPACK_DEADLINE = 60_000
+
 /**
  * Unpacks the tarball once, so each project can be compared against the bytes that were
  * supposed to be installed rather than against whatever the registry happens to hold.
+ *
+ * @throws `Error` when the tarball ships a `node_modules`. Trees are hashed whole, so one
+ * would be compared against whatever the package manager installed and fail as swapped bytes
+ * rather than as the packaging fault it is.
  */
 export function unpackReference(tarballPath, workspace) {
   const reference = join(workspace, 'reference')
   mkdirSync(reference, { recursive: true })
-  execFileSync('tar', ['-xzf', tarballPath, '-C', reference], { stdio: 'inherit' })
+  // The tarball is untrusted input: bound the unpack and capture its output.
+  execFileSync('tar', ['-xzf', tarballPath, '-C', reference], {
+    stdio: 'pipe',
+    timeout: UNPACK_DEADLINE,
+  })
   const packageRoot = join(reference, 'package')
+  const bundled = listFiles(packageRoot, '', []).find(
+    (path) => path === 'node_modules' || path.startsWith('node_modules/'),
+  )
+  if (bundled !== undefined) {
+    throw new Error(`the tarball ships a node_modules directory (${bundled})`)
+  }
   const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'))
   return {
     name: manifest.name,
     version: manifest.version,
     entryPoints: entryPoints(manifest),
-    distHash: hashTree(join(packageRoot, 'dist')),
+    // Everything the tarball ships, not `dist/` alone.
+    treeHash: hashTree(packageRoot),
   }
 }
 
@@ -93,8 +111,7 @@ export function checkInstalledIsTheTarball(project, reference, name, problems) {
   if (entryPoints(manifest) !== reference.entryPoints) {
     problems.push(`${name}: the installed package points at different entry points`)
   }
-  const dist = join(installed, 'dist')
-  if (!existsSync(dist) || hashTree(dist) !== reference.distHash) {
-    problems.push(`${name}: the installed dist/ is not the one in the tarball`)
+  if (hashTree(installed) !== reference.treeHash) {
+    problems.push(`${name}: the installed files are not the ones in the tarball`)
   }
 }

--- a/scripts/lib/secret-filter.mjs
+++ b/scripts/lib/secret-filter.mjs
@@ -1,0 +1,67 @@
+/**
+ * Removes values a parent injected into a child from that child's output as it streams through.
+ *
+ * Defence in depth: runners redact what they print themselves, and this catches what they
+ * never see, such as a message from a dependency. A tail of one character less than the
+ * longest secret is held back between chunks so a secret split across two of them still
+ * matches. It is a Transform, so piping it carries backpressure end to end.
+ *
+ * @module
+ */
+
+import { StringDecoder } from 'node:string_decoder'
+import { Transform } from 'node:stream'
+
+/** Fixed-length replacement, so it says nothing about what it replaced. */
+const REPLACEMENT = '[redacted]'
+
+/** Every occurrence of every secret, replaced. */
+function redactAll(text, secrets) {
+  let result = text
+  for (const secret of secrets) result = result.split(secret).join(REPLACEMENT)
+  return result
+}
+
+/**
+ * Where to cut `text` so `index` onwards is held back, never between a surrogate pair.
+ *
+ * A pair split across two writes is decoded as two lone surrogates and reaches the terminal as
+ * replacement characters, so an emoji next to the boundary would be corrupted.
+ */
+function cutBefore(text, index) {
+  if (index <= 0) return 0
+  const last = text.charCodeAt(index - 1)
+  return last >= 0xd800 && last <= 0xdbff ? index - 1 : index
+}
+
+/**
+ * A Transform that redacts secrets out of the text flowing through it.
+ *
+ * @param {string[]} secrets The values to remove. Empty strings are ignored.
+ * @returns {Transform} A stream to pipe a child's output through.
+ */
+export function createSecretFilter(secrets) {
+  const wanted = secrets.filter((secret) => secret.length > 0)
+  // A decoder, so a character split across two chunks survives intact.
+  const decoder = new StringDecoder('utf8')
+  // Any shorter and the tail of a split secret could be emitted before the rest arrived.
+  const held = wanted.length === 0 ? 0 : Math.max(...wanted.map((s) => s.length)) - 1
+  let pending = ''
+
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      const cleaned = redactAll(pending + decoder.write(chunk), wanted)
+      const cut = cutBefore(cleaned, Math.max(cleaned.length - held, 0))
+      const emit = cleaned.slice(0, cut)
+      pending = cleaned.slice(cut)
+      if (emit === '') callback()
+      else callback(null, emit)
+    },
+    flush(callback) {
+      const rest = redactAll(pending + decoder.end(), wanted)
+      pending = ''
+      if (rest === '') callback()
+      else callback(null, rest)
+    },
+  })
+}

--- a/scripts/lib/subpath-resolution.mjs
+++ b/scripts/lib/subpath-resolution.mjs
@@ -1,0 +1,92 @@
+/**
+ * Where the published subpaths actually resolve to, asked from inside the project that
+ * installed the package.
+ *
+ * A checkout of this package resolves its own name: the manifest's `name` together with its
+ * `exports` makes `llmswitch/postgres` reach `dist/` from any file inside the working tree.
+ * A verification runner left in the repository would therefore import the tree it is meant to
+ * be judging and report a pass with the tarball never involved. So the runner and this module
+ * are copied into the scratch project, next to the `node_modules` the tarball was installed
+ * into, and every subpath is resolved from there before anything is imported.
+ *
+ * This module must sit in that project's root directory: the project is the directory this
+ * file is in, and resolution is asked for from this file's own location.
+ *
+ * @module
+ */
+
+import { existsSync, readFileSync, realpathSync } from 'node:fs'
+import { dirname, join, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** The directory this file was copied into, which is the project that did the installing. */
+function projectDirectory() {
+  return dirname(fileURLToPath(import.meta.url))
+}
+
+/**
+ * Every specifier the installed package publishes, read off its own `exports` map rather than
+ * from a list here, so an added or renamed entry point is checked without being remembered.
+ *
+ * @param manifest The installed package's `package.json`, already parsed.
+ * @returns The specifiers to resolve, in manifest order.
+ * @throws `Error` when the manifest publishes nothing, or publishes a pattern that cannot be
+ * resolved as a specifier on its own.
+ */
+export function publishedSubpaths(manifest) {
+  const name = manifest.name
+  const map = manifest.exports
+  if (typeof name !== 'string' || typeof map !== 'object' || map === null) {
+    throw new Error('the installed package declares no name or no exports map')
+  }
+  const subpaths = []
+  for (const key of Object.keys(map)) {
+    if (key === '.') {
+      subpaths.push(name)
+      continue
+    }
+    if (!key.startsWith('./') || key.includes('*')) {
+      throw new Error(`the installed package exports '${key}', which this check cannot resolve`)
+    }
+    subpaths.push(`${name}${key.slice(1)}`)
+  }
+  if (subpaths.length === 0) throw new Error('the installed package publishes no entry points')
+  return subpaths
+}
+
+/**
+ * Confirms every published subpath resolves inside this project's own copy of the package.
+ *
+ * @returns Each subpath with the file it resolved to, in the order they were asked for.
+ * @throws `Error` when the package is not installed here, when its manifest publishes nothing
+ * this check can resolve, when a subpath does not resolve at all, or when one resolves to a
+ * file anywhere outside `node_modules/llmswitch`.
+ */
+export function assertInstalledPackageResolves() {
+  const installed = join(projectDirectory(), 'node_modules', 'llmswitch')
+  if (!existsSync(installed)) {
+    throw new Error(`the package is not installed at ${installed}`)
+  }
+  const manifest = JSON.parse(readFileSync(join(installed, 'package.json'), 'utf8'))
+  // Resolved paths come back with symlinks followed — a package manager that links its store
+  // would otherwise compare a link against its target and reject an honest install.
+  const root = realpathSync(installed)
+  const resolved = []
+  for (const subpath of publishedSubpaths(manifest)) {
+    let url
+    try {
+      url = import.meta.resolve(subpath)
+    } catch {
+      throw new Error(`'${subpath}' does not resolve from ${projectDirectory()}`)
+    }
+    if (!url.startsWith('file:')) {
+      throw new Error(`'${subpath}' resolves to ${url}, which is not a file`)
+    }
+    const file = realpathSync(fileURLToPath(url))
+    if (file !== root && !file.startsWith(root + sep)) {
+      throw new Error(`'${subpath}' resolves to ${file}, which is not under ${root}`)
+    }
+    resolved.push({ subpath, file })
+  }
+  return resolved
+}

--- a/scripts/live-check-providers.mjs
+++ b/scripts/live-check-providers.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * Calls every built-in adapter against its real provider, once with a plain prompt and once
+ * asking for a JSON object, and checks that what comes back is what the package documents.
+ *
+ * Recorded fixtures prove the adapters read the shapes that were recorded; only this proves
+ * the providers still send them. Manual by design: it spends money and needs keys, so it is
+ * never wired into CI.
+ *
+ * Key custody is why this file and the runner are separate. Each provider is checked in a
+ * child process carrying exactly one credential, built from the shared allowlist; no key is
+ * ever an argument, and the child's output is filtered on the way through.
+ *
+ * Usage: node scripts/live-check-providers.mjs [--release <path-to-tgz>]
+ *   With `--release` the checks run from a throwaway project that installed that tarball, the
+ *   OpenAI-compatible check is pinned to the official endpoint, and every adapter must run: a
+ *   missing key is a failure. Without it they run against the working tree's current build and
+ *   an adapter whose key is absent is skipped with a notice, which is for local development
+ *   and is not evidence about a release.
+ * Exit codes: 0 every adapter that had to run did and passed, 1 one did not, 2 wrong usage.
+ */
+
+import { mkdtempSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { isAbsolute, join, resolve } from 'node:path'
+
+import { buildChildEnvironment } from './lib/child-environment.mjs'
+import {
+  createConsumerProject,
+  pinnedDevelopmentOverrides,
+  pinnedDevelopmentVersion,
+  runChild,
+  runInConsumerProject,
+  stopRunningChildren,
+} from './lib/consumer-project.mjs'
+
+const ROOT = join(import.meta.dirname, '..')
+const RUNNER = join(import.meta.dirname, 'runners', 'live-check.mjs')
+/** The runner imports this, so it is copied into the scratch project beside it. */
+const TOLERANCE = join(import.meta.dirname, 'runners', 'json-tolerance.mjs')
+const USAGE = 'usage: live-check-providers.mjs [--release <path-to-tgz>]\n'
+
+/**
+ * The adapters, each with the credential it needs and the model it is checked on.
+ *
+ * The models are the smallest each provider offers, and the runner asks for a handful of
+ * tokens: a full run should cost a fraction of a cent. Change them here when a provider
+ * retires one — nowhere else names a model.
+ */
+const PROVIDERS = [
+  { name: 'anthropic', key: 'ANTHROPIC_API_KEY', model: 'claude-haiku-4-5' },
+  { name: 'openai-compatible', key: 'OPENAI_API_KEY', model: 'gpt-4.1-nano' },
+  { name: 'gemini', key: 'GEMINI_API_KEY', model: 'gemini-2.5-flash-lite' },
+]
+
+/** Two calls to a live provider; anything beyond this is a hang, not a slow model. */
+const CHECK_DEADLINE = 2 * 60_000
+
+/** The one adapter whose endpoint may be pointed elsewhere, and the name that does it. */
+const ENDPOINT_OVERRIDE = { provider: 'openai-compatible', name: 'OPENAI_BASE_URL' }
+
+/** The tarball to check against, `null` for the working tree, or a usage failure. */
+function readArguments(argv) {
+  if (argv.length === 0) return { tarball: null, problem: null }
+  if (argv.length !== 2 || argv[0] !== '--release') return { tarball: null, problem: USAGE }
+  const named = argv[1]
+  const tarball = isAbsolute(named) ? named : resolve(named)
+  let file = null
+  try {
+    file = statSync(tarball)
+  } catch {
+    // Reported below, together with the case of a path that is not a file at all.
+  }
+  if (file === null || !file.isFile()) {
+    return { tarball: null, problem: `'${named}' is not an existing tarball file\n${USAGE}` }
+  }
+  return { tarball, problem: null }
+}
+
+/**
+ * The environment names one adapter's child is given: exactly one credential, and the endpoint
+ * override only for the adapter that can use it.
+ */
+function childValues(descriptor) {
+  const values = { [descriptor.key]: process.env[descriptor.key] }
+  if (descriptor.name === ENDPOINT_OVERRIDE.provider) {
+    values[ENDPOINT_OVERRIDE.name] = process.env[ENDPOINT_OVERRIDE.name]
+  }
+  return values
+}
+
+/** Runs one adapter's check against the working tree's build, from the repository. */
+function checkFromWorkingTree(descriptor, home) {
+  return runChild({
+    command: process.execPath,
+    args: [RUNNER, descriptor.name, descriptor.model],
+    cwd: ROOT,
+    env: buildChildEnvironment(home, childValues(descriptor)),
+    timeout: CHECK_DEADLINE,
+    redact: secretsFor(descriptor),
+  })
+}
+
+/** The values this process put in the child's environment that must not appear in its output. */
+function secretsFor(descriptor) {
+  return [process.env[descriptor.key] ?? ''].filter((value) => value !== '')
+}
+
+async function main() {
+  const { tarball, problem: usageProblem } = readArguments(process.argv.slice(2))
+  if (usageProblem !== null) {
+    process.stderr.write(usageProblem)
+    return 2
+  }
+  const release = tarball !== null
+
+  // The adapter's default endpoint is part of what a release check verifies, so an override is
+  // refused rather than ignored.
+  if (release && (process.env.OPENAI_BASE_URL ?? '') !== '') {
+    process.stderr.write(
+      'OPENAI_BASE_URL is set. A release check calls the official endpoint; unset it and run ' +
+        'again.\n',
+    )
+    return 2
+  }
+
+  const workspace = mkdtempSync(join(tmpdir(), 'llmswitch-live-check-'))
+  removeOnSignal(workspace)
+  const problems = []
+  let ran = 0
+  try {
+    const project = release
+      ? createConsumerProject({
+          workspace,
+          name: 'consumer',
+          tarballPath: tarball,
+          packages: [pinnedDevelopmentVersion('zod')],
+          overrides: pinnedDevelopmentOverrides(['zod']),
+          files: [RUNNER, TOLERANCE],
+        })
+      : null
+
+    for (const descriptor of PROVIDERS) {
+      const present = (process.env[descriptor.key] ?? '') !== ''
+      if (!present) {
+        if (release) {
+          problems.push(`${descriptor.name}: ${descriptor.key} is not set`)
+          continue
+        }
+        process.stdout.write(`${descriptor.name}: skipped, ${descriptor.key} is not set\n`)
+        continue
+      }
+
+      ran += 1
+      const check =
+        project === null
+          ? await checkFromWorkingTree(descriptor, workspace)
+          : await runInConsumerProject(project, {
+              script: 'live-check.mjs',
+              args: [descriptor.name, descriptor.model, '--release'],
+              values: { [descriptor.key]: process.env[descriptor.key] },
+              timeout: CHECK_DEADLINE,
+              redact: secretsFor(descriptor),
+            })
+      if (check.note !== '') process.stderr.write(`${descriptor.name}: ${check.note}\n`)
+      if (!check.ok) problems.push(`${descriptor.name}: the check failed`)
+    }
+  } catch (error) {
+    problems.push(error instanceof Error ? error.message : 'unknown error')
+  } finally {
+    rmSync(workspace, { recursive: true, force: true })
+  }
+
+  for (const problem of problems) process.stdout.write(`${problem}\n`)
+  const total = String(PROVIDERS.length)
+  if (problems.length > 0) {
+    process.stdout.write(
+      `${String(ran)} of ${total} adapter(s) ran, ${String(problems.length)} problem(s)\n`,
+    )
+    return 1
+  }
+  // Outside release mode the count is the verdict: "none failed" is equally true of a run that
+  // called nothing.
+  process.stdout.write(
+    release
+      ? `all ${total} adapter(s) ran against their providers and passed\n`
+      : `${String(ran)} of ${total} adapter(s) ran and passed; ${String(PROVIDERS.length - ran)} ` +
+          'had no key and were skipped, so this run is not evidence about a release\n',
+  )
+  return 0
+}
+
+/** Kills the child, removes the workspace and stops when this process is interrupted. */
+function removeOnSignal(workspace) {
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => {
+      process.stderr.write(`\nstopped by ${signal}; cleaning up\n`)
+      // The child first: a signal to this process is not delivered to it, so a runner holding
+      // a credential would otherwise carry on orphaned.
+      void stopRunningChildren().finally(() => {
+        rmSync(workspace, { recursive: true, force: true })
+        // A handler replaces the default disposition, so the exit must be explicit.
+        process.exit(1)
+      })
+    })
+  }
+}
+
+try {
+  process.exitCode = await main()
+} catch (error) {
+  process.stderr.write(
+    `the live check could not run: ${error instanceof Error ? error.message : 'unknown'}\n`,
+  )
+  process.exitCode = 1
+}

--- a/scripts/runners/json-tolerance.mjs
+++ b/scripts/runners/json-tolerance.mjs
@@ -1,0 +1,100 @@
+/**
+ * Reads a JSON object out of what a model returned for the live check's JSON call.
+ *
+ * On adapters with no native JSON mode the call is a prompt, so the object may arrive in a
+ * code fence or wrapped in prose; both are tolerated. An empty object is not — it parses and
+ * proves nothing.
+ *
+ * Copied into the scratch project alongside `live-check.mjs`, and kept separate from it so it
+ * can be unit-tested without the runner needing to know whether it was run or imported.
+ *
+ * @module
+ */
+
+/**
+ * The first balanced `{…}` in a string, or `null` when there is none. Braces inside string
+ * literals are skipped. What it finds is handed to `JSON.parse` to be judged.
+ */
+function firstBracedSpan(text) {
+  let depth = 0
+  let start = -1
+  let inString = false
+  let escaped = false
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index]
+    if (inString) {
+      if (escaped) escaped = false
+      else if (character === '\\') escaped = true
+      else if (character === '"') inString = false
+      continue
+    }
+    if (character === '"') inString = true
+    else if (character === '{') {
+      if (depth === 0) start = index
+      depth += 1
+    } else if (character === '}') {
+      depth -= 1
+      if (depth === 0) return text.slice(start, index + 1)
+      if (depth < 0) return null
+    }
+  }
+  return null
+}
+
+/** Readings to try when the text as a whole is not JSON: a fenced body, then one object. */
+function fallbackCandidates(trimmed) {
+  const candidates = []
+  const fenced = /```[A-Za-z]*\n([\s\S]*?)```/.exec(trimmed)?.[1]
+  if (fenced !== undefined) candidates.push(fenced.trim())
+  const braced = firstBracedSpan(trimmed)
+  if (braced !== null) candidates.push(braced)
+  return candidates
+}
+
+/** The parsed value wrapped in an object, or `null` when the text is not JSON. */
+function parseJson(text) {
+  try {
+    return { value: JSON.parse(text) }
+  } catch {
+    return null
+  }
+}
+
+/** Why a parsed value is not the non-empty object the call asked for, or `null`. */
+function describeValue(value) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return 'the JSON call: the output parsed, but not to a JSON object'
+  }
+  if (Object.keys(value).length === 0) {
+    return 'the JSON call: the output was an empty object, which proves nothing'
+  }
+  return null
+}
+
+/**
+ * Adds a problem unless the output is a non-empty JSON object at the top level.
+ *
+ * @param {string} text What the provider returned.
+ * @param {string[]} problems The run's problem list, appended to in place.
+ */
+export function checkJsonShape(text, problems) {
+  const trimmed = text.trim()
+
+  // Valid JSON is judged as that value alone: falling through would let `[{"ok":true}]` pass
+  // on the object nested inside it.
+  const literal = parseJson(trimmed)
+  if (literal !== null) {
+    const problem = describeValue(literal.value)
+    if (problem !== null) problems.push(problem)
+    return
+  }
+
+  for (const candidate of fallbackCandidates(trimmed)) {
+    const found = parseJson(candidate)
+    if (found === null) continue
+    const problem = describeValue(found.value)
+    if (problem !== null) problems.push(problem)
+    return
+  }
+  problems.push('the JSON call: the output did not parse as JSON, in a code fence or otherwise')
+}

--- a/scripts/runners/live-check.mjs
+++ b/scripts/runners/live-check.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * One provider's live check, in a process that holds one provider's credential.
+ *
+ * Two calls: a plain one and one asking for a JSON object. Both have to come back complete,
+ * with text, and with usage the package was able to normalize — a provider whose wire shape
+ * has moved under the adapter shows up here as a null usage or a missing field, which is the
+ * whole reason this check exists.
+ *
+ * Nothing it prints carries a credential, a prompt, a request or a response body. The key is
+ * read from the environment, never from an argument, and every line goes out through a
+ * redactor, so a value that reached a message by some path nobody thought of still does not
+ * reach the terminal.
+ *
+ * How much untidiness is tolerated in a prompted JSON answer is decided by
+ * `./json-tolerance.mjs`, which is copied into the scratch project alongside this file.
+ *
+ * Usage: node live-check.mjs <provider> <model> [--release]
+ * With `--release` the package is required to come from the project this runner sits in.
+ * Exit codes: 0 both calls were as documented, 1 one was not, 2 wrong usage.
+ *
+ * @module
+ */
+
+import { checkJsonShape } from './json-tolerance.mjs'
+
+/** Which environment name each adapter's credential arrives under. */
+const KEYS = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+  'openai-compatible': 'OPENAI_API_KEY',
+}
+
+/** Small enough that a run costs almost nothing, large enough for a one-line answer. */
+const MAX_OUTPUT_TOKENS = 64
+/** The two prompts, kept to a sentence each for the same reason. */
+const PLAIN_PROMPT = 'Reply with the single word: ready'
+const JSON_PROMPT = 'Reply with only this JSON object and nothing else: {"ok": true}'
+
+/** A credential can only be printed if it is in the string; this makes sure it is not. */
+function redactor(secret) {
+  return (text) => (secret === '' ? text : text.split(secret).join('<redacted>'))
+}
+
+/**
+ * A failure in terms of what it was, never what it said.
+ *
+ * A `ProviderError` is safe to name: the package builds it without prompt, output, or
+ * anything the provider sent back. Nothing else is, so nothing else is quoted.
+ */
+function describeFailure(error, ProviderError) {
+  if (ProviderError.is(error)) return `ProviderError(${error.kind})`
+  if (error instanceof Error) return `${error.name} (message withheld)`
+  return `a thrown ${typeof error}`
+}
+
+/** Everything a completed call has to be, whichever adapter produced it. */
+function checkResponse(label, response, problems) {
+  if (response.kind !== 'complete') {
+    problems.push(`${label}: kind was '${response.kind}', not 'complete'`)
+    return
+  }
+  if (typeof response.text !== 'string' || response.text.trim() === '') {
+    problems.push(`${label}: the output text was empty`)
+  }
+  const { usage } = response
+  if (usage === null) {
+    problems.push(`${label}: usage was null, so the adapter could not read the counters`)
+    return
+  }
+  for (const field of ['inputTokens', 'outputTokens']) {
+    const value = usage[field]
+    if (!Number.isSafeInteger(value) || value < 0) {
+      problems.push(`${label}: ${field} was not a non-negative whole number`)
+    }
+  }
+}
+
+/** Cancels the call in flight when this process is asked to stop. */
+function abortOnSignal(controller) {
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => {
+      process.stderr.write(`the live check was stopped by ${signal}\n`)
+      controller.abort()
+      // A handler replaces the default disposition, so the exit must be explicit.
+      process.exit(1)
+    })
+  }
+}
+
+async function main() {
+  const argv = process.argv.slice(2)
+  const release = argv.includes('--release')
+  const [provider, model] = argv.filter((argument) => argument !== '--release')
+  if (provider === undefined || model === undefined || !Object.hasOwn(KEYS, provider)) {
+    process.stderr.write('usage: live-check.mjs <provider> <model> [--release]\n')
+    return 2
+  }
+
+  if (release) {
+    const { assertInstalledPackageResolves } = await import('./subpath-resolution.mjs')
+    try {
+      for (const { subpath, file } of assertInstalledPackageResolves()) {
+        process.stdout.write(`resolved ${subpath} -> ${file}\n`)
+      }
+    } catch (error) {
+      // Said in full: the guard reports file paths and nothing else, and a run that imported
+      // the wrong package is worth naming precisely.
+      process.stderr.write(`${error instanceof Error ? error.message : 'unknown failure'}\n`)
+      return 1
+    }
+  }
+  const llmswitch = await import('llmswitch')
+  const { ProviderError } = llmswitch
+
+  const keyName = KEYS[provider]
+  const apiKey = process.env[keyName] ?? ''
+  const redact = redactor(apiKey)
+  if (apiKey === '') {
+    process.stderr.write(`${keyName} is not set in this process\n`)
+    return 1
+  }
+
+  const build = {
+    anthropic: () => llmswitch.anthropic({ apiKey: () => Promise.resolve(apiKey) }),
+    gemini: () => llmswitch.gemini({ apiKey: () => Promise.resolve(apiKey) }),
+    'openai-compatible': () => {
+      const options = { apiKey: () => Promise.resolve(apiKey) }
+      // In release mode the parent refuses to pass an override at all, so this is the
+      // adapter's own default endpoint; locally an override may travel and is honoured.
+      const baseUrl = process.env.OPENAI_BASE_URL ?? ''
+      if (!release && baseUrl !== '') options.baseUrl = baseUrl
+      return llmswitch.openaiCompatible(options)
+    },
+  }
+  const prepared = await build[provider]().prepare()
+
+  const problems = []
+  // One controller for the whole run, so an interrupt reaches the call in flight.
+  const inFlight = new AbortController()
+  abortOnSignal(inFlight)
+  const request = (prompt, responseFormat) => ({
+    prompt,
+    model,
+    responseFormat,
+    maxOutputTokens: MAX_OUTPUT_TOKENS,
+    temperature: 0,
+    signal: inFlight.signal,
+  })
+
+  try {
+    const plain = await prepared.complete(request(PLAIN_PROMPT, { type: 'text' }))
+    checkResponse('the plain call', plain, problems)
+  } catch (error) {
+    problems.push(`the plain call: ${describeFailure(error, ProviderError)}`)
+  }
+
+  try {
+    const json = await prepared.complete(
+      request(JSON_PROMPT, { type: 'json', topLevel: 'object' }),
+    )
+    checkResponse('the JSON call', json, problems)
+    if (json.kind === 'complete') checkJsonShape(json.text, problems)
+  } catch (error) {
+    problems.push(`the JSON call: ${describeFailure(error, ProviderError)}`)
+  }
+
+  for (const problem of problems) process.stdout.write(redact(`${problem}\n`))
+  if (problems.length === 0) {
+    process.stdout.write(`${provider}: both calls completed with normalized usage\n`)
+  }
+  return problems.length === 0 ? 0 : 1
+}
+
+// Never gate this on an entry-point check: `import.meta.filename` is realpath-resolved and
+// `process.argv[1]` is not, so under a symlinked TMPDIR the runner would silently do nothing.
+try {
+  process.exitCode = await main()
+} catch (error) {
+  // No adapter to ask here, so only the kind of failure is reported.
+  process.stderr.write(
+    `the live check could not run: ${error instanceof Error ? error.name : 'unknown failure'}\n`,
+  )
+  process.exitCode = 1
+}

--- a/scripts/runners/release-conformance.mjs
+++ b/scripts/runners/release-conformance.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+/**
+ * The release check itself, executed from inside the scratch project that installed the
+ * tarball. It is copied there rather than run from the repository, so what it resolves is the
+ * installed package (see `subpath-resolution`).
+ *
+ * In order: confirm every published subpath resolves to the installed package, apply the
+ * packaged migration to the given schema, run the two store conformance suites against the
+ * installed PostgreSQL stores, and run the provider suite against a fixture backend served
+ * from this process.
+ *
+ * The schema is named by the caller, which also drops it — this process can be killed and so
+ * cannot be relied on to clean up after itself.
+ *
+ * Usage: node release-conformance.mjs <schema>
+ * Needs `DATABASE_URL`. Exit codes: 0 everything passed, 1 something did not.
+ *
+ * @module
+ */
+
+import { createServer } from 'node:http'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import pg from 'pg'
+
+import { assertInstalledPackageResolves } from './subpath-resolution.mjs'
+
+/** The template the fixture backend answers from, copied in beside this runner. */
+const TEMPLATE = join(import.meta.dirname, 'openai-chat-completion.json')
+/** Not a key and not shaped like one: the fixture only checks that it arrives verbatim. */
+const FIXTURE_KEY = 'fixture-credential-for-the-release-check'
+
+/* ------------------------------------------------------------------ the guard ---- */
+
+/**
+ * Everything the three subpaths export, filled in once the guard has said where they came
+ * from. Nothing below runs before that, so a runner that ended up beside the wrong package
+ * reports which file it would have imported instead of a stack from importing it.
+ */
+let installed = null
+
+/** Imports all three subpaths. Only ever called after `assertInstalledPackageResolves`. */
+async function importInstalledPackage() {
+  return {
+    package: await import('llmswitch'),
+    postgres: await import('llmswitch/postgres'),
+    conformance: await import('llmswitch/conformance'),
+  }
+}
+
+/* ---------------------------------------------------------------- the fixture ---- */
+
+/**
+ * The provider backend, driven scenario by scenario.
+ *
+ * The provider suite puts the backend into a named condition and then dispatches; this server
+ * is that backend. Every classification row the built-in adapter documents is covered here, so
+ * the suite reports nothing as unverified — a release must not ship on a partial answer.
+ */
+function renderScenario(template, scenario) {
+  const body = structuredClone(template)
+  switch (scenario) {
+    case 'success':
+      body.choices[0].message.content = JSON.stringify({ ok: true })
+      return { status: 200, body }
+    case 'truncated':
+      body.choices[0].message.content = 'partial'
+      body.choices[0].finish_reason = 'length'
+      return { status: 200, body }
+    case 'refused':
+      body.choices[0].message.refusal = 'the backend declined this request'
+      return { status: 200, body }
+    case 'malformed_response':
+      body.choices[0].finish_reason = 'a reason no adapter maps'
+      return { status: 200, body }
+    case 'auth':
+      return { status: 401, body: { error: { message: 'unauthorized' } } }
+    case 'rate_limit':
+      return { status: 429, body: { error: { message: 'slow down' } } }
+    case 'model_not_found':
+      return { status: 404, body: { error: { message: 'no such model' } } }
+    case 'invalid_request':
+      return { status: 422, body: { error: { message: 'unprocessable' } } }
+    case 'transient':
+      return { status: 503, body: { error: { message: 'unavailable' } } }
+    default:
+      return { status: 500, body: { error: { message: `unknown scenario ${scenario}` } } }
+  }
+}
+
+/** Why a call is not one this check expects, or `null` when it is. */
+function describeUnexpected(request, rawBody, model) {
+  if (request.method !== 'POST') return `method ${String(request.method)}`
+  if (request.url !== '/v1/chat/completions') return `path ${String(request.url)}`
+  if (request.headers.authorization !== `Bearer ${FIXTURE_KEY}`) return 'credential'
+  let body
+  try {
+    body = JSON.parse(rawBody)
+  } catch {
+    return 'body is not JSON'
+  }
+  if (body?.model !== model) return `model ${String(body?.model)}`
+  return null
+}
+
+function startFixture(state) {
+  return new Promise((ready, failed) => {
+    const server = createServer((request, response) => {
+      const chunks = []
+      request.on('data', (chunk) => chunks.push(chunk))
+      request.on('end', () => {
+        const problem = describeUnexpected(
+          request,
+          Buffer.concat(chunks).toString('utf8'),
+          state.model,
+        )
+        if (problem !== null) state.unexpected.push(problem)
+        const answer = renderScenario(state.template, state.scenario)
+        response.writeHead(answer.status, { 'content-type': 'application/json' })
+        response.end(JSON.stringify(answer.body))
+      })
+    })
+    server.on('error', failed)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      ready({
+        server,
+        port: typeof address === 'object' && address !== null ? address.port : 0,
+      })
+    })
+  })
+}
+
+/* ------------------------------------------------------------------ the suites ---- */
+
+/** The control statements the suites need, which no store method sends. */
+function controlStatements(schema) {
+  return {
+    truncate: `TRUNCATE "${schema}".usage_counters, "${schema}".usage_reservations,
+"${schema}".usage_settlements, "${schema}".operation_routes`,
+    readSettled: `SELECT reservation_id, operation, subject_id, to_char(day, 'YYYY-MM-DD') AS day,
+       outcome, attempts FROM "${schema}".usage_settlements WHERE reservation_id = $1`,
+    seedRaw: `INSERT INTO "${schema}".operation_routes (operation, route) VALUES ($1, $2::jsonb)
+ON CONFLICT (operation) DO UPDATE SET route = EXCLUDED.route`,
+  }
+}
+
+/**
+ * Runs both store suites against the installed stores, reached only through the public
+ * factory and a pool of this check's own — the shape an adopter has.
+ */
+async function runStoreSuites(pool, schema) {
+  const controls = controlStatements(schema)
+  let pinned = null
+  const drifted = []
+  // From the installed package, not a copy: a copy would keep matching after the package had
+  // changed it.
+  const marker = installed.postgres.USAGE_STORE_MARKER
+  // Strict: an unrecognised marker is reported rather than silently running the usage suite
+  // against the database's own clock.
+  const wrapper = {
+    query(sql, params) {
+      if (!sql.startsWith(marker)) return pool.query(sql, params)
+      const supplied = [...(params ?? [])]
+      if (supplied.length === 0) drifted.push('a usage statement carried no parameters')
+      if (supplied.at(-1) !== null) drifted.push('a usage statement did not end with null')
+      supplied[supplied.length - 1] = pinned?.toISOString() ?? null
+      return pool.query(sql, supplied)
+    },
+  }
+  const stores = installed.package.postgresStores({ pool: wrapper, schema })
+
+  const usage = await installed.conformance.runUsageStoreConformance({
+    create: () =>
+      Promise.resolve({
+        store: stores.usage,
+        setTime: (date) => {
+          pinned = date
+          return Promise.resolve()
+        },
+        reset: async () => {
+          pinned = null
+          await pool.query(controls.truncate)
+        },
+        readSettled: async (reservationId) => {
+          const { rows } = await pool.query(controls.readSettled, [reservationId])
+          const [row] = rows
+          return row === undefined
+            ? null
+            : {
+                reservation: {
+                  reservationId: row.reservation_id,
+                  key: { operation: row.operation, subjectId: row.subject_id },
+                  day: row.day,
+                },
+                outcome: row.outcome,
+                attempts: row.attempts,
+              }
+        },
+      }),
+  })
+
+  const config = await installed.conformance.runConfigStoreConformance({
+    create: () =>
+      Promise.resolve({
+        store: stores.config,
+        reset: () => pool.query(controls.truncate).then(() => undefined),
+        seedRaw: (operation, value) =>
+          pool
+            .query(controls.seedRaw, [operation, JSON.stringify(value)])
+            .then(() => undefined),
+      }),
+  })
+
+  return { usage, config, drifted }
+}
+
+/** Runs the provider suite against the fixture backend, every scenario supplied. */
+async function runProviderSuite(state, port) {
+  const provider = installed.package.openaiCompatible({
+    apiKey: () => Promise.resolve(FIXTURE_KEY),
+    // Concatenated, not interpolated: an interpolation mid-link leaves the denylist scanner a
+    // token it cannot parse.
+    baseUrl: 'http://127.0.0.1:' + String(port) + '/v1',
+    // The fixture answers JSON on the success path, so the adapter is held to the native duty
+    // rather than skipped as unverified.
+    jsonMode: 'native',
+  })
+  const enter = (scenario) => () => {
+    state.scenario = scenario
+    return Promise.resolve()
+  }
+  return installed.conformance.runProviderConformance({
+    provider,
+    requestFactory: () => ({
+      prompt: 'reply with {"ok":true}',
+      // The model the fixture's recorded response names; anything else and the backend would
+      // answer with a body claiming to be a different model.
+      model: state.model,
+      responseFormat: { type: 'text' },
+      maxOutputTokens: 16,
+      signal: new AbortController().signal,
+    }),
+    scenarios: {
+      success: enter('success'),
+      auth: enter('auth'),
+      rate_limit: enter('rate_limit'),
+      model_not_found: enter('model_not_found'),
+      invalid_request: enter('invalid_request'),
+      transient: enter('transient'),
+      malformed_response: enter('malformed_response'),
+      truncated: enter('truncated'),
+      refused: enter('refused'),
+    },
+    controls: { jsonCapability: 'native' },
+  })
+}
+
+/* ----------------------------------------------------------------------- main ---- */
+
+/** A suite's verdict as a line, and its failures. Skips count against a release too. */
+function report(name, result, problems) {
+  for (const failure of result.failures) problems.push(`${name}: ${failure}`)
+  for (const skip of result.skipped) {
+    problems.push(`${name}: '${skip}' was skipped, so it is unverified`)
+  }
+  if (result.failures.length > 0 || result.skipped.length > 0) return
+  // `passed` is the suite's verdict; empty lists are only this side's reading of it.
+  if (result.passed !== true) {
+    problems.push(`${name}: reported not passed without naming a failure`)
+    return
+  }
+  process.stdout.write(`${name}: passed, nothing skipped\n`)
+}
+
+/**
+ * Releases the pool and the listening socket when this process is asked to stop, so it is not
+ * holding a connection to the schema its caller is about to drop. The schema is the caller's.
+ */
+function closeOnSignal(fixture, pool) {
+  let stopping = false
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => {
+      if (stopping) return
+      stopping = true
+      process.stderr.write(`the release check was stopped by ${signal}\n`)
+      fixture.server.close()
+      void pool.end().catch(() => undefined)
+      // A handler replaces the default disposition, so the exit must be explicit.
+      process.exit(1)
+    })
+  }
+}
+
+async function main() {
+  const [schema] = process.argv.slice(2)
+  if (schema === undefined) {
+    process.stderr.write('usage: release-conformance.mjs <schema>\n')
+    return 2
+  }
+  const url = process.env.DATABASE_URL ?? ''
+  if (url === '') {
+    process.stderr.write('DATABASE_URL is not set\n')
+    return 2
+  }
+
+  try {
+    for (const { subpath, file } of assertInstalledPackageResolves()) {
+      process.stdout.write(`resolved ${subpath} -> ${file}\n`)
+    }
+  } catch (error) {
+    // Said in full: the guard reports file paths and nothing else, and a run that would have
+    // imported the wrong package is worth naming precisely.
+    process.stderr.write(`${error instanceof Error ? error.message : 'unknown failure'}\n`)
+    return 1
+  }
+  installed = await importInstalledPackage()
+  if (typeof installed.postgres.USAGE_STORE_MARKER !== 'string') {
+    process.stderr.write('the installed package publishes no USAGE_STORE_MARKER\n')
+    return 1
+  }
+
+  const problems = []
+  const template = JSON.parse(readFileSync(TEMPLATE, 'utf8'))
+  const state = {
+    template,
+    // Read off the fixture rather than written down twice.
+    model: template.model,
+    scenario: 'success',
+    unexpected: [],
+  }
+  if (typeof state.model !== 'string' || state.model === '') {
+    process.stderr.write('the fixture response names no model\n')
+    return 1
+  }
+  const fixture = await startFixture(state)
+  const pool = new pg.Pool({ connectionString: url })
+  closeOnSignal(fixture, pool)
+  try {
+    const migration = installed.postgres.migrationSql({ schema })
+    process.stdout.write(`migration sha256 ${migration.sha256}, schema ${schema}\n`)
+    await pool.query(migration.sql)
+
+    const stores = await runStoreSuites(pool, schema)
+    for (const drift of stores.drifted) problems.push(`the usage store: ${drift}`)
+    report('the usage store suite', stores.usage, problems)
+    report('the config store suite', stores.config, problems)
+
+    const provider = await runProviderSuite(state, fixture.port)
+    report('the provider suite', provider, problems)
+    for (const unexpected of state.unexpected) {
+      problems.push(`the fixture refused a provider call: ${unexpected}`)
+    }
+  } finally {
+    // The schema is left standing: the caller named it and drops it.
+    await pool.end().catch(() => undefined)
+    await new Promise((done) => fixture.server.close(() => done(undefined)))
+  }
+
+  for (const problem of problems) process.stdout.write(`${problem}\n`)
+  return problems.length === 0 ? 0 : 1
+}
+
+try {
+  process.exitCode = await main()
+} catch (error) {
+  process.stderr.write(
+    `the release check could not run: ${error instanceof Error ? error.message : 'unknown'}\n`,
+  )
+  process.exitCode = 1
+}

--- a/scripts/runners/subpath-resolution.d.mts
+++ b/scripts/runners/subpath-resolution.d.mts
@@ -1,0 +1,20 @@
+/**
+ * Declares `./subpath-resolution.mjs`, which exists only once a runner has been copied into a
+ * scratch project, so the runners are type-checked in the repository like every other script.
+ *
+ * Kept in step with `../lib/subpath-resolution.mjs` by hand.
+ *
+ * @module
+ */
+
+/** Every specifier the installed package publishes, read off its own `exports` map. */
+export declare function publishedSubpaths(manifest: {
+  name?: unknown
+  exports?: unknown
+}): string[]
+
+/** Confirms every published subpath resolves inside this project's own copy of the package. */
+export declare function assertInstalledPackageResolves(): {
+  subpath: string
+  file: string
+}[]

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * Verifies a packed tarball end to end, from outside the repository's own tree.
+ *
+ * The tarball is installed into a throwaway project, the installed bytes are checked against
+ * it, and the check runs from inside that project: it applies the packaged migration to a real
+ * PostgreSQL in a schema of its own and runs all three conformance suites. A skipped case
+ * fails the run as a failing one does — a release must not ship on an unverified
+ * classification. The suites `import` the package, so they exercise its ESM build; the
+ * CommonJS build is covered by the consumer fixtures.
+ *
+ * This process owns the schema and drops it on every exit path, including signals: the runner
+ * it starts can be killed and cannot be relied on to tidy up after itself. A drop that fails
+ * is reported and makes the run non-zero.
+ *
+ * Usage: node scripts/verify-release.mjs <path-to-tgz>
+ * Needs `DATABASE_URL` in exactly one shape: postgres://user:password@127.0.0.1:port/database —
+ * an address in 127.0.0.0/8, an explicit port, and no query string or fragment.
+ *
+ * A database for the run, thrown away with the container:
+ *
+ *   docker run --rm -d --name llmswitch-verify-db -p 127.0.0.1:5433:5432 \
+ *     -e POSTGRES_PASSWORD=<throwaway> \
+ *     postgres:14@sha256:2fdfb9b432d4a73bd3eea3d989752c1e669b68d502347e0bfd2cc6d709f3d6b4
+ *   export DATABASE_URL=postgres://postgres:<throwaway>@127.0.0.1:5433/postgres
+ *   npm run verify:release -- <path-to-tgz>
+ *   docker rm -f llmswitch-verify-db
+ *
+ * The image is pinned by digest so two runs a month apart are the same check.
+ * Exit codes: 0 verified, 1 a check failed, 2 wrong usage or a missing database.
+ */
+
+import { randomBytes } from 'node:crypto'
+import { mkdtempSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { isAbsolute, join, resolve } from 'node:path'
+
+import pg from 'pg'
+
+import {
+  createConsumerProject,
+  pinnedDevelopmentOverrides,
+  pinnedDevelopmentVersion,
+  runInConsumerProject,
+  stopRunningChildren,
+} from './lib/consumer-project.mjs'
+import { describeUnusableDatabase } from './lib/database-target.mjs'
+import { hashFile } from './lib/installed-package.mjs'
+
+const USAGE = 'usage: verify-release.mjs <path-to-tgz>\n'
+const RUNNER = join(import.meta.dirname, 'runners', 'release-conformance.mjs')
+const TEMPLATE = join(import.meta.dirname, 'fixtures', 'openai-chat-completion.json')
+
+/** What a project installing llmswitch has to bring: the declared peer and the driver. */
+const PEERS = ['zod', 'pg', 'pg-connection-string']
+
+/** Long enough for the suites on a cold database, short enough that a hang is a failure. */
+const CHECK_DEADLINE = 10 * 60_000
+/** Dropping one schema is one statement; longer than this means nothing is coming back. */
+const CLEANUP_DEADLINE = 30_000
+
+/**
+ * What this run created and must remove. `leftover` records a removal that failed, so the run
+ * cannot then report success.
+ *
+ * @type {{
+ *   workspace: string | null
+ *   schema: string | null
+ *   databaseUrl: string | null
+ *   leftover: boolean
+ * }}
+ */
+const owned = { workspace: null, schema: null, databaseUrl: null, leftover: false }
+
+/** The clean-up already under way, so a second caller waits for it instead of starting one. */
+let releasing = null
+
+/**
+ * Drops the schema and removes the workspace, once.
+ *
+ * Returns the in-flight promise rather than a "done" flag so an interrupt arriving mid-drop
+ * waits for it instead of exiting the process out from under it.
+ */
+function releaseWhatThisRunOwns() {
+  releasing ??= release()
+  return releasing
+}
+
+/** The clean-up itself. Called once; everything else waits on the promise it returned. */
+async function release() {
+  if (owned.schema !== null && owned.databaseUrl !== null) {
+    const pool = new pg.Pool({
+      connectionString: owned.databaseUrl,
+      connectionTimeoutMillis: CLEANUP_DEADLINE,
+      // The connection timeout bounds reaching the server, not the statement: without these
+      // a drop waiting on a lock would hang the signal path.
+      statement_timeout: CLEANUP_DEADLINE,
+      query_timeout: CLEANUP_DEADLINE,
+    })
+    try {
+      await pool.query(`DROP SCHEMA IF EXISTS "${owned.schema}" CASCADE`)
+    } catch {
+      owned.leftover = true
+      process.stderr.write(
+        `the schema ${owned.schema} could not be dropped. If the run reached the database, ` +
+          `it is still there — remove it with: DROP SCHEMA IF EXISTS "${owned.schema}" CASCADE\n`,
+      )
+    } finally {
+      await pool.end().catch(() => undefined)
+    }
+  }
+  if (owned.workspace !== null) {
+    // A throw here would become an unhandled rejection through the memoised promise.
+    try {
+      rmSync(owned.workspace, { recursive: true, force: true })
+    } catch {
+      owned.leftover = true
+      process.stderr.write(`the directory ${owned.workspace} could not be removed\n`)
+    }
+  }
+}
+
+/** Cleans up and stops when this process is interrupted, rather than leaving a schema behind. */
+function cleanUpOnSignal() {
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.on(signal, () => {
+      process.stderr.write(`\nstopped by ${signal}; cleaning up\n`)
+      // The child first: a signal to this process is not delivered to it, so dropping the
+      // schema while it is still writing to it would leave an orphan behind.
+      void stopRunningChildren()
+        .then(() => releaseWhatThisRunOwns())
+        .finally(() => {
+          // A handler replaces the default disposition, so the exit must be explicit.
+          process.exit(1)
+        })
+    })
+  }
+}
+
+/**
+ * Drops every `PG*` name from this process's environment, so its pools connect on the
+ * connection string alone — as the children already do under their allowlist. The driver reads
+ * these as defaults, so an ambient `PGSSLMODE` or `PGPORT` could otherwise make the clean-up
+ * connect differently from the run it is cleaning up after.
+ */
+function forgetAmbientPostgresSettings() {
+  for (const name of Object.keys(process.env)) {
+    if (name.startsWith('PG')) Reflect.deleteProperty(process.env, name)
+  }
+}
+
+/** The tarball to verify, or the reason there is nothing to verify. */
+function readArguments(argv) {
+  const [named] = argv
+  if (argv.length !== 1 || named === undefined) return { tarball: null, problem: USAGE }
+  const tarball = isAbsolute(named) ? named : resolve(named)
+  let file = null
+  try {
+    file = statSync(tarball)
+  } catch {
+    // Reported below, together with the case of a path that is not a file at all.
+  }
+  if (file === null || !file.isFile()) {
+    return { tarball: null, problem: `'${named}' is not an existing tarball file\n${USAGE}` }
+  }
+  return { tarball, problem: null }
+}
+
+async function main() {
+  const { tarball, problem: usageProblem } = readArguments(process.argv.slice(2))
+  if (usageProblem !== null) {
+    process.stderr.write(usageProblem)
+    return 2
+  }
+
+  const databaseUrl = process.env.DATABASE_URL ?? ''
+  if (databaseUrl === '') {
+    process.stderr.write(`DATABASE_URL is not set\n${USAGE}`)
+    return 2
+  }
+  const unusable = describeUnusableDatabase(databaseUrl)
+  if (unusable !== null) {
+    process.stderr.write(`${unusable}\n`)
+    return 2
+  }
+  forgetAmbientPostgresSettings()
+
+  const before = hashFile(tarball)
+  cleanUpOnSignal()
+  owned.databaseUrl = databaseUrl
+  owned.workspace = mkdtempSync(join(tmpdir(), 'llmswitch-release-'))
+  try {
+    const project = createConsumerProject({
+      workspace: owned.workspace,
+      name: 'consumer',
+      tarballPath: tarball,
+      // The declared peer, the driver the package does not ship, and the parser the guard
+      // above judged the connection string with. What they in turn require is pinned as
+      // overrides rather than installed, so an optional dependency stays optional.
+      packages: PEERS.map((name) => pinnedDevelopmentVersion(name)),
+      overrides: pinnedDevelopmentOverrides(PEERS),
+      files: [RUNNER, TEMPLATE],
+    })
+
+    // A schema of this run's own, so a leftover from an interrupted run is never mistaken for
+    // what this one applied.
+    owned.schema = `release_${randomBytes(4).toString('hex')}`
+    const check = await runInConsumerProject(project, {
+      script: 'release-conformance.mjs',
+      args: [owned.schema],
+      values: { DATABASE_URL: databaseUrl },
+      timeout: CHECK_DEADLINE,
+    })
+    if (check.note !== '') process.stderr.write(`${check.note}\n`)
+    if (!check.ok) return 1
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : 'unknown error'}\n`)
+    return 1
+  } finally {
+    await releaseWhatThisRunOwns()
+  }
+
+  // A run that could not remove what it created left a database dirty, whatever the suites said.
+  if (owned.leftover) return 1
+
+  if (hashFile(tarball) !== before) {
+    process.stdout.write('the tarball changed while it was being verified\n')
+    return 1
+  }
+  process.stdout.write(
+    'the installed tarball applied its packaged migration to PostgreSQL and passed all ' +
+      `three conformance suites with nothing skipped — from sha256 ${before}\n`,
+  )
+  return 0
+}
+
+try {
+  process.exitCode = await main()
+} catch (error) {
+  // The check itself broke; it must still clean up.
+  process.stderr.write(
+    `the release check could not run: ${error instanceof Error ? error.message : 'unknown'}\n`,
+  )
+  await releaseWhatThisRunOwns()
+  process.exitCode = 1
+}

--- a/src/postgres.ts
+++ b/src/postgres.ts
@@ -1,11 +1,17 @@
 /**
  * PostgreSQL entry point — `import { … } from 'llmswitch/postgres'`.
  *
- * The packaged migrations, and nothing else: `MIGRATIONS` is every published version with its
- * template hash, and `migrationSql()` renders them for your schema. The stores themselves are
- * exported from the root, so an application that has already migrated never loads the DDL.
+ * The packaged migrations: `MIGRATIONS` is every published version with its template hash, and
+ * `migrationSql()` renders them for your schema. The stores themselves are exported from the
+ * root, so an application that has already migrated never loads the DDL.
+ *
+ * `USAGE_STORE_MARKER` is published here too. A conformance harness that reaches the packaged
+ * store through a pool of its own has to recognise the store's usage statements to drive their
+ * clock (spec §6b), and reading that marker out of the source of an installed package is not
+ * something an adopter should have to do.
  *
  * @module
  */
 
 export { MIGRATIONS, migrationSql } from './stores/postgres/migrations'
+export { USAGE_STORE_MARKER } from './stores/postgres/sql'

--- a/test/types/spec-surface-postgres.d.ts
+++ b/test/types/spec-surface-postgres.d.ts
@@ -10,3 +10,7 @@ export declare const MIGRATIONS: ReadonlyArray<{
 // All versions concatenated in order, idempotent, schema-rendered; sha256 covers the
 // exact aggregate sql bytes.
 export declare function migrationSql(opts?: { schema?: string }): { sql: string; sha256: string }
+// The comment every usage-protocol statement begins with. A harness that reaches the packaged
+// store only through an adopter-shaped pool recognises marked statements by it and substitutes
+// their trailing clock parameter (see the conformance note below).
+export declare const USAGE_STORE_MARKER: string

--- a/test/unit/scripts/database-target.test.ts
+++ b/test/unit/scripts/database-target.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  describeUnusableDatabase,
+  isLoopbackAddress,
+} from '../../../scripts/lib/database-target.mjs'
+
+describe('the database target guard', () => {
+  it('accepts a bare loopback connection string', () => {
+    expect(describeUnusableDatabase('postgres://user:pw@127.0.0.1:5433/postgres')).toBeNull()
+  })
+
+  it('accepts any address in 127.0.0.0/8', () => {
+    expect(describeUnusableDatabase('postgres://user@127.0.0.2:5433/db')).toBeNull()
+    expect(describeUnusableDatabase('postgres://user@127.15.200.9:5432/db')).toBeNull()
+    expect(isLoopbackAddress('127.0.0.1')).toBe(true)
+    expect(isLoopbackAddress('127.255.255.254')).toBe(true)
+    expect(isLoopbackAddress('128.0.0.1')).toBe(false)
+    expect(isLoopbackAddress('126.255.255.255')).toBe(false)
+  })
+
+  it('rejects the IPv6 loopback, which the driver would resolve as a name', () => {
+    // The parser returns `[::1]` bracketed, and `net.connect` treats that as a name.
+    expect(describeUnusableDatabase('postgres://user@[::1]:5432/db')).toMatch(/connects to/)
+    expect(isLoopbackAddress('::1')).toBe(false)
+    expect(isLoopbackAddress('[::1]')).toBe(false)
+    expect(isLoopbackAddress('0:0:0:0:0:0:0:1')).toBe(false)
+  })
+
+  it('rejects a connection string with no port, which PGPORT would then choose', () => {
+    expect(describeUnusableDatabase('postgres://user@127.0.0.1/db')).toMatch(/names no port/)
+    expect(describeUnusableDatabase('postgres://user:pw@127.0.0.1/postgres')).toMatch(
+      /postgres:\/\/user:password@127\.0\.0\.1:port\/database/,
+    )
+  })
+
+  it('rejects a host parameter that moves the connection off this machine', () => {
+    // The authority reads as loopback while the driver connects elsewhere.
+    expect(
+      describeUnusableDatabase('postgres://user@127.0.0.1:5433/db?host=example.com'),
+    ).toMatch(/connects to 'example.com'/)
+  })
+
+  it('rejects a hostaddr parameter, which decides the address on its own', () => {
+    expect(
+      describeUnusableDatabase('postgres://user@127.0.0.1:5433/db?hostaddr=203.0.113.7'),
+    ).toMatch(/hostaddr/)
+  })
+
+  it('rejects any query string at all, even a harmless-looking one', () => {
+    expect(
+      describeUnusableDatabase('postgres://user@127.0.0.1:5433/db?sslmode=disable'),
+    ).toMatch(/'\?' or '#'/)
+    expect(describeUnusableDatabase('postgres://user@127.0.0.1:5433/db?port=6000')).toMatch(
+      /'\?' or '#'/,
+    )
+  })
+
+  it("rejects a bare '?' and a fragment, which a parser reads as no query at all", () => {
+    // `new URL(...).search` is empty for both, so a check on the parsed query would pass them.
+    expect(describeUnusableDatabase('postgres://user@127.0.0.1:5433/db?')).toMatch(
+      /'\?' or '#'/,
+    )
+    expect(describeUnusableDatabase('postgres://user@127.0.0.1:5433/db#?host=evil')).toMatch(
+      /'\?' or '#'/,
+    )
+  })
+
+  it('rejects a host name, including localhost', () => {
+    // What `localhost` resolves to is decided by a hosts file and a resolver.
+    expect(describeUnusableDatabase('postgres://user@localhost:5433/db')).toMatch(
+      /connects to 'localhost'/,
+    )
+    expect(describeUnusableDatabase('postgres://user@example.com:5432/db')).toMatch(
+      /connects to 'example.com'/,
+    )
+    expect(isLoopbackAddress('localhost')).toBe(false)
+  })
+
+  it('rejects what is not a connection string, and one that names no host', () => {
+    expect(describeUnusableDatabase('')).toBe('DATABASE_URL is not a URL')
+    expect(describeUnusableDatabase('not a url')).toBe('DATABASE_URL is not a URL')
+    expect(describeUnusableDatabase('postgres:///db')).toBe('DATABASE_URL names no host')
+  })
+})

--- a/test/unit/scripts/live-check-json.test.ts
+++ b/test/unit/scripts/live-check-json.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { checkJsonShape } from '../../../scripts/runners/json-tolerance.mjs'
+
+/** What the live check accepts as "the model returned a JSON object", and what it does not. */
+function problemsFor(text: string): string[] {
+  const problems: string[] = []
+  checkJsonShape(text, problems)
+  return problems
+}
+
+describe('the live check reading a JSON answer', () => {
+  it('accepts the object on its own', () => {
+    expect(problemsFor('{"ok": true}')).toEqual([])
+    expect(problemsFor('  \n{"ok": true}\n  ')).toEqual([])
+  })
+
+  it('accepts an object a model wrapped in a code fence', () => {
+    expect(problemsFor('```json\n{"ok": true}\n```')).toEqual([])
+    expect(problemsFor('```\n{"ok": true}\n```')).toEqual([])
+  })
+
+  it('accepts an object a model wrapped in a sentence', () => {
+    expect(problemsFor('Sure! Here it is: {"ok": true} — let me know.')).toEqual([])
+  })
+
+  it('is not fooled by a brace inside a string', () => {
+    expect(problemsFor('note: {"closing": "}", "ok": true} done')).toEqual([])
+  })
+
+  it('rejects an empty object, which parses and proves nothing', () => {
+    expect(problemsFor('{}')).toEqual([
+      'the JSON call: the output was an empty object, which proves nothing',
+    ])
+    expect(problemsFor('```json\n{}\n```')).toEqual([
+      'the JSON call: the output was an empty object, which proves nothing',
+    ])
+  })
+
+  it('rejects output that is not an object at the top level', () => {
+    expect(problemsFor('[1, 2, 3]')).toEqual([
+      'the JSON call: the output parsed, but not to a JSON object',
+    ])
+    expect(problemsFor('"ok"')).toEqual([
+      'the JSON call: the output parsed, but not to a JSON object',
+    ])
+  })
+
+  it('judges valid JSON as itself rather than looking inside it', () => {
+    expect(problemsFor('[{"ok":true}]')).toEqual([
+      'the JSON call: the output parsed, but not to a JSON object',
+    ])
+    expect(problemsFor('{"nested": {"ok": true}}')).toEqual([])
+  })
+
+  it('rejects output with no JSON in it at all', () => {
+    expect(problemsFor('I cannot help with that.')).toEqual([
+      'the JSON call: the output did not parse as JSON, in a code fence or otherwise',
+    ])
+    expect(problemsFor('{not json at all}')).toEqual([
+      'the JSON call: the output did not parse as JSON, in a code fence or otherwise',
+    ])
+  })
+})

--- a/test/unit/scripts/secret-filter.test.ts
+++ b/test/unit/scripts/secret-filter.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSecretFilter } from '../../../scripts/lib/secret-filter.mjs'
+
+/**
+ * What a filter lets through, given the chunks it was written.
+ *
+ * The output is collected as bytes and decoded once at the end, exactly as a terminal reads
+ * it. Decoding each write on its own would paper over a character split across two of them.
+ */
+async function through(secrets: string[], chunks: Buffer[]): Promise<string> {
+  const filter = createSecretFilter(secrets)
+  const written: Buffer[] = []
+  filter.on('data', (chunk: Buffer) => {
+    written.push(Buffer.from(chunk))
+  })
+  const ended = new Promise((resolve) => filter.on('end', resolve))
+  for (const chunk of chunks) filter.write(chunk)
+  filter.end()
+  await ended
+  return Buffer.concat(written).toString('utf8')
+}
+
+/** Each string as one chunk. */
+function chunks(...text: string[]): Buffer[] {
+  return text.map((piece) => Buffer.from(piece, 'utf8'))
+}
+
+/**
+ * One chunk per character, so every character boundary is exercised.
+ *
+ * By code point, not by code unit: a lone surrogate is not encodable, so splitting a pair here
+ * would corrupt it before the filter ever saw it. A real stream delivers bytes, which
+ * `perByte` covers.
+ */
+function perCharacter(text: string): Buffer[] {
+  const characters: Buffer[] = []
+  for (const character of text) characters.push(Buffer.from(character, 'utf8'))
+  return characters
+}
+
+/** One chunk per byte, so every byte boundary is exercised. */
+function perByte(text: string): Buffer[] {
+  const bytes = Buffer.from(text, 'utf8')
+  return Array.from({ length: bytes.length }, (_, index) => bytes.subarray(index, index + 1))
+}
+
+describe('the child output secret filter', () => {
+  it('passes output through unchanged when it holds no secret', async () => {
+    expect(await through(['sk-key'], chunks('hello ', 'world\n'))).toBe('hello world\n')
+  })
+
+  it('replaces a secret inside one chunk', async () => {
+    expect(await through(['sk-key'], chunks('auth failed for sk-key\n'))).toBe(
+      'auth failed for [redacted]\n',
+    )
+  })
+
+  it('replaces a secret split across two chunks', async () => {
+    expect(await through(['sk-secret-value'], chunks('token=sk-secret', '-value done\n'))).toBe(
+      'token=[redacted] done\n',
+    )
+  })
+
+  it('replaces a secret split one character at a time', async () => {
+    const secret = 'sk-abcdef'
+    expect(await through([secret], perCharacter(`before ${secret} after\n`))).toBe(
+      'before [redacted] after\n',
+    )
+  })
+
+  it('replaces every occurrence, and handles several secrets', async () => {
+    expect(await through(['aaa', 'bbb'], chunks('x aaa y bbb z aaa\n'))).toBe(
+      'x [redacted] y [redacted] z [redacted]\n',
+    )
+  })
+
+  it('flushes what it was holding back when the stream ends', async () => {
+    expect(await through(['sk-long-secret'], chunks('tail'))).toBe('tail')
+  })
+
+  it('keeps an astral character whole when the held-back tail falls inside it', async () => {
+    // A three-character secret holds back two characters, which for `A😀B` is the second half
+    // of the surrogate pair and the `B`: cutting there would emit a lone high surrogate.
+    expect(await through(['key'], chunks('A😀B'))).toBe('A😀B')
+    expect(await through(['key'], perCharacter('A😀B'))).toBe('A😀B')
+    expect(await through(['key'], chunks('x😀', '😀y'))).toBe('x😀😀y')
+  })
+
+  it('does not split a multi-byte character across chunks', async () => {
+    expect(await through(['sk-key'], perByte('héllo ✓ 😀\n'))).toBe('héllo ✓ 😀\n')
+  })
+
+  it('passes output through when there is no secret to remove', async () => {
+    expect(await through([], chunks('anything at all\n'))).toBe('anything at all\n')
+    expect(await through([''], chunks('anything at all\n'))).toBe('anything at all\n')
+  })
+})

--- a/test/unit/smoke.test.ts
+++ b/test/unit/smoke.test.ts
@@ -20,7 +20,11 @@ describe('entry points', () => {
       'openaiCompatible',
       'postgresStores',
     ])
-    expect(Object.keys(postgres).sort()).toEqual(['MIGRATIONS', 'migrationSql'])
+    expect(Object.keys(postgres).sort()).toEqual([
+      'MIGRATIONS',
+      'USAGE_STORE_MARKER',
+      'migrationSql',
+    ])
     expect(Object.keys(conformance).sort()).toEqual([
       'runConfigStoreConformance',
       'runProviderConformance',

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,12 +9,26 @@
     // files with type comments; everything else strict still applies.
     "checkJs": true,
     "noImplicitAny": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    // The runners import the package by its published name. Left to the manifest that
+    // resolves into `dist/`, which makes this typecheck depend on a build having happened
+    // first — it has not in CI, where typecheck runs before build. Pointed at the sources
+    // instead, which are what `dist/` is generated from.
+    "paths": {
+      "llmswitch": ["./src/index.ts"],
+      "llmswitch/postgres": ["./src/postgres.ts"],
+      "llmswitch/conformance": ["./src/conformance.ts"]
+    }
   },
   "include": ["test", "scripts", "*.config.ts", "eslint.config.js"],
   // `test/types` holds the compile fixtures, half of which are meant to fail. They carry
   // their own tsconfig and are checked one program at a time by
   // `scripts/check-types-fixtures.mjs`; compiling them here would simply report their
   // intended errors as build errors.
+  //
+  // `scripts/runners` is checked with everything else. Those files are copied into a throwaway
+  // project before they run, so the guard they import sits at a path that exists only there;
+  // `scripts/runners/subpath-resolution.d.mts` declares it, and the package they import by its
+  // published name is mapped to `src/` by `paths` above.
   "exclude": ["test/consumers", "test/types"]
 }


### PR DESCRIPTION
Two scripts that gate a release on proof rather than assumption. `npm run verify:release <tgz>` installs the packed tarball into a scratch consumer project and runs the package's own conformance suites (usage store, config store, provider) against a real local PostgreSQL, applying the packaged migration along the way. It also proves the installed bytes are the tarball's bytes, that every published subpath resolves inside the installed package, and that `USAGE_STORE_MARKER` is reachable from `llmswitch/postgres`. `npm run live:providers` calls every built-in adapter against its real provider; locally, adapters without a key are skipped and say so, while `--release <tgz>` requires every adapter to run against the installed tarball or the check fails — no skips, no endpoint overrides.

The database check is destructive by design (it creates and drops a schema and truncates tables inside it), so `DATABASE_URL` is held to one shape — a literal 127.0.0.0/8 address with an explicit port and no query string or fragment — validated against the effective target the driver would resolve rather than the URL authority, with ambient `PG*` variables cleared. The parent process owns the schema and drops it on every exit path; a failed drop names the schema, prints the statement that removes it, and fails the run. Provider keys reach one child process each through an env allowlist, never argv or disk, and child output streams through a redaction filter. The scratch consumer's dependencies are pinned to the repository lockfile's exact versions, transitive closure included.

768 tests cover the connection-string guard, the JSON-shape tolerance, and the redaction filter (chunk-boundary and multi-byte cases); the whole flow is verified end to end against a dockerized PostgreSQL.

Replaces #16 (same tree, cleaned-up commit).