### PR TITLE
Current Gemini model for the live check

### DIFF
--- a/scripts/live-check-providers.mjs
+++ b/scripts/live-check-providers.mjs
@@ -50,7 +50,7 @@ const USAGE = 'usage: live-check-providers.mjs [--release <path-to-tgz>]\n'
 const PROVIDERS = [
   { name: 'anthropic', key: 'ANTHROPIC_API_KEY', model: 'claude-haiku-4-5' },
   { name: 'openai-compatible', key: 'OPENAI_API_KEY', model: 'gpt-4.1-nano' },
-  { name: 'gemini', key: 'GEMINI_API_KEY', model: 'gemini-2.5-flash-lite' },
+  { name: 'gemini', key: 'GEMINI_API_KEY', model: 'gemini-3.5-flash-lite' },
 ]
 
 /** Two calls to a live provider; anything beyond this is a hang, not a slow model. */


### PR DESCRIPTION
gemini-2.5-flash-lite is no longer served to new accounts; the API's own error names gemini-3.5-flash-lite as the replacement, verified live with a 200.