### PR TITLE
The package is llmdispatch

### DIFF
--- a/.changeset/quickstart-and-provider-reference.md
+++ b/.changeset/quickstart-and-provider-reference.md
@@ -1,5 +1,5 @@
 ---
-'llmswitch': patch
+'llmdispatch': patch
 ---
 
 Docs: the README quickstart is now self-contained and mechanically verified — its

--- a/.changeset/readme-security-policy.md
+++ b/.changeset/readme-security-policy.md
@@ -1,5 +1,5 @@
 ---
-'llmswitch': patch
+'llmdispatch': patch
 ---
 
 Docs: the README's Contributing section now points at the security policy — security

--- a/.changeset/runnable-examples.md
+++ b/.changeset/runnable-examples.md
@@ -1,5 +1,5 @@
 ---
-'llmswitch': patch
+'llmdispatch': patch
 ---
 
 Docs: the README now links two runnable examples — `examples/next` (TypeScript, App

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
           - '*'
 
   # The examples pin every dependency exactly and commit a lockfile, so they go stale like
-  # any other project and are updated the same way. Their `llmswitch` dependency is the
+  # any other project and are updated the same way. Their `llmdispatch` dependency is the
   # locally packed tarball rather than a registry one, and is not something to update here.
   # `@types/node` tracks the package's Node 20 floor in the Next.js example for the same
   # reason it does at the root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ promises will not compile. `check-types-fixtures.mjs` compiles each in a program
 - `test/types/scaffold.d.ts` declares the values the README examples use without introducing
   them, so those examples compile as printed.
 
-**Errors.** Two public classes. `LLMSwitchError` has a closed set of codes and a `retryable`
+**Errors.** Two public classes. `LLMDispatchError` has a closed set of codes and a `retryable`
 flag copied from the classification row in spec §5b rather than worked out on the spot. The
 flag belongs to the row and not to the code — `PROVIDER_FAILED` is retryable for a
 `transient` failure and not for a `refused` one — which is why `src/errors` has one factory
@@ -83,11 +83,11 @@ continuous integration, where a missing database is a failure rather than a quie
 version they are written against is the one CI runs:
 
 ```bash
-docker run -d --name llmswitch-pg -p 5432:5432 -e POSTGRES_PASSWORD=postgres \
+docker run -d --name llmdispatch-pg -p 5432:5432 -e POSTGRES_PASSWORD=postgres \
   postgres:14@sha256:2fdfb9b432d4a73bd3eea3d989752c1e669b68d502347e0bfd2cc6d709f3d6b4
-until docker exec llmswitch-pg pg_isready -U postgres; do sleep 1; done
+until docker exec llmdispatch-pg pg_isready -U postgres; do sleep 1; done
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres npm run test:integration
-docker rm -f llmswitch-pg
+docker rm -f llmdispatch-pg
 ```
 
 `src/core` and `src/errors` are held at 90%

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# llmswitch
+# llmdispatch
 
 **Control which LLM handles each operation in your app. Swap providers at runtime, fall back on failure, enforce per-user quotas.**
 
@@ -12,7 +12,7 @@ Apps that use AI usually have several distinct AI *operations* — parse a docum
 
 Today most codebases hard-code one provider SDK and scatter model names across the code. Changing anything means a deploy. Adding limits means building rate limiting from scratch.
 
-llmswitch gives you one place to declare your operations, and a control panel's worth of behavior behind a single function call:
+llmdispatch gives you one place to declare your operations, and a control panel's worth of behavior behind a single function call:
 
 - **Per-operation routing** — each operation gets its own provider + model: store overrides with an optional code-declared default, editable at runtime without a redeploy.
 - **Schema-validated output** — every operation declares the shape it expects (a [Zod](https://zod.dev) schema); responses are validated before you see them.
@@ -20,22 +20,22 @@ llmswitch gives you one place to declare your operations, and a control panel's 
 - **Per-user quotas** — daily limits per operation per subject, counted atomically in your database, fail-closed, and editable at runtime like a route.
 - **Usage accounting** — provider-reported token counts per attempt; cost estimates if you supply your prices.
 
-What llmswitch deliberately is **not**: it doesn't auto-pick models for you (it's a switchboard, not a brain), it doesn't proxy traffic through anyone's servers, and v0.1 is text-only — no streaming, no PDF/image input yet (both on the [roadmap](#roadmap)).
+What llmdispatch deliberately is **not**: it doesn't auto-pick models for you (it's a switchboard, not a brain), it doesn't proxy traffic through anyone's servers, and v0.1 is text-only — no streaming, no PDF/image input yet (both on the [roadmap](#roadmap)).
 
 ## Quickstart
 
 Two packages. That's the whole install — built-in adapters are plain-`fetch`, **zero vendor SDKs**:
 
 ```bash
-npm install llmswitch zod
+npm install llmdispatch zod
 ```
 
-Any package manager works — `pnpm add llmswitch zod` or `yarn add llmswitch zod`.
+Any package manager works — `pnpm add llmdispatch zod` or `yarn add llmdispatch zod`.
 
 The snippet uses top-level `await`, so it needs an ESM project. In a fresh directory, run `npm pkg set type=module` first, or save the file as `.mts`.
 
 ```ts
-import { createSwitch, defineOperation, defineOperations, anthropic, openaiCompatible, memoryStores } from 'llmswitch'
+import { createSwitch, defineOperation, defineOperations, anthropic, openaiCompatible, memoryStores } from 'llmdispatch'
 import { z } from 'zod'
 
 const ai = createSwitch({
@@ -111,7 +111,7 @@ The exact pipeline is spec §3.
 
 ## Errors
 
-Classified llmswitch failures throw `LLMSwitchError` with a stable `code` (exceptions from *your own* callbacks pass through raw — see below):
+Classified llmdispatch failures throw `LLMDispatchError` with a stable `code` (exceptions from *your own* callbacks pass through raw — see below):
 
 | Code | Meaning | Retryable | Sensible HTTP |
 | --- | --- | --- | --- |
@@ -125,9 +125,9 @@ Classified llmswitch failures throw `LLMSwitchError` with a stable `code` (excep
 | `PROVIDER_FAILED` | the final attempt failed at the provider level (see `error.attempts` for the full path) | per final classification (spec §5b) | 502 |
 | `OUTPUT_REJECTED` | the final attempt's output failed schema/quality validation, or was truncated by a token limit | yes | 502 |
 
-The table is ordered: pre-dispatch checks run top-to-bottom (config before quota — a misconfigured operation never consumes quota). One nuance for an operation whose *code* declares no quota and gets one only from its route: llmswitch can't know it is quota'd until config resolves, so for that case `CONFIG_STORE_UNAVAILABLE`/`INVALID_CONFIG` surfaces before `MISSING_SUBJECT`. An operation that declares a quota in code keeps the early check even when a route overrides the number. For post-dispatch failures the code reflects the **final attempt's** classification, with every attempt detailed in `error.attempts` (including token usage of failed runs). A fallback attempt can itself end in `INVALID_CONFIG` or `ABORTED` — the terminal-code mapping is spec §5b.
+The table is ordered: pre-dispatch checks run top-to-bottom (config before quota — a misconfigured operation never consumes quota). One nuance for an operation whose *code* declares no quota and gets one only from its route: llmdispatch can't know it is quota'd until config resolves, so for that case `CONFIG_STORE_UNAVAILABLE`/`INVALID_CONFIG` surfaces before `MISSING_SUBJECT`. An operation that declares a quota in code keeps the early check even when a route overrides the number. For post-dispatch failures the code reflects the **final attempt's** classification, with every attempt detailed in `error.attempts` (including token usage of failed runs). A fallback attempt can itself end in `INVALID_CONFIG` or `ABORTED` — the terminal-code mapping is spec §5b.
 
-**`LLMSwitchError`'s package-owned fields are sanitized by design**: classifications, HTTP status codes, safe metadata — never prompts, model output, or raw provider errors from a dispatched attempt. One deliberate pass-through: a pre-dispatch error may chain the underlying store or `prepare()` failure as `cause`, verbatim — your own thrown error, or a provider adapter's readiness failure; do not treat that `cause` as sanitized. Exceptions thrown by *your own* code (prompt builder, quality gate, schema transforms) pass through unwrapped; they're your bugs to see in full.
+**`LLMDispatchError`'s package-owned fields are sanitized by design**: classifications, HTTP status codes, safe metadata — never prompts, model output, or raw provider errors from a dispatched attempt. One deliberate pass-through: a pre-dispatch error may chain the underlying store or `prepare()` failure as `cause`, verbatim — your own thrown error, or a provider adapter's readiness failure; do not treat that `cause` as sanitized. Exceptions thrown by *your own* code (prompt builder, quality gate, schema transforms) pass through unwrapped; they're your bugs to see in full.
 
 ## When fallback fires
 
@@ -147,7 +147,7 @@ One fallback route per operation, one retry, decided by failure *classification*
 
 `fallbackOnAuthOrModelNotFound: true` on `createSwitch` (off by default) lets a *primary* attempt that dies on bad credentials or an unrecognized model name fall back anyway — availability over noise, when a stale key shouldn't take an operation down. It's off by default because a broken route is worth finding out about immediately, rather than paying another provider to hide it, and it changes nothing else: when the fallback *also* dies on credentials or an unknown model the terminal code is still `INVALID_CONFIG`, and otherwise the final attempt's own classification decides it, as always (spec §5b).
 
-Built-in adapters make exactly one client-side HTTP request per attempt — no retries in llmswitch's own HTTP layer, so `timeoutMs` and `attempts[]` mean what they say (a gateway host may retry upstream internally; that's outside our boundary). Truncated responses and provider refusals are detected from termination metadata (`finish_reason`/`stop_reason`), never passed off as good data — truncation falls back, refusals don't. Timeouts and caller cancellation are classified by llmswitch itself, not the adapter: a timeout is retry-worthy, a caller who hung up is not.
+Built-in adapters make exactly one client-side HTTP request per attempt — no retries in llmdispatch's own HTTP layer, so `timeoutMs` and `attempts[]` mean what they say (a gateway host may retry upstream internally; that's outside our boundary). Truncated responses and provider refusals are detected from termination metadata (`finish_reason`/`stop_reason`), never passed off as good data — truncation falls back, refusals don't. Timeouts and caller cancellation are classified by llmdispatch itself, not the adapter: a timeout is retry-worthy, a caller who hung up is not.
 
 ```ts
 operations: { summarize: { /* ... */ timeoutMs: 60_000 } }   // provider I/O timeout per attempt; default 60s
@@ -159,7 +159,7 @@ await ai.run('summarize', { input, subjectId }, { signal: controller.signal })
 Limits are per operation, per `subjectId`, per UTC day — and the *store's* clock owns the day boundary. A limit can be declared in code and overridden at runtime from the config store, exactly like a route ([Runtime config](#runtime-config)). The accounting unit is one **run**: a run and its fallback attempt share one slot. Lifecycle (spec §4 has the exact store contract):
 
 1. **Reserve** — after config checks pass, one slot is atomically reserved. Over the limit → `QUOTA_EXCEEDED`, nothing dispatched.
-2. **Commit** — an idempotent, confirmed transition immediately before the first provider request. **Committed slots are never refunded** — a run that reaches a provider counts even if it fails, because refunding failures would let a failing user burn unlimited provider spend. llmswitch never dispatches without a confirmed commit.
+2. **Commit** — an idempotent, confirmed transition immediately before the first provider request. **Committed slots are never refunded** — a run that reaches a provider counts even if it fails, because refunding failures would let a failing user burn unlimited provider spend. llmdispatch never dispatches without a confirmed commit.
 3. **Expire** — a reservation that never commits (crash before dispatch) expires after its lease and frees the slot — safe, because no provider was called.
 4. **Settle** — attempt records are written idempotently, best-effort with bounded retries and an `onSettlementError` hook. Settlement is accounting only: quota correctness was fixed at commit, and a settlement failure never changes an otherwise successful outcome (the initial write may delay delivery by up to its 10s deadline in the worst case).
 
@@ -199,24 +199,24 @@ The rules, stated plainly:
 - **Config can only reference registered provider IDs**, and secrets never enter the store. With built-in adapters, a tampered row can misroute among *your* registered endpoints but cannot redirect traffic to an arbitrary attacker URL. Scope honestly: for gateway-style providers (e.g. OpenRouter) the model string itself selects downstream infrastructure — protect store write access like the privileged surface it is.
 - Rows are **validated on every read**; a malformed row fails its own operation (`INVALID_CONFIG`) without poisoning others.
 - `defaultRoute` applies **only when a successful store read finds no row** — never as an outage fallback. Expired cache + unreachable store = `CONFIG_STORE_UNAVAILABLE`, fail-closed, so an outage can't silently undo an operator's route switch. Full resolution matrix: spec §2.
-- Reads are cached per process (default 5s, `configTtlMs`), and a change — to a route or a limit — reaches another instance when that instance's cached entry expires and it re-reads. This is not an upper bound: an instance that read just before your write can keep serving the old value for one more TTL after that read finishes, and how fast your write becomes visible to other instances' reads is your store's business, not llmswitch's. Your own process sees its own writes immediately. In-flight runs always finish on the route and limit they resolved with.
+- Reads are cached per process (default 5s, `configTtlMs`), and a change — to a route or a limit — reaches another instance when that instance's cached entry expires and it re-reads. This is not an upper bound: an instance that read just before your write can keep serving the old value for one more TTL after that read finishes, and how fast your write becomes visible to other instances' reads is your store's business, not llmdispatch's. Your own process sees its own writes immediately. In-flight runs always finish on the route and limit they resolved with.
 
 ## Stores
 
 Two interfaces; implement them for any database, or use the built-in pairs:
 
 ```ts
-import { memoryStores, postgresStores } from 'llmswitch'
+import { memoryStores, postgresStores } from 'llmdispatch'
 
 stores: memoryStores()                                 // dev & tests — resets on restart
-stores: postgresStores({ pool, schema: 'llmswitch' })  // production — plain SQL, bring your own pg.Pool
+stores: postgresStores({ pool, schema: 'llmdispatch' })  // production — plain SQL, bring your own pg.Pool
 ```
 
-`postgresStores` ships a versioned SQL migration (you run it — llmswitch never touches your schema on its own) and uses single-statement atomic operations, safe under concurrency. The exact `ConfigStore`/`UsageStore` contracts — including the idempotent commit protocol and lease semantics — are spec §4 and §6, and a **conformance test suite** ships with the package: passing it verifies your custom adapter against every executed case, concurrency included — check its `skipped` list, because scenarios you don't supply are unverified, not passed.
+`postgresStores` ships a versioned SQL migration (you run it — llmdispatch never touches your schema on its own) and uses single-statement atomic operations, safe under concurrency. The exact `ConfigStore`/`UsageStore` contracts — including the idempotent commit protocol and lease semantics — are spec §4 and §6, and a **conformance test suite** ships with the package: passing it verifies your custom adapter against every executed case, concurrency included — check its `skipped` list, because scenarios you don't supply are unverified, not passed.
 
 The pool you hand it must run at `READ COMMITTED`, which is PostgreSQL's default: that is the level the single-statement reserve is built for, and under `REPEATABLE READ` or `SERIALIZABLE` two concurrent reserves abort with a serialization failure (surfaced as the usage store being unavailable) instead of one of them being cleanly denied.
 
-Applying the schema is your job, not the library's: `migrationSql()` from `llmswitch/postgres` returns the SQL and its sha256, and you run it with whatever tool you already use, in a schema dedicated to llmswitch. Re-running the same file is safe — every statement is idempotent, so "apply twice" and "re-run after a failure" are the same operation — and a *different* version-1 template is refused by the version record at the end of the file. The file carries no transaction control of its own, though, because migration tools differ on whether they supply theirs: a tool that commits statement by statement leaves the earlier DDL in place when that final record is the thing that conflicts, and re-running the same file is what completes a partial apply.
+Applying the schema is your job, not the library's: `migrationSql()` from `llmdispatch/postgres` returns the SQL and its sha256, and you run it with whatever tool you already use, in a schema dedicated to llmdispatch. Re-running the same file is safe — every statement is idempotent, so "apply twice" and "re-run after a failure" are the same operation — and a *different* version-1 template is refused by the version record at the end of the file. The file carries no transaction control of its own, though, because migration tools differ on whether they supply theirs: a tool that commits statement by statement leaves the earlier DDL in place when that final record is the thing that conflicts, and re-running the same file is what completes a partial apply.
 
 Apply the whole rendered file in one transaction on one connection, which is also what makes an advisory lock cover the DDL rather than just the call that took it:
 
@@ -228,12 +228,12 @@ COMMIT;
 ```
 
 ```ts
-import { migrationSql } from 'llmswitch/postgres'
+import { migrationSql } from 'llmdispatch/postgres'
 
-const { sql } = migrationSql({ schema: 'llmswitch' })   // your migration tool runs this
+const { sql } = migrationSql({ schema: 'llmdispatch' })   // your migration tool runs this
 ```
 
-Whatever store you write it against, the strings llmswitch hands a store — operation names, provider IDs, models, subject IDs, reservation IDs — are well-formed Unicode, free of U+0000, and at most 1 000 bytes of UTF-8, checked before every store call, so any relational backend can hold them verbatim (spec §6).
+Whatever store you write it against, the strings llmdispatch hands a store — operation names, provider IDs, models, subject IDs, reservation IDs — are well-formed Unicode, free of U+0000, and at most 1 000 bytes of UTF-8, checked before every store call, so any relational backend can hold them verbatim (spec §6).
 
 ## Providers
 
@@ -245,12 +245,12 @@ Whatever store you write it against, the strings llmswitch hands a store — ope
 
 Built-in adapters are **zero-dependency**: plain `fetch` against pinned API versions (with redirects disabled — exactly one HTTP request per attempt), no vendor SDKs to install, ever. They're ordinary implementations of the same public `Provider` interface, including its optional `prepare()` readiness hook — nothing built-in has special powers, so the package stays provider-agnostic by construction.
 
-Why two native adapters instead of routing everything through OpenAI-compatibility layers? Because we verified the compat layers break exactly what llmswitch depends on: Anthropic's compat endpoint ignores `response_format` entirely (no JSON mode) and is documented by Anthropic as a testing tool, and Gemini's is beta with token totals that silently include unitemized "thinking" tokens — which would corrupt cost tracking. The exact wire contracts and error mappings for all three adapters are spec §5c, with sources — also published as a per-adapter reference in [docs/providers.md](./docs/providers.md).
+Why two native adapters instead of routing everything through OpenAI-compatibility layers? Because we verified the compat layers break exactly what llmdispatch depends on: Anthropic's compat endpoint ignores `response_format` entirely (no JSON mode) and is documented by Anthropic as a testing tool, and Gemini's is beta with token totals that silently include unitemized "thinking" tokens — which would corrupt cost tracking. The exact wire contracts and error mappings for all three adapters are spec §5c, with sources — also published as a per-adapter reference in [docs/providers.md](./docs/providers.md).
 
 Custom providers implement one required method (plus an optional `prepare()` readiness hook) and classify their failures with `ProviderError` — the classification is what drives the fallback matrix. Full contract and types: spec §5–6.
 
 ```ts
-import { ProviderError, type Provider } from 'llmswitch'
+import { ProviderError, type Provider } from 'llmdispatch'
 
 const myProvider: Provider = {
   async complete(req) {
@@ -280,14 +280,14 @@ createSwitch({
 
 ## TypeScript
 
-Inference-first: operation names are typed (`ai.run('summarize', …)` compiles, `ai.run('sumarize', …)` doesn't), `input` checks against the operation's input schema, and `result.data` is the output schema's inferred type. All public types — `Provider`, `ProviderError`, `ConfigStore`, `UsageStore`, `LLMSwitchError`, `OperationDefinition` — are exported and specified in spec §6.
+Inference-first: operation names are typed (`ai.run('summarize', …)` compiles, `ai.run('sumarize', …)` doesn't), `input` checks against the operation's input schema, and `result.data` is the output schema's inferred type. All public types — `Provider`, `ProviderError`, `ConfigStore`, `UsageStore`, `LLMDispatchError`, `OperationDefinition` — are exported and specified in spec §6.
 
 ## Compatibility
 
 - **Node.js ≥ 20**, server-side only. Browsers and edge runtimes are not supported in v0.1.
 - **No bundled runtime dependencies** — **Zod 4** is the one required peer you install alongside it.
 - **ESM and CJS** both supported, with explicit `exports` and bundled type declarations.
-- Postgres adapter: PostgreSQL ≥ 14, bring your own pool (any object with a `query` method — `pg` works, but isn't required by llmswitch).
+- Postgres adapter: PostgreSQL ≥ 14, bring your own pool (any object with a `query` method — `pg` works, but isn't required by llmdispatch).
 
 ## Using it in your framework
 
@@ -303,7 +303,7 @@ export async function POST(req: Request) {
     const result = await ai.run('summarize', { input: parsed.data, subjectId: userId })
     return Response.json(result.data)
   } catch (err) {
-    return toHttpResponse(err)                     // map LLMSwitchError codes as in the Errors table
+    return toHttpResponse(err)                     // map LLMDispatchError codes as in the Errors table
   }
 }
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -110,7 +110,7 @@ staging.
    the workflow run. Then confirm it against the registry, and confirm it is the only one:
 
    ```bash
-   npm stage list llmswitch
+   npm stage list llmdispatch
    ```
 
    Exactly one stage for the version being released. If there is another — an abandoned
@@ -129,14 +129,14 @@ staging.
 7. Download it with `npm stage download <stage-id>`. This is the step with no web equivalent,
    and the reason for the CLI floors above; the Staged Packages tab is a fallback for reading
    the stage identifier and for the approval, never for this. The file arrives named for the
-   stage, as `llmswitch-<version>-<stage-id>.tgz`, so it does not collide with the artifact
+   stage, as `llmdispatch-<version>-<stage-id>.tgz`, so it does not collide with the artifact
    you unpacked in step 4.
 8. Verify those exact bytes. Because the download carries the stage identifier in its name,
    `sha256sum -c tarball.sha256` would check the artifact sitting beside it and pass while
    telling you nothing. Compare values instead:
 
    ```bash
-   sha256sum llmswitch-<version>-<stage-id>.tgz
+   sha256sum llmdispatch-<version>-<stage-id>.tgz
    cut -d' ' -f1 tarball.sha256
    ```
 
@@ -169,7 +169,7 @@ staging.
     expected="$(cut -d' ' -f1 tarball.sha512)"
     mkdir release-check && cd release-check
     npm init -y > /dev/null
-    npm install llmswitch@<version> --userconfig "$PWD/npm-scratch" \
+    npm install llmdispatch@<version> --userconfig "$PWD/npm-scratch" \
       --registry=https://registry.npmjs.org/
     npm audit signatures --json --include-attestations --userconfig "$PWD/npm-scratch" \
       --registry=https://registry.npmjs.org/ > signatures.json
@@ -182,14 +182,14 @@ staging.
     that has no attestation at all.
 
     What lands in `signatures.json` is `invalid`, `missing`, and a `verified` list. There must
-    be an entry there for `llmswitch`; no entry is itself the failure. Its attestations are
+    be an entry there for `llmdispatch`; no entry is itself the failure. Its attestations are
     Sigstore bundles, so the readable part is base64 inside each one and has to be decoded:
 
     ```bash
     node -e "
     const report = require('./signatures.json')
-    const entry = (report.verified || []).find((p) => p.name === 'llmswitch')
-    if (!entry) throw new Error('no verified attestation for llmswitch')
+    const entry = (report.verified || []).find((p) => p.name === 'llmdispatch')
+    if (!entry) throw new Error('no verified attestation for llmdispatch')
     for (const { predicateType, bundle } of entry.attestationBundles) {
       const payload = bundle.dsseEnvelope.payload
       const statement = JSON.parse(Buffer.from(payload, 'base64').toString())
@@ -211,7 +211,7 @@ staging.
     Then, separately, check the bytes on offer to installers:
 
     ```bash
-    npm view llmswitch@<version> dist.integrity --registry=https://registry.npmjs.org/
+    npm view llmdispatch@<version> dist.integrity --registry=https://registry.npmjs.org/
     ```
 
     That prints `sha512-` and the registry's digest for the tarball in base64; decode it with
@@ -222,20 +222,20 @@ staging.
 
     A missing attestation, a missing entry, or a digest that does not match is an incident on
     a version that is already installable. Deprecate it while you investigate —
-    `npm deprecate llmswitch@<version> "under investigation"` — rather than leaving it
+    `npm deprecate llmdispatch@<version> "under investigation"` — rather than leaving it
     recommended to everyone, and do not go on to step 11.
 
 11. Settle the dist-tags. Approval already applied `latest`, so the only question left is
     whether a stale tag is pointing somewhere it should not. Read them first:
 
     ```bash
-    npm dist-tag ls llmswitch
+    npm dist-tag ls llmdispatch
     ```
 
     In practice only the bootstrap leaves anything to do here, because the release candidate
     is what puts `next` on the package. If `next` is present, either move it —
-    `npm dist-tag add llmswitch@<version> next` — or remove it —
-    `npm dist-tag rm llmswitch next` — and read the tags back. If it is absent, there is
+    `npm dist-tag add llmdispatch@<version> next` — or remove it —
+    `npm dist-tag rm llmdispatch next` — and read the tags back. If it is absent, there is
     nothing to move and nothing to add. Then close the session.
 
 Consult `npm stage --help` for exact subcommand syntax at the time you run it: staged
@@ -361,20 +361,21 @@ npm will only let a trusted publisher be configured on a package that already ex
 very first version cannot go through the workflow. This section exists once. Follow it in
 order — several steps are ordered for a reason, noted where it matters.
 
-1. **Recheck the name.** Immediately before publishing, confirm `llmswitch` is still
-   unclaimed:
+1. **Recheck the name.** The name is already held by a `0.0.0` placeholder published from
+   this project, so the check is ownership, not absence. Immediately before publishing:
 
    ```bash
-   npm view llmswitch --registry=https://registry.npmjs.org/
+   npm view llmdispatch versions maintainers --registry=https://registry.npmjs.org/
    ```
 
-   It must fail with `E404`. The registry is named explicitly because a mirror or a corporate
-   proxy will happily return `E404` for a name that is taken on the public registry. If the
-   name has been claimed, **stop**. Moving to a scoped name is not a rename — the import
-   specifier is the package's public contract, and it appears in the README, the type
-   fixtures, the consumer tests, the examples and their lockfiles, and the verification
-   harnesses. That is a migration with every release gate re-run, and it needs planning on
-   its own.
+   It must show exactly the placeholder `0.0.0` and the maintainer account this document's
+   sessions sign in as. The registry is named explicitly because a mirror or a corporate
+   proxy can answer differently from the public registry. Anything else — extra versions, an
+   unfamiliar maintainer — means the name is not in the expected state: **stop** and find out
+   why before publishing. Moving to a different name is not a rename — the import specifier
+   is the package's public contract, and it appears in the README, the type fixtures, the
+   consumer tests, the examples and their lockfiles, and the verification harnesses. That is
+   a migration with every release gate re-run, and it needs planning on its own.
 
 2. **Build a release candidate.** Set the version to `0.1.0-rc.0` — this one bump is an
    exception to the changesets rule above, because the RC is not a stable release: edit
@@ -390,7 +391,7 @@ order — several steps are ordered for a reason, noted where it matters.
    session, as that exact tarball:
 
    ```bash
-   npm publish ./llmswitch-0.1.0-rc.0.tgz --tag=next --access=public --ignore-scripts
+   npm publish ./llmdispatch-0.1.0-rc.0.tgz --tag=next --access=public --ignore-scripts
    ```
 
    You must be presented with a 2FA challenge. If none appears, **stop** and find out why
@@ -411,7 +412,7 @@ order — several steps are ordered for a reason, noted where it matters.
    | Field             | Value               |
    | ----------------- | ------------------- |
    | GitHub owner      | `parvezrob`         |
-   | Repository        | `llmswitch`         |
+   | Repository        | `llmdispatch`       |
    | Workflow filename | `publish.yml`       |
    | Environment       | `release`           |
    | Allowed action    | `npm stage publish` |
@@ -459,9 +460,9 @@ order — several steps are ordered for a reason, noted where it matters.
 
 11. **Clean up the `next` tag**, as step 11 of that flow. Approving the stage applied `latest`
     to `0.1.0`; `next` is still on the RC until you move it —
-    `npm dist-tag add llmswitch@0.1.0 next` — or remove it —
-    `npm dist-tag rm llmswitch next`. Read the result back with
-    `npm dist-tag ls llmswitch` and check both tags say what you intended. These commands run
+    `npm dist-tag add llmdispatch@0.1.0 next` — or remove it —
+    `npm dist-tag rm llmdispatch next`. Read the result back with
+    `npm dist-tag ls llmdispatch` and check both tags say what you intended. These commands run
     in the same authenticated session as the approval, which is what pins the registry for
     them; a configured mirror would otherwise take them silently.
 

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -1,8 +1,8 @@
 import { C as RunResult, D as TokenUsage, E as Switch, O as UsageStore, S as RouteTarget, T as StorePair, _ as ProviderResponse, b as QuotaView, c as ModelPrice, d as OperationRoute, f as OperationsMap, g as ProviderRequest, h as ProviderErrorKind, i as ConfigStore, l as OperationConfigView, m as Provider, n as AttemptOutcome, o as CreateSwitchConfig, p as PreparedProvider, r as AttemptRecord, s as Logger, t as ApiKeyResolver, u as OperationDefinition, v as QualityVerdict, w as SettlementFailure, x as ReservationEnvelope, y as QuotaKey } from "./types.js";
 import { z } from "zod";
-//#region src/errors/llmswitch-error.d.ts
+//#region src/errors/llmdispatch-error.d.ts
 /** A classified failure: a stable `code`, a literal `retryable`, no dispatch content of its own. */
-declare class LLMSwitchError extends Error {
+declare class LLMDispatchError extends Error {
   private constructor();
   /** What went wrong, as a closed set (spec §5b). */
   readonly code: 'INVALID_INPUT' | 'MISSING_SUBJECT' | 'QUOTA_EXCEEDED' | 'USAGE_STORE_UNAVAILABLE' | 'CONFIG_STORE_UNAVAILABLE' | 'INVALID_CONFIG' | 'ABORTED' | 'PROVIDER_FAILED' | 'OUTPUT_REJECTED';
@@ -87,8 +87,8 @@ declare function memoryStores(): StorePair;
  *
  * @param opts `pool` is your own driver pool, which must run at `READ COMMITTED`
  * (PostgreSQL's default; a stricter level makes concurrent reserves abort rather than deny);
- * `schema` defaults to `llmswitch` and `leaseMs` to 120 000.
- * @throws `RangeError` when `schema` is not a name llmswitch may own, or `leaseMs` is outside
+ * `schema` defaults to `llmdispatch` and `leaseMs` to 120 000.
+ * @throws `RangeError` when `schema` is not a name llmdispatch may own, or `leaseMs` is outside
  * 5 000–600 000.
  */
 declare function postgresStores(opts: {
@@ -134,7 +134,7 @@ declare function defineOperations<Ops extends OperationsMap>(operations: Ops): O
  * here, loudly, rather than on the first request.
  *
  * @param config Who can be called, what the app does, and where config and counters live.
- * @throws `LLMSwitchError` with code `INVALID_CONFIG` naming the field that failed.
+ * @throws `LLMDispatchError` with code `INVALID_CONFIG` naming the field that failed.
  * @example
  * ```ts
  * const ai = createSwitch({ providers, operations, stores: memoryStores() })
@@ -143,5 +143,5 @@ declare function defineOperations<Ops extends OperationsMap>(operations: Ops): O
  */
 declare function createSwitch<Ops extends OperationsMap>(config: CreateSwitchConfig<Ops>): Switch<Ops>;
 //#endregion
-export { type ApiKeyResolver, type AttemptOutcome, type AttemptRecord, type ConfigStore, type CreateSwitchConfig, LLMSwitchError, type Logger, type ModelPrice, type OperationConfigView, type OperationDefinition, type OperationRoute, type OperationsMap, type PreparedProvider, type Provider, ProviderError, type ProviderErrorKind, type ProviderRequest, type ProviderResponse, type QualityVerdict, type QuotaKey, type QuotaView, type ReservationEnvelope, type RouteTarget, type RunResult, type SettlementFailure, type StorePair, type Switch, type TokenUsage, type UsageStore, anthropic, createSwitch, defineOperation, defineOperations, gemini, memoryStores, openaiCompatible, postgresStores };
+export { type ApiKeyResolver, type AttemptOutcome, type AttemptRecord, type ConfigStore, type CreateSwitchConfig, LLMDispatchError, type Logger, type ModelPrice, type OperationConfigView, type OperationDefinition, type OperationRoute, type OperationsMap, type PreparedProvider, type Provider, ProviderError, type ProviderErrorKind, type ProviderRequest, type ProviderResponse, type QualityVerdict, type QuotaKey, type QuotaView, type ReservationEnvelope, type RouteTarget, type RunResult, type SettlementFailure, type StorePair, type Switch, type TokenUsage, type UsageStore, anthropic, createSwitch, defineOperation, defineOperations, gemini, memoryStores, openaiCompatible, postgresStores };
 //# sourceMappingURL=index.d.ts.map

--- a/api/postgres.d.ts
+++ b/api/postgres.d.ts
@@ -2,7 +2,7 @@
 /**
  * The packaged migrations (spec §6b).
  *
- * llmswitch never runs DDL: it hands you the SQL and its hash, and you apply it with whatever
+ * llmdispatch never runs DDL: it hands you the SQL and its hash, and you apply it with whatever
  * tool you already use. The hash a version records is the hash of its template — the schema
  * placeholder still in place — so two adopters using different schema names still agree on
  * which version 1 they applied.
@@ -18,9 +18,9 @@ declare const MIGRATIONS: readonly {
   /**
    * Renders this migration for one schema.
    *
-   * @param opts `schema` defaults to `llmswitch` and is validated, then quoted.
+   * @param opts `schema` defaults to `llmdispatch` and is validated, then quoted.
    * @returns The SQL to apply, and the hash of exactly those bytes.
-   * @throws `RangeError` when the schema is not a name llmswitch may own.
+   * @throws `RangeError` when the schema is not a name llmdispatch may own.
    */
   render(opts?: {
     schema?: string;
@@ -33,8 +33,8 @@ declare const MIGRATIONS: readonly {
  * Every migration rendered for one schema and concatenated in version order, with the sha256
  * of exactly the bytes it hands back.
  *
- * @param opts `schema` defaults to `llmswitch` and is validated, then quoted.
- * @throws `RangeError` when the schema is not a name llmswitch may own.
+ * @param opts `schema` defaults to `llmdispatch` and is validated, then quoted.
+ * @throws `RangeError` when the schema is not a name llmdispatch may own.
  */
 declare function migrationSql(opts?: {
   schema?: string;
@@ -59,7 +59,7 @@ declare function migrationSql(opts?: {
  * Test harnesses that can only reach the store through an adopter-shaped pool recognise the
  * four usage statements by this prefix and substitute that trailing `null`.
  */
-declare const USAGE_STORE_MARKER = "/* llmswitch:usage-store */";
+declare const USAGE_STORE_MARKER = "/* llmdispatch:usage-store */";
 //#endregion
 export { MIGRATIONS, USAGE_STORE_MARKER, migrationSql };
 //# sourceMappingURL=postgres.d.ts.map

--- a/api/types.d.ts
+++ b/api/types.d.ts
@@ -7,7 +7,7 @@ interface Switch<Ops extends OperationsMap> {
   /**
    * Runs one operation end to end and resolves with its validated result.
    *
-   * @throws `LLMSwitchError` with the code the final classification maps to (spec §5b).
+   * @throws `LLMDispatchError` with the code the final classification maps to (spec §5b).
    */
   run<K extends keyof Ops & string>(operation: K, args: {
     input: z.input<Ops[K]['input']>;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,9 +12,9 @@ the pieces are arranged so it can keep doing it.
 ```mermaid
 graph TD
   subgraph entries["entry points (what the manifest exports)"]
-    root["index.ts<br/><i>llmswitch</i>"]
-    pg["postgres.ts<br/><i>llmswitch/postgres</i>"]
-    conf["conformance.ts<br/><i>llmswitch/conformance</i>"]
+    root["index.ts<br/><i>llmdispatch</i>"]
+    pg["postgres.ts<br/><i>llmdispatch/postgres</i>"]
+    conf["conformance.ts<br/><i>llmdispatch/conformance</i>"]
   end
 
   core["core/<br/>decisions, no I/O"]
@@ -50,7 +50,7 @@ changes most often — the adapters — sits where nothing depends on it.
 **`types.ts`** is the floor: every shape the package publishes, declared once from spec §6,
 importing nothing but Zod.
 
-**`errors/`** is the bottom layer of behaviour. Two public classes: `LLMSwitchError`, with a
+**`errors/`** is the bottom layer of behaviour. Two public classes: `LLMDispatchError`, with a
 closed set of codes, the typed factories that construct it, and the literal `retryable` of
 the spec §5b classification row — the row, not the code, since `PROVIDER_FAILED` is retryable
 for a `transient` failure and not for a `refused` one; and `ProviderError`, which an adapter

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,6 +1,6 @@
-# llmswitch v0.1 — Normative Specification
+# llmdispatch v0.1 — Normative Specification
 
-This document is the exact contract for llmswitch v0.1. The [README](../README.md) is the
+This document is the exact contract for llmdispatch v0.1. The [README](../README.md) is the
 introduction; when they disagree, this spec wins. §8 defines the adopter-facing conformance
 suite; the core's own behavior (state machine, matrices, sanitization, type inference) is
 enforced by the package's internal test suite, including compile-time positive and negative
@@ -262,7 +262,7 @@ implementing exactly this.
   fallback-eligible unless `fallbackOnAuthOrModelNotFound` (§6) is on, and the flag governs
   a **primary** attempt only — it never introduces a second fallback and does not touch the
   local `INVALID_CONFIG` paths above. `detectedAt` is a property of the thrown
-  `LLMSwitchError`, never of an `AttemptRecord` (§6), and `detectedAt:'provider'` is set only
+  `LLMDispatchError`, never of an `AttemptRecord` (§6), and `detectedAt:'provider'` is set only
   when the terminal code is `INVALID_CONFIG` from the final attempt: a primary rescued by its
   fallback contributes an attempt record with outcome `auth`/`model_not_found` and the run
   raises no error at all, while a fallback that itself ends `auth`/`model_not_found` is
@@ -289,7 +289,7 @@ implementing exactly this.
 Pre-dispatch codes: `USAGE_STORE_UNAVAILABLE` / `CONFIG_STORE_UNAVAILABLE` → `true`;
 `QUOTA_EXCEEDED` → `false` (`resetsAt` carries timing); `INVALID_INPUT`,
 `MISSING_SUBJECT`, `ABORTED` → `false`; `INVALID_CONFIG` → `false` except the §5a
-transient-prepare case. `LLMSwitchError.retryable` is always the literal boolean from these
+transient-prepare case. `LLMDispatchError.retryable` is always the literal boolean from these
 tables.
 
 - Terminal code = final attempt's row; all dispatched attempts appear in
@@ -297,10 +297,10 @@ tables.
 - Fallback: at most once, only if configured, shares the run's slot.
 - Built-in adapters make exactly one client-side HTTP request per attempt: `redirect:
   'error'` on every fetch (a 3xx → `transient`; no prompt/credential ever reaches a
-  redirect target); no retries in llmswitch's own HTTP layer. (Gateway hosts may retry
+  redirect target); no retries in llmdispatch's own HTTP layer. (Gateway hosts may retry
   upstream internally — outside our boundary.)
 - **ProviderError recognition is brand-based, never bare `instanceof`**: the class carries
-  `Symbol.for('llmswitch.ProviderError')` and exposes `ProviderError.is(value)`; the core
+  `Symbol.for('llmdispatch.ProviderError')` and exposes `ProviderError.is(value)`; the core
   classifies with `.is()` so a `ProviderError` crossing ESM/CJS entry points (dual-package
   hazard) still classifies correctly.
 - Invalid usage numbers never fail a run: they normalize to `null`.
@@ -583,12 +583,12 @@ export interface UsageStore {
 export declare function memoryStores(): StorePair
 export declare function postgresStores(opts: {
   pool: { query(sql: string, params?: unknown[]): Promise<{ rows: unknown[] }> }
-  schema?: string                                        // default 'llmswitch'; validated identifier
+  schema?: string                                        // default 'llmdispatch'; validated identifier
   leaseMs?: number                                       // default 120_000; 5_000–600_000
 }): StorePair
 
 // ——— errors ———
-export declare class LLMSwitchError extends Error {
+export declare class LLMDispatchError extends Error {
   private constructor()                                  // instances come from the package; narrow on `code`
   readonly code: 'INVALID_INPUT' | 'MISSING_SUBJECT' | 'QUOTA_EXCEEDED'
     | 'USAGE_STORE_UNAVAILABLE' | 'CONFIG_STORE_UNAVAILABLE' | 'INVALID_CONFIG'
@@ -639,7 +639,7 @@ store that had to narrow the domain itself would not be substitutable.
 ## 6b. Packaged operational surfaces (exact declarations)
 
 ```ts
-// subpath: llmswitch/postgres
+// subpath: llmdispatch/postgres
 export declare const MIGRATIONS: ReadonlyArray<{
   version: number
   templateSha256: string                                  // hash of the canonical template (schema placeholder form)
@@ -653,7 +653,7 @@ export declare function migrationSql(opts?: { schema?: string }): { sql: string;
 // their trailing clock parameter (see the conformance note below).
 export declare const USAGE_STORE_MARKER: string
 
-// subpath: llmswitch/conformance
+// subpath: llmdispatch/conformance
 export interface ConformanceResult { passed: boolean; failures: string[]; skipped: string[] }
 export declare function runUsageStoreConformance(opts: {
   // create returns the store under test plus REQUIRED test controls:

--- a/examples/express/README.md
+++ b/examples/express/README.md
@@ -1,9 +1,9 @@
 # Express example
 
-A minimal Express server with one llmswitch operation behind it.
+A minimal Express server with one llmdispatch operation behind it.
 
 - `switch.js` — the switch: one provider, one `summarize` operation, in-memory stores.
-- `server.js` — `POST /summarize`, with `LLMSwitchError` codes mapped to HTTP statuses,
+- `server.js` — `POST /summarize`, with `LLMDispatchError` codes mapped to HTTP statuses,
   and `GET /healthz`.
 
 Plain ESM JavaScript. The route is `openaiCompatible`, so it works against OpenAI or any
@@ -16,7 +16,7 @@ Nothing here is special to this repository except how the dependency is installe
 section below). In your own project it is simply:
 
 ```bash
-npm install llmswitch zod
+npm install llmdispatch zod
 ```
 
 Then copy `switch.js` and `server.js` and replace the `demo-user` subject with the user id
@@ -30,7 +30,7 @@ against the bytes that would be published. Two steps:
 ```bash
 # from the repository root
 tgz=$(npm pack --silent --pack-destination examples/express)
-mv "examples/express/$tgz" examples/express/llmswitch-local.tgz
+mv "examples/express/$tgz" examples/express/llmdispatch-local.tgz
 ```
 
 Then, in this directory:
@@ -41,7 +41,7 @@ OPENAI_API_KEY=your-key npm start
 ```
 
 The committed `package-lock.json` pins the transitive tree but records no checksum
-for `llmswitch-local.tgz`: you pack that file yourself, so its bytes are yours.
+for `llmdispatch-local.tgz`: you pack that file yourself, so its bytes are yours.
 
 ```bash
 curl -s localhost:3000/summarize \

--- a/examples/express/package-lock.json
+++ b/examples/express/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "llmswitch-example-express",
+  "name": "llmdispatch-example-express",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "llmswitch-example-express",
+      "name": "llmdispatch-example-express",
       "version": "0.0.0",
       "dependencies": {
         "express": "5.2.1",
-        "llmswitch": "file:./llmswitch-local.tgz",
+        "llmdispatch": "file:./llmdispatch-local.tgz",
         "zod": "4.4.3"
       }
     },
@@ -462,9 +462,9 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
-    "node_modules/llmswitch": {
+    "node_modules/llmdispatch": {
       "version": "0.1.0",
-      "resolved": "file:llmswitch-local.tgz",
+      "resolved": "file:llmdispatch-local.tgz",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "llmswitch-example-express",
+  "name": "llmdispatch-example-express",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "5.2.1",
-    "llmswitch": "file:./llmswitch-local.tgz",
+    "llmdispatch": "file:./llmdispatch-local.tgz",
     "zod": "4.4.3"
   }
 }

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -1,5 +1,5 @@
 import express from 'express'
-import { LLMSwitchError } from 'llmswitch'
+import { LLMDispatchError } from 'llmdispatch'
 
 import { SummarizeBody, ai } from './switch.js'
 
@@ -57,7 +57,7 @@ app.post('/summarize', async (request, response) => {
       usedFallback: result.usedFallback,
     })
   } catch (error) {
-    if (error instanceof LLMSwitchError) {
+    if (error instanceof LLMDispatchError) {
       response.status(STATUS_BY_CODE[error.code] ?? 500).json({ error: error.code })
       return
     }

--- a/examples/express/switch.js
+++ b/examples/express/switch.js
@@ -4,7 +4,7 @@ import {
   defineOperations,
   memoryStores,
   openaiCompatible,
-} from 'llmswitch'
+} from 'llmdispatch'
 import { z } from 'zod'
 
 /** The body `POST /summarize` accepts, checked before the switch ever sees it. */

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -1,9 +1,9 @@
 # Next.js example
 
-A Next.js App Router project with one llmswitch operation behind a route handler.
+A Next.js App Router project with one llmdispatch operation behind a route handler.
 
 - `lib/switch.ts` — the switch: one provider, one `summarize` operation, in-memory stores.
-- `app/api/summarize/route.ts` — `POST`, with `LLMSwitchError` codes mapped to HTTP
+- `app/api/summarize/route.ts` — `POST`, with `LLMDispatchError` codes mapped to HTTP
   statuses.
 - `app/api/healthz/route.ts` — `GET`.
 
@@ -17,7 +17,7 @@ Nothing here is special to this repository except how the dependency is installe
 section below). In your own project it is simply:
 
 ```bash
-npm install llmswitch zod
+npm install llmdispatch zod
 ```
 
 Then copy `lib/switch.ts` and the route handler, and replace the `demo-user` subject with
@@ -31,7 +31,7 @@ against the bytes that would be published. Two steps:
 ```bash
 # from the repository root
 tgz=$(npm pack --silent --pack-destination examples/next)
-mv "examples/next/$tgz" examples/next/llmswitch-local.tgz
+mv "examples/next/$tgz" examples/next/llmdispatch-local.tgz
 ```
 
 Then, in this directory:
@@ -43,7 +43,7 @@ OPENAI_API_KEY=your-key npm start
 ```
 
 The committed `package-lock.json` pins the transitive tree but records no checksum
-for `llmswitch-local.tgz`: you pack that file yourself, so its bytes are yours.
+for `llmdispatch-local.tgz`: you pack that file yourself, so its bytes are yours.
 
 ```bash
 curl -s localhost:3000/api/summarize \

--- a/examples/next/app/api/summarize/route.ts
+++ b/examples/next/app/api/summarize/route.ts
@@ -1,9 +1,9 @@
-import { LLMSwitchError } from 'llmswitch'
+import { LLMDispatchError } from 'llmdispatch'
 
 import { SummarizeBody, ai } from '../../../lib/switch'
 
 /** The mapping from the README's error table. */
-const STATUS_BY_CODE: Record<LLMSwitchError['code'], number> = {
+const STATUS_BY_CODE: Record<LLMDispatchError['code'], number> = {
   INVALID_INPUT: 400,
   MISSING_SUBJECT: 500,
   CONFIG_STORE_UNAVAILABLE: 503,
@@ -48,7 +48,7 @@ export async function POST(request: Request): Promise<Response> {
       usedFallback: result.usedFallback,
     })
   } catch (error) {
-    if (error instanceof LLMSwitchError) {
+    if (error instanceof LLMDispatchError) {
       return Response.json({ error: error.code }, { status: STATUS_BY_CODE[error.code] })
     }
     // Anything else is a bug in this application's own callbacks.

--- a/examples/next/lib/switch.ts
+++ b/examples/next/lib/switch.ts
@@ -4,7 +4,7 @@ import {
   defineOperations,
   memoryStores,
   openaiCompatible,
-} from 'llmswitch'
+} from 'llmdispatch'
 import { z } from 'zod'
 
 /** The body `POST /api/summarize` accepts, checked before the switch ever sees it. */

--- a/examples/next/package-lock.json
+++ b/examples/next/package-lock.json
@@ -1,14 +1,14 @@
 {
-  "name": "llmswitch-example-next",
+  "name": "llmdispatch-example-next",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "llmswitch-example-next",
+      "name": "llmdispatch-example-next",
       "version": "0.0.0",
       "dependencies": {
-        "llmswitch": "file:./llmswitch-local.tgz",
+        "llmdispatch": "file:./llmdispatch-local.tgz",
         "next": "16.3.3",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -1149,9 +1149,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/llmswitch": {
+    "node_modules/llmdispatch": {
       "version": "0.1.0",
-      "resolved": "file:llmswitch-local.tgz",
+      "resolved": "file:llmdispatch-local.tgz",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "llmswitch-example-next",
+  "name": "llmdispatch-example-next",
   "version": "0.0.0",
   "private": true,
   "scripts": {
@@ -7,7 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "llmswitch": "file:./llmswitch-local.tgz",
+    "llmdispatch": "file:./llmdispatch-local.tgz",
     "next": "16.3.3",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "llmswitch",
+  "name": "llmdispatch",
   "version": "0.1.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "llmswitch",
+      "name": "llmdispatch",
       "version": "0.1.0-rc.0",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "llmswitch",
+  "name": "llmdispatch",
   "version": "0.1.0-rc.0",
   "description": "Per-operation routing across LLM providers with fallback and daily quotas",
   "keywords": [
@@ -11,11 +11,11 @@
     "fallback",
     "quota"
   ],
-  "homepage": "https://github.com/parvezrob/llmswitch",
-  "bugs": "https://github.com/parvezrob/llmswitch/issues",
+  "homepage": "https://github.com/parvezrob/llmdispatch",
+  "bugs": "https://github.com/parvezrob/llmdispatch/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/parvezrob/llmswitch.git"
+    "url": "git+https://github.com/parvezrob/llmdispatch.git"
   },
   "license": "MIT",
   "type": "module",

--- a/scripts/check-spec-surface.mjs
+++ b/scripts/check-spec-surface.mjs
@@ -36,8 +36,8 @@ const ENTRY_POINTS = [
 
 /** The comments §6b uses to say which subpath the declarations under them belong to. */
 const SUBPATH_MARKERS = {
-  postgres: '// subpath: llmswitch/postgres',
-  conformance: '// subpath: llmswitch/conformance',
+  postgres: '// subpath: llmdispatch/postgres',
+  conformance: '// subpath: llmdispatch/conformance',
 }
 
 /** A section: its heading down to the next one of the same level. */

--- a/scripts/check-types-fixtures.mjs
+++ b/scripts/check-types-fixtures.mjs
@@ -30,17 +30,17 @@ const SCAFFOLD = join(TYPES_DIR, 'scaffold.d.ts')
 const README = join(ROOT, 'README.md')
 const USAGE = 'usage: check-types-fixtures.mjs [--target spec|package]\n'
 
-/** Where `llmswitch` and its subpaths point for each target. */
+/** Where `llmdispatch` and its subpaths point for each target. */
 const TARGETS = {
   spec: {
-    llmswitch: './spec-surface.d.ts',
-    'llmswitch/postgres': './spec-surface-postgres.d.ts',
-    'llmswitch/conformance': './spec-surface-conformance.d.ts',
+    llmdispatch: './spec-surface.d.ts',
+    'llmdispatch/postgres': './spec-surface-postgres.d.ts',
+    'llmdispatch/conformance': './spec-surface-conformance.d.ts',
   },
   package: {
-    llmswitch: '../../dist/index.d.ts',
-    'llmswitch/postgres': '../../dist/postgres.d.ts',
-    'llmswitch/conformance': '../../dist/conformance.d.ts',
+    llmdispatch: '../../dist/index.d.ts',
+    'llmdispatch/postgres': '../../dist/postgres.d.ts',
+    'llmdispatch/conformance': '../../dist/conformance.d.ts',
   },
 }
 

--- a/scripts/lib/consumer-project.mjs
+++ b/scripts/lib/consumer-project.mjs
@@ -3,7 +3,7 @@
  * there.
  *
  * Projects are always created outside the repository: one under the working tree would find
- * the repository's own `node_modules` on the way up, and its resolution of `llmswitch` would
+ * the repository's own `node_modules` on the way up, and its resolution of `llmdispatch` would
  * stop being evidence about the tarball.
  *
  * @module
@@ -158,13 +158,13 @@ export function createConsumerProject(opts) {
   mkdirSync(directory, { recursive: true })
   mkdirSync(home, { recursive: true })
 
-  // Named for what it is and never `llmswitch`: a project carrying the package's own name
+  // Named for what it is and never `llmdispatch`: a project carrying the package's own name
   // would resolve the subpaths to itself, which is the one thing the guard exists to catch.
   writeFileSync(
     join(directory, 'package.json'),
     `${JSON.stringify(
       {
-        name: `llmswitch-${opts.name}`,
+        name: `llmdispatch-${opts.name}`,
         version: '0.0.0',
         private: true,
         type: 'module',

--- a/scripts/lib/installed-package.mjs
+++ b/scripts/lib/installed-package.mjs
@@ -96,7 +96,7 @@ export function unpackReference(tarballPath, workspace) {
  * same-named package fetched from the registry, which is the one thing it must not do.
  */
 export function checkInstalledIsTheTarball(project, reference, name, problems) {
-  const installed = join(project, 'node_modules', 'llmswitch')
+  const installed = join(project, 'node_modules', 'llmdispatch')
   if (!existsSync(installed)) {
     problems.push(`${name}: the package was not installed`)
     return

--- a/scripts/lib/subpath-resolution.mjs
+++ b/scripts/lib/subpath-resolution.mjs
@@ -3,7 +3,7 @@
  * installed the package.
  *
  * A checkout of this package resolves its own name: the manifest's `name` together with its
- * `exports` makes `llmswitch/postgres` reach `dist/` from any file inside the working tree.
+ * `exports` makes `llmdispatch/postgres` reach `dist/` from any file inside the working tree.
  * A verification runner left in the repository would therefore import the tree it is meant to
  * be judging and report a pass with the tarball never involved. So the runner and this module
  * are copied into the scratch project, next to the `node_modules` the tarball was installed
@@ -60,10 +60,10 @@ export function publishedSubpaths(manifest) {
  * @returns Each subpath with the file it resolved to, in the order they were asked for.
  * @throws `Error` when the package is not installed here, when its manifest publishes nothing
  * this check can resolve, when a subpath does not resolve at all, or when one resolves to a
- * file anywhere outside `node_modules/llmswitch`.
+ * file anywhere outside `node_modules/llmdispatch`.
  */
 export function assertInstalledPackageResolves() {
-  const installed = join(projectDirectory(), 'node_modules', 'llmswitch')
+  const installed = join(projectDirectory(), 'node_modules', 'llmdispatch')
   if (!existsSync(installed)) {
     throw new Error(`the package is not installed at ${installed}`)
   }

--- a/scripts/live-check-providers.mjs
+++ b/scripts/live-check-providers.mjs
@@ -124,7 +124,7 @@ async function main() {
     return 2
   }
 
-  const workspace = mkdtempSync(join(tmpdir(), 'llmswitch-live-check-'))
+  const workspace = mkdtempSync(join(tmpdir(), 'llmdispatch-live-check-'))
   removeOnSignal(workspace)
   const problems = []
   let ran = 0

--- a/scripts/runners/live-check.mjs
+++ b/scripts/runners/live-check.mjs
@@ -110,8 +110,8 @@ async function main() {
       return 1
     }
   }
-  const llmswitch = await import('llmswitch')
-  const { ProviderError } = llmswitch
+  const llmdispatch = await import('llmdispatch')
+  const { ProviderError } = llmdispatch
 
   const keyName = KEYS[provider]
   const apiKey = process.env[keyName] ?? ''
@@ -122,15 +122,15 @@ async function main() {
   }
 
   const build = {
-    anthropic: () => llmswitch.anthropic({ apiKey: () => Promise.resolve(apiKey) }),
-    gemini: () => llmswitch.gemini({ apiKey: () => Promise.resolve(apiKey) }),
+    anthropic: () => llmdispatch.anthropic({ apiKey: () => Promise.resolve(apiKey) }),
+    gemini: () => llmdispatch.gemini({ apiKey: () => Promise.resolve(apiKey) }),
     'openai-compatible': () => {
       const options = { apiKey: () => Promise.resolve(apiKey) }
       // In release mode the parent refuses to pass an override at all, so this is the
       // adapter's own default endpoint; locally an override may travel and is honoured.
       const baseUrl = process.env.OPENAI_BASE_URL ?? ''
       if (!release && baseUrl !== '') options.baseUrl = baseUrl
-      return llmswitch.openaiCompatible(options)
+      return llmdispatch.openaiCompatible(options)
     },
   }
   const prepared = await build[provider]().prepare()

--- a/scripts/runners/release-conformance.mjs
+++ b/scripts/runners/release-conformance.mjs
@@ -43,9 +43,9 @@ let installed = null
 /** Imports all three subpaths. Only ever called after `assertInstalledPackageResolves`. */
 async function importInstalledPackage() {
   return {
-    package: await import('llmswitch'),
-    postgres: await import('llmswitch/postgres'),
-    conformance: await import('llmswitch/conformance'),
+    package: await import('llmdispatch'),
+    postgres: await import('llmdispatch/postgres'),
+    conformance: await import('llmdispatch/conformance'),
   }
 }
 

--- a/scripts/scan-denylist.mjs
+++ b/scripts/scan-denylist.mjs
@@ -61,7 +61,7 @@ const ALLOWED_ADDRESSES = new Set(['48731060+parvezrob@users.noreply.github.com'
 const PLACEHOLDER_DOMAIN = 'exam' + 'ple.com'
 /** Repositories we link to on purpose: this one, and the tools the workflows pin. */
 const ALLOWED_REPOSITORIES = new Set([
-  'parvezrob/llmswitch',
+  'parvezrob/llmdispatch',
   'gitleaks/gitleaks',
   'actions/checkout',
   'actions/setup-node',
@@ -496,7 +496,7 @@ function buildNearMisses(root) {
   )
   write(
     'ok-repo.md',
-    'see ' + 'ht' + 'tps://' + 'git' + 'hub' + '.com/parvezrob/llmswitch' + '\n',
+    'see ' + 'ht' + 'tps://' + 'git' + 'hub' + '.com/parvezrob/llmdispatch' + '\n',
   )
   write('ok-import.ts', "import thing from './thing.js'\n")
   write(

--- a/scripts/test-consumers.mjs
+++ b/scripts/test-consumers.mjs
@@ -32,11 +32,11 @@ const TYPESCRIPT = 'typescript@5.9.3'
 /** Only the TypeScript fixture needs a driver: it is there to prove a real pool compiles. */
 const DRIVER = ['pg@8.23.0', '@types/pg@8.23.1', '@types/node@20.19.43']
 
-const SUBPATHS = ['llmswitch', 'llmswitch/postgres', 'llmswitch/conformance']
+const SUBPATHS = ['llmdispatch', 'llmdispatch/postgres', 'llmdispatch/conformance']
 const DECLARATIONS = {
-  index: 'llmswitch',
-  postgres: 'llmswitch/postgres',
-  conformance: 'llmswitch/conformance',
+  index: 'llmdispatch',
+  postgres: 'llmdispatch/postgres',
+  conformance: 'llmdispatch/conformance',
 }
 
 /** Enough for any plausible run; more than this is a runaway, and a runaway is a failure. */
@@ -98,7 +98,7 @@ function checkResolutions(trace, problems) {
   ]
   for (const { file, extension } of cases) {
     for (const [entry, specifier] of Object.entries(DECLARATIONS)) {
-      const expected = `node_modules/llmswitch/dist/${entry}${extension}`
+      const expected = `node_modules/llmdispatch/dist/${entry}${extension}`
       const hit = resolutions.some(
         (r) => r.specifier === specifier && r.from.endsWith(file) && r.to.endsWith(expected),
       )
@@ -186,7 +186,7 @@ function main() {
     problems.length === 0
       ? `all fixtures reached ${String(SUBPATHS.length)} entry points, recognised a ProviderError ` +
           'across the ESM and CommonJS builds in both directions, rejected the values that only ' +
-          'look like one, narrowed LLMSwitchError by code, and round-tripped a reservation ' +
+          'look like one, narrowed LLMDispatchError by code, and round-tripped a reservation ' +
           'through the in-memory stores, and rendered the same packaged migration from both ' +
           `builds — from sha256 ${before}\n`
       : `${String(problems.length)} problem(s)\n`,

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -63,8 +63,8 @@ const MODEL = 'gpt-4.1-mini'
 /** Not a key and not shaped like one: the fixture only checks that it arrives verbatim. */
 const FIXTURE_KEY = 'fixture-credential-for-the-examples-harness'
 /** How every example must declare the package, and how its lockfile must resolve it. */
-const LOCAL_SPEC = 'file:./llmswitch-local.tgz'
-const LOCAL_RESOLVED = 'file:llmswitch-local.tgz'
+const LOCAL_SPEC = 'file:./llmdispatch-local.tgz'
+const LOCAL_RESOLVED = 'file:llmdispatch-local.tgz'
 
 /** One per stage, so a slow install and a hung server fail as different things. */
 const DEADLINES = {
@@ -576,27 +576,27 @@ function checkLockfileShape(lockfile, name, problems) {
     problems.push(`${name}: package-lock.json has no package tree`)
     return false
   }
-  const local = packages['node_modules/llmswitch']
+  const local = packages['node_modules/llmdispatch']
   if (local === undefined) {
-    problems.push(`${name}: package-lock.json does not install llmswitch at the tree root`)
+    problems.push(`${name}: package-lock.json does not install llmdispatch at the tree root`)
     return false
   }
   // Where the package comes from, not just where it lands. Dropping the checksum below is
   // only safe because the source is this file: a lockfile edited to name a registry copy
   // would have no checksum either, and would otherwise walk straight through that waiver.
-  if (packages['']?.dependencies?.llmswitch !== LOCAL_SPEC) {
-    problems.push(`${name}: package.json must depend on llmswitch as '${LOCAL_SPEC}'`)
+  if (packages['']?.dependencies?.llmdispatch !== LOCAL_SPEC) {
+    problems.push(`${name}: package.json must depend on llmdispatch as '${LOCAL_SPEC}'`)
     return false
   }
   if (local.resolved !== LOCAL_RESOLVED) {
     problems.push(
-      `${name}: package-lock.json resolves llmswitch from ${String(local.resolved)}, ` +
+      `${name}: package-lock.json resolves llmdispatch from ${String(local.resolved)}, ` +
         `not the packed tarball at ${LOCAL_RESOLVED}`,
     )
     return false
   }
   if (local.link === true) {
-    problems.push(`${name}: package-lock.json links llmswitch rather than unpacking it`)
+    problems.push(`${name}: package-lock.json links llmdispatch rather than unpacking it`)
     return false
   }
   // The local tarball is packed fresh for every run, so no committed checksum can describe
@@ -605,7 +605,7 @@ function checkLockfileShape(lockfile, name, problems) {
   // tarball itself — which only holds while nothing else can supply the package.
   if (local.integrity !== undefined) {
     problems.push(
-      `${name}: package-lock.json records a checksum for llmswitch-local.tgz — ` +
+      `${name}: package-lock.json records a checksum for llmdispatch-local.tgz — ` +
         'regenerate it and drop that field, or no packed tarball but that one will install',
     )
     return false
@@ -619,8 +619,10 @@ function checkLockfileShape(lockfile, name, problems) {
     }
   }
   for (const path of Object.keys(packages)) {
-    if (path !== 'node_modules/llmswitch' && path.endsWith('/llmswitch')) {
-      problems.push(`${name}: package-lock.json installs a second copy of llmswitch at ${path}`)
+    if (path !== 'node_modules/llmdispatch' && path.endsWith('/llmdispatch')) {
+      problems.push(
+        `${name}: package-lock.json installs a second copy of llmdispatch at ${path}`,
+      )
       return false
     }
   }
@@ -655,7 +657,7 @@ function assembleProject(descriptor, workspace, tarball, problems) {
   const lockfile = JSON.parse(readFileSync(join(project, 'package-lock.json'), 'utf8'))
   if (!checkLockfileShape(lockfile, descriptor.name, problems)) return null
 
-  copyFileSync(tarball, join(project, 'llmswitch-local.tgz'))
+  copyFileSync(tarball, join(project, 'llmdispatch-local.tgz'))
   return project
 }
 
@@ -926,7 +928,7 @@ async function main() {
     }
   }
 
-  const workspace = mkdtempSync(join(tmpdir(), 'llmswitch-examples-'))
+  const workspace = mkdtempSync(join(tmpdir(), 'llmdispatch-examples-'))
   shutdown.directories.add(workspace)
   const problems = []
   try {

--- a/scripts/verify-quickstart.mjs
+++ b/scripts/verify-quickstart.mjs
@@ -5,11 +5,11 @@
  * Extraction is the strict one the fixture checker also applies: the `## Quickstart`
  * section must contain exactly one `bash` install fence followed by one `ts` code fence.
  * The install is the documented command with only the unpublished registry argument
- * `llmswitch` replaced by the tarball path; the code fence is written byte-for-byte to its
+ * `llmdispatch` replaced by the tarball path; the code fence is written byte-for-byte to its
  * own file — never edited, wrapped or rewritten — and executed by a two-line harness that
  * imports it. The child environment is the shared allowlist, which carries no provider key
  * and no `NODE_OPTIONS`, so the run cannot become live billed traffic and nothing preloaded
- * can put a key back: without a key, the documented outcome is an `LLMSwitchError`
+ * can put a key back: without a key, the documented outcome is an `LLMDispatchError`
  * with code `INVALID_CONFIG` from the unresolvable key, and that exact rejection is the
  * pass condition. Anything else — a ReferenceError, a different code, a run that resolves —
  * means the printed quickstart is wrong.
@@ -36,17 +36,17 @@ const USAGE = 'usage: verify-quickstart.mjs [path-to-tarball]\n'
 
 /**
  * The harness: import the printed file, require the documented rejection — a real
- * `LLMSwitchError` from the installed package, `INVALID_CONFIG`, detected locally (the
+ * `LLMDispatchError` from the installed package, `INVALID_CONFIG`, detected locally (the
  * unresolvable key), never a dispatched provider rejection.
  */
-const HARNESS = `import { LLMSwitchError } from 'llmswitch'
+const HARNESS = `import { LLMDispatchError } from 'llmdispatch'
 try {
   await import('./quickstart.ts')
   console.error('the quickstart ran to completion without an API key — expected INVALID_CONFIG')
   process.exit(1)
 } catch (error) {
   if (
-    error instanceof LLMSwitchError &&
+    error instanceof LLMDispatchError &&
     error.code === 'INVALID_CONFIG' &&
     error.detectedAt === 'local'
   ) {
@@ -71,9 +71,9 @@ function main() {
     for (const problem of problems) process.stderr.write(`${problem}\n`)
     return 1
   }
-  if (quickstart.install !== 'npm install llmswitch zod') {
+  if (quickstart.install !== 'npm install llmdispatch zod') {
     process.stderr.write(
-      `README.md ## Quickstart: the install fence reads '${quickstart.install}', not the documented 'npm install llmswitch zod' this script derives from\n`,
+      `README.md ## Quickstart: the install fence reads '${quickstart.install}', not the documented 'npm install llmdispatch zod' this script derives from\n`,
     )
     return 1
   }
@@ -93,7 +93,7 @@ function main() {
     }
   }
 
-  const directory = mkdtempSync(join(tmpdir(), 'llmswitch-quickstart-'))
+  const directory = mkdtempSync(join(tmpdir(), 'llmdispatch-quickstart-'))
   // A home of its own, so npm's cache and any config a tool writes for itself go away
   // with the run rather than reaching into the machine's real one.
   const home = join(directory, 'home')
@@ -122,7 +122,7 @@ function main() {
     // no user npmrc is in reach.
     const install = quickstart.install
       .split(' ')
-      .map((word) => (word === 'llmswitch' ? tarball : word))
+      .map((word) => (word === 'llmdispatch' ? tarball : word))
     step = 'installing the documented packages'
     execFileSync('npm', install.slice(1), {
       cwd: directory,

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -19,12 +19,12 @@
  *
  * A database for the run, thrown away with the container:
  *
- *   docker run --rm -d --name llmswitch-verify-db -p 127.0.0.1:5433:5432 \
+ *   docker run --rm -d --name llmdispatch-verify-db -p 127.0.0.1:5433:5432 \
  *     -e POSTGRES_PASSWORD=<throwaway> \
  *     postgres:14@sha256:2fdfb9b432d4a73bd3eea3d989752c1e669b68d502347e0bfd2cc6d709f3d6b4
  *   export DATABASE_URL=postgres://postgres:<throwaway>@127.0.0.1:5433/postgres
  *   npm run verify:release -- <path-to-tgz>
- *   docker rm -f llmswitch-verify-db
+ *   docker rm -f llmdispatch-verify-db
  *
  * The image is pinned by digest so two runs a month apart are the same check.
  * Exit codes: 0 verified, 1 a check failed, 2 wrong usage or a missing database.
@@ -51,7 +51,7 @@ const USAGE = 'usage: verify-release.mjs <path-to-tgz>\n'
 const RUNNER = join(import.meta.dirname, 'runners', 'release-conformance.mjs')
 const TEMPLATE = join(import.meta.dirname, 'fixtures', 'openai-chat-completion.json')
 
-/** What a project installing llmswitch has to bring: the declared peer and the driver. */
+/** What a project installing llmdispatch has to bring: the declared peer and the driver. */
 const PEERS = ['zod', 'pg', 'pg-connection-string']
 
 /** Long enough for the suites on a cold database, short enough that a hang is a failure. */
@@ -188,7 +188,7 @@ async function main() {
   const before = hashFile(tarball)
   cleanUpOnSignal()
   owned.databaseUrl = databaseUrl
-  owned.workspace = mkdtempSync(join(tmpdir(), 'llmswitch-release-'))
+  owned.workspace = mkdtempSync(join(tmpdir(), 'llmdispatch-release-'))
   try {
     const project = createConsumerProject({
       workspace: owned.workspace,

--- a/src/conformance.ts
+++ b/src/conformance.ts
@@ -1,5 +1,5 @@
 /**
- * Conformance entry point — `import { … } from 'llmswitch/conformance'`.
+ * Conformance entry point — `import { … } from 'llmdispatch/conformance'`.
  *
  * For anyone writing their own usage store, config store or provider adapter: the harnesses
  * check an implementation against the behaviour the rest of the package relies on, so a store

--- a/src/conformance/README.md
+++ b/src/conformance/README.md
@@ -1,6 +1,6 @@
 # `src/conformance`
 
-The harnesses published under `llmswitch/conformance`. They exercise a provider, usage
+The harnesses published under `llmdispatch/conformance`. They exercise a provider, usage
 store or config store purely through its public interface and report which behaviours
 hold, so anyone can prove a custom implementation is substitutable for a built-in one.
 

--- a/src/core/create-switch.ts
+++ b/src/core/create-switch.ts
@@ -209,7 +209,7 @@ function validateOperation(
  * Pure wiring plus §6 validation; no store is called and no provider is prepared here.
  * Internal — the public `createSwitch` in the root entry supplies the real runtime.
  *
- * @throws `LLMSwitchError` with code `INVALID_CONFIG` naming the field that failed.
+ * @throws `LLMDispatchError` with code `INVALID_CONFIG` naming the field that failed.
  */
 export function createSwitchCore<Ops extends OperationsMap>(
   config: CreateSwitchConfig<Ops>,

--- a/src/core/quota.ts
+++ b/src/core/quota.ts
@@ -366,7 +366,7 @@ export interface SettlementContext {
 
 /** The stable message `logger.error` carries when settlement finally fails. */
 export const SETTLEMENT_FAILED_MESSAGE =
-  'llmswitch: settlement failed after every retry; attempt records were not persisted'
+  'llmdispatch: settlement failed after every retry; attempt records were not persisted'
 
 /** The §6 string-domain re-check before `settle` (spec §6): envelope and attempt strings. */
 function settlementDomainProblem(

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -22,7 +22,7 @@ import {
   providerFailed,
   ProviderError,
 } from '../errors'
-import type { LLMSwitchError } from '../errors'
+import type { LLMDispatchError } from '../errors'
 import type { ProviderFailureKind } from '../errors/factories'
 import type {
   AttemptRecord,
@@ -108,7 +108,7 @@ function terminalFor(
   operation: string,
   kind: Exclude<AttemptFailureKind, 'output_schema_error' | 'quality_error'>,
   attempts: AttemptRecord[],
-): LLMSwitchError {
+): LLMDispatchError {
   switch (kind) {
     case 'transient':
     case 'rate_limit':
@@ -133,7 +133,7 @@ function terminalFor(
 /**
  * Runs one operation end to end (spec §1).
  *
- * @throws `LLMSwitchError` per the stage table and §5b, or the user's own exception raw
+ * @throws `LLMDispatchError` per the stage table and §5b, or the user's own exception raw
  *   (stages 2 and 6 pre-quota; `output_schema_error`/`quality_error` post-dispatch, settled
  *   first).
  */
@@ -341,7 +341,7 @@ async function runAttempts(
   shared: AttemptShared,
 ): Promise<RunResult<unknown>> {
   const { signal, attempts } = shared
-  const abortedWithAttempts = (): LLMSwitchError => aborted(operation, copyAttempts(attempts))
+  const abortedWithAttempts = (): LLMDispatchError => aborted(operation, copyAttempts(attempts))
   // A helper, not an inline read: the checks repeat, and TypeScript would otherwise narrow
   // `signal.aborted` to `false` after the first throw even though it changes over time.
   const callerAborted = (): boolean => signal?.aborted === true

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -3,7 +3,7 @@
  * route shape.
  *
  * Everything here answers a problem description or `null` rather than throwing: the caller
- * knows which `LLMSwitchError` its boundary mints (`INVALID_CONFIG` at `createSwitch` and
+ * knows which `LLMDispatchError` its boundary mints (`INVALID_CONFIG` at `createSwitch` and
  * `setConfig`, `INVALID_INPUT` for a `subjectId`, a malformed row for a stored route), and
  * one description per problem keeps the messages stable.
  *

--- a/src/errors/README.md
+++ b/src/errors/README.md
@@ -1,6 +1,6 @@
 # `src/errors`
 
-The two error classes adopters see. `LLMSwitchError` is what a classified failure raises: a
+The two error classes adopters see. `LLMDispatchError` is what a classified failure raises: a
 closed `code` union, a private constructor, and a `retryable` flag that is the literal of the
 spec §5b classification row rather than of the code — `PROVIDER_FAILED` is retryable for a
 `transient` failure and not for a `refused` one, which is why there is one typed factory per

--- a/src/errors/factories.ts
+++ b/src/errors/factories.ts
@@ -1,5 +1,5 @@
 /**
- * The typed constructors for every `LLMSwitchError` the package raises.
+ * The typed constructors for every `LLMDispatchError` the package raises.
  *
  * One factory per classification, not per code: spec §5b makes `retryable` a function of the
  * classification, so `PROVIDER_FAILED` is retryable for a `transient` failure and not for a
@@ -11,8 +11,8 @@
  */
 
 import type { AttemptRecord } from '../types'
-import { constructLLMSwitchError } from './llmswitch-error'
-import type { LLMSwitchError } from './llmswitch-error'
+import { constructLLMDispatchError } from './llmdispatch-error'
+import type { LLMDispatchError } from './llmdispatch-error'
 import type { ProviderError } from './provider-error'
 
 /** The classifications that end a run as `PROVIDER_FAILED` (spec §5b). */
@@ -46,8 +46,8 @@ const outputRejectionRetryable: Readonly<Record<OutputRejectionKind, boolean>> =
 }
 
 /** The input failed the operation's schema, or the operation name is not one of ours. */
-export function invalidInput(operation: string, field: string): LLMSwitchError {
-  return constructLLMSwitchError({
+export function invalidInput(operation: string, field: string): LLMDispatchError {
+  return constructLLMDispatchError({
     code: 'INVALID_INPUT',
     message: `invalid input for "${operation}": ${field}`,
     operation,
@@ -56,8 +56,8 @@ export function invalidInput(operation: string, field: string): LLMSwitchError {
 }
 
 /** The operation has an effective quota, so it cannot run without a subject. */
-export function missingSubject(operation: string): LLMSwitchError {
-  return constructLLMSwitchError({
+export function missingSubject(operation: string): LLMDispatchError {
+  return constructLLMDispatchError({
     code: 'MISSING_SUBJECT',
     message: `"${operation}" has an effective quota, so it requires a subjectId`,
     operation,
@@ -66,8 +66,8 @@ export function missingSubject(operation: string): LLMSwitchError {
 }
 
 /** The subject has used its allowance for the store's current UTC day. */
-export function quotaExceeded(operation: string, resetsAt: string): LLMSwitchError {
-  return constructLLMSwitchError({
+export function quotaExceeded(operation: string, resetsAt: string): LLMDispatchError {
+  return constructLLMDispatchError({
     code: 'QUOTA_EXCEEDED',
     message: `"${operation}" is over its daily quota until ${resetsAt}`,
     operation,
@@ -77,8 +77,8 @@ export function quotaExceeded(operation: string, resetsAt: string): LLMSwitchErr
 }
 
 /** The usage store did not answer, so the run is refused rather than risked. */
-export function usageStoreUnavailable(operation: string, cause: unknown): LLMSwitchError {
-  return constructLLMSwitchError({
+export function usageStoreUnavailable(operation: string, cause: unknown): LLMDispatchError {
+  return constructLLMDispatchError({
     code: 'USAGE_STORE_UNAVAILABLE',
     message: `the usage store did not answer, so "${operation}" was refused`,
     operation,
@@ -88,8 +88,8 @@ export function usageStoreUnavailable(operation: string, cause: unknown): LLMSwi
 }
 
 /** The config store did not answer and no fresh route was cached. */
-export function configStoreUnavailable(operation: string, cause: unknown): LLMSwitchError {
-  return constructLLMSwitchError({
+export function configStoreUnavailable(operation: string, cause: unknown): LLMDispatchError {
+  return constructLLMDispatchError({
     code: 'CONFIG_STORE_UNAVAILABLE',
     message: `the config store did not answer, so "${operation}" was refused`,
     operation,
@@ -109,8 +109,8 @@ export function invalidConfigLocal(
   operation: string,
   field: string,
   opts: { cause?: unknown } = {},
-): LLMSwitchError {
-  return constructLLMSwitchError({
+): LLMDispatchError {
+  return constructLLMDispatchError({
     code: 'INVALID_CONFIG',
     message: `invalid configuration for "${operation}": ${field}`,
     operation,
@@ -124,8 +124,8 @@ export function invalidConfigLocal(
 export function invalidConfigTransientPrepare(
   operation: string,
   cause: ProviderError,
-): LLMSwitchError {
-  return constructLLMSwitchError({
+): LLMDispatchError {
+  return constructLLMDispatchError({
     code: 'INVALID_CONFIG',
     message: `a provider for "${operation}" could not be prepared; the failure is transient`,
     operation,
@@ -139,8 +139,8 @@ export function invalidConfigTransientPrepare(
 export function invalidConfigProvider(
   operation: string,
   attempts: AttemptRecord[],
-): LLMSwitchError {
-  return constructLLMSwitchError({
+): LLMDispatchError {
+  return constructLLMDispatchError({
     code: 'INVALID_CONFIG',
     message: `the provider rejected the credentials or model configured for "${operation}"`,
     operation,
@@ -151,8 +151,8 @@ export function invalidConfigProvider(
 }
 
 /** The caller's signal fired; `attempts` only when the run had already dispatched. */
-export function aborted(operation: string, attempts?: AttemptRecord[]): LLMSwitchError {
-  return constructLLMSwitchError({
+export function aborted(operation: string, attempts?: AttemptRecord[]): LLMDispatchError {
+  return constructLLMDispatchError({
     code: 'ABORTED',
     message: `"${operation}" was aborted by its caller`,
     operation,
@@ -166,8 +166,8 @@ export function providerFailed(
   operation: string,
   kind: ProviderFailureKind,
   attempts: AttemptRecord[],
-): LLMSwitchError {
-  return constructLLMSwitchError({
+): LLMDispatchError {
+  return constructLLMDispatchError({
     code: 'PROVIDER_FAILED',
     message: `"${operation}" failed at the provider: ${kind}`,
     operation,
@@ -181,8 +181,8 @@ export function outputRejected(
   operation: string,
   kind: OutputRejectionKind,
   attempts: AttemptRecord[],
-): LLMSwitchError {
-  return constructLLMSwitchError({
+): LLMDispatchError {
+  return constructLLMDispatchError({
     code: 'OUTPUT_REJECTED',
     message: `"${operation}" produced output that was rejected: ${kind}`,
     operation,

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,13 +1,13 @@
 /**
  * The error layer: the two classes adopters see, and the factories the package throws through.
  *
- * Only the classes reach the published surface. Letting an adopter build an `LLMSwitchError`
+ * Only the classes reach the published surface. Letting an adopter build an `LLMDispatchError`
  * would make its code mean "someone said so" rather than "the package classified it".
  *
  * @module
  */
 
-export { LLMSwitchError } from './llmswitch-error'
+export { LLMDispatchError } from './llmdispatch-error'
 export { ProviderError } from './provider-error'
 export {
   aborted,

--- a/src/errors/llmdispatch-error.ts
+++ b/src/errors/llmdispatch-error.ts
@@ -1,5 +1,5 @@
 /**
- * The error every classified llmswitch failure raises.
+ * The error every classified llmdispatch failure raises.
  *
  * Adopters catch it and branch on `code`; they never construct it, which is why the
  * constructor is private (spec §6). Inside the package it is reached through `./factories`,
@@ -11,8 +11,8 @@
 import type { AttemptRecord } from '../types'
 
 /** The fields a factory supplies. Not public: the shape an adopter sees is the class. */
-interface LLMSwitchErrorInit {
-  code: LLMSwitchError['code']
+interface LLMDispatchErrorInit {
+  code: LLMDispatchError['code']
   message: string
   operation: string
   retryable: boolean
@@ -28,15 +28,15 @@ interface LLMSwitchErrorInit {
  * A class's static block runs with the class's own privileges, so it can hand the constructor
  * to this module without widening it for anyone.
  */
-let construct: (init: LLMSwitchErrorInit) => LLMSwitchError
+let construct: (init: LLMDispatchErrorInit) => LLMDispatchError
 
 /** A classified failure: a stable `code`, a literal `retryable`, no dispatch content of its own. */
-export class LLMSwitchError extends Error {
-  private constructor(init: LLMSwitchErrorInit) {
+export class LLMDispatchError extends Error {
+  private constructor(init: LLMDispatchErrorInit) {
     // Presence, not value: `new Error(m, { cause: undefined })` carries a `cause`, and a
     // caught `undefined` is still something the caller chose to chain.
     super(init.message, 'cause' in init ? { cause: init.cause } : {})
-    this.name = 'LLMSwitchError'
+    this.name = 'LLMDispatchError'
     this.code = init.code
     this.operation = init.operation
     this.retryable = init.retryable
@@ -77,15 +77,15 @@ export class LLMSwitchError extends Error {
   // adopter's own thrown store/prepare failure as `cause`, verbatim.
 
   static {
-    construct = (init) => new LLMSwitchError(init)
+    construct = (init) => new LLMDispatchError(init)
   }
 }
 
 /**
- * Builds an `LLMSwitchError`.
+ * Builds an `LLMDispatchError`.
  *
  * @internal Only `./factories` calls this; it is not part of the published surface.
  */
-export function constructLLMSwitchError(init: LLMSwitchErrorInit): LLMSwitchError {
+export function constructLLMDispatchError(init: LLMDispatchErrorInit): LLMDispatchError {
   return construct(init)
 }

--- a/src/errors/provider-error.ts
+++ b/src/errors/provider-error.ts
@@ -12,7 +12,7 @@
 import type { ProviderErrorKind } from '../types'
 
 /** The recognition brand: one symbol per process, whichever copy or realm asks for it. */
-const brand: unique symbol = Symbol.for('llmswitch.ProviderError')
+const brand: unique symbol = Symbol.for('llmdispatch.ProviderError')
 
 /** The closed set from spec §6; `satisfies` makes a kind added to the union a compile error. */
 const kinds = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Root entry point — `import { … } from 'llmswitch'`.
+ * Root entry point — `import { … } from 'llmdispatch'`.
  *
  * The only module that assembles the pieces: the factory that turns providers, operations
  * and stores into a working switch, the built-in adapters, the in-memory stores, the errors,
@@ -44,7 +44,7 @@ import { createSwitchCore } from './core/create-switch'
 import { createGlobalRuntime } from './runtime'
 import type { CreateSwitchConfig, OperationsMap, Switch } from './types'
 
-export { LLMSwitchError, ProviderError } from './errors'
+export { LLMDispatchError, ProviderError } from './errors'
 export { anthropic } from './providers/anthropic'
 export { openaiCompatible } from './providers/openai-compatible'
 export { gemini } from './providers/gemini'
@@ -61,7 +61,7 @@ export { defineOperation, defineOperations } from './core/create-switch'
  * here, loudly, rather than on the first request.
  *
  * @param config Who can be called, what the app does, and where config and counters live.
- * @throws `LLMSwitchError` with code `INVALID_CONFIG` naming the field that failed.
+ * @throws `LLMDispatchError` with code `INVALID_CONFIG` naming the field that failed.
  * @example
  * ```ts
  * const ai = createSwitch({ providers, operations, stores: memoryStores() })

--- a/src/postgres.ts
+++ b/src/postgres.ts
@@ -1,5 +1,5 @@
 /**
- * PostgreSQL entry point — `import { … } from 'llmswitch/postgres'`.
+ * PostgreSQL entry point — `import { … } from 'llmdispatch/postgres'`.
  *
  * The packaged migrations: `MIGRATIONS` is every published version with its template hash, and
  * `migrationSql()` renders them for your schema. The stores themselves are exported from the

--- a/src/stores/postgres/identifiers.ts
+++ b/src/stores/postgres/identifiers.ts
@@ -11,10 +11,10 @@
 const SCHEMA_PATTERN = /^[a-z_][a-z0-9_]{0,62}$/
 
 /** The schema `postgresStores()` and `render()` use when the caller names none. */
-export const DEFAULT_SCHEMA = 'llmswitch'
+export const DEFAULT_SCHEMA = 'llmdispatch'
 
 /**
- * Checks a schema name llmswitch may own.
+ * Checks a schema name llmdispatch may own.
  *
  * @param schema The name as the caller supplied it.
  * @throws `RangeError` for anything that is not a string, for anything outside
@@ -41,7 +41,7 @@ export function assertSchema(schema: string): void {
  * Checks a schema name and returns it quoted, ready to be spliced into SQL text.
  *
  * @param schema The name as the caller supplied it.
- * @throws `RangeError` when the name is not one llmswitch may own.
+ * @throws `RangeError` when the name is not one llmdispatch may own.
  */
 export function quotedSchema(schema: string): string {
   assertSchema(schema)

--- a/src/stores/postgres/index.ts
+++ b/src/stores/postgres/index.ts
@@ -2,7 +2,7 @@
  * The PostgreSQL store pair: routes and quota counters in a schema you own.
  *
  * Bring your own pool — the package has no driver dependency and never opens a connection of
- * its own. Nothing here runs DDL either: apply `migrationSql()` from `llmswitch/postgres`
+ * its own. Nothing here runs DDL either: apply `migrationSql()` from `llmdispatch/postgres`
  * first, and this pair will find its tables where the migration put them.
  *
  * @module
@@ -29,8 +29,8 @@ export interface PostgresStoreOptions {
  * Builds a PostgreSQL store pair with its test controls.
  *
  * @param options `pool` runs every statement; `schema`, `leaseMs` and `now` default to
- * `llmswitch`, 120 000 ms and the database's own clock.
- * @throws `RangeError` when `schema` is not a name llmswitch may own, or `leaseMs` is outside
+ * `llmdispatch`, 120 000 ms and the database's own clock.
+ * @throws `RangeError` when `schema` is not a name llmdispatch may own, or `leaseMs` is outside
  * 5 000–600 000.
  */
 export function createPostgresStores(options: PostgresStoreOptions): InternalStores {
@@ -68,8 +68,8 @@ export function createPostgresStores(options: PostgresStoreOptions): InternalSto
  *
  * @param opts `pool` is your own driver pool, which must run at `READ COMMITTED`
  * (PostgreSQL's default; a stricter level makes concurrent reserves abort rather than deny);
- * `schema` defaults to `llmswitch` and `leaseMs` to 120 000.
- * @throws `RangeError` when `schema` is not a name llmswitch may own, or `leaseMs` is outside
+ * `schema` defaults to `llmdispatch` and `leaseMs` to 120 000.
+ * @throws `RangeError` when `schema` is not a name llmdispatch may own, or `leaseMs` is outside
  * 5 000–600 000.
  */
 export function postgresStores(opts: {

--- a/src/stores/postgres/migrations/001-initial.ts
+++ b/src/stores/postgres/migrations/001-initial.ts
@@ -118,7 +118,7 @@ INSERT INTO __SCHEMA__.usage_reservations (reservation_id, operation, subject_id
 INSERT INTO __SCHEMA__.usage_settlements (reservation_id, operation, subject_id, day, outcome, attempts, settled_at)
   SELECT 'x', '', '', '2000-01-01', 'failed', '[]'::jsonb, now() WHERE false ON CONFLICT (reservation_id) DO NOTHING;
 
--- Pruning. Run it on your own schedule; llmswitch never deletes anything itself. Batched so
+-- Pruning. Run it on your own schedule; llmdispatch never deletes anything itself. Batched so
 -- that a busy day never becomes one huge transaction, and SKIP LOCKED so that two pruners
 -- never wait on each other. Repeat each statement until it reports 0 rows.
 --   DELETE FROM __SCHEMA__.usage_settlements WHERE ctid IN (
@@ -165,9 +165,9 @@ export function sha256(text: string): string {
 /**
  * Renders the migration for one schema.
  *
- * @param opts `schema` defaults to `llmswitch` and is validated, then quoted.
+ * @param opts `schema` defaults to `llmdispatch` and is validated, then quoted.
  * @returns The SQL to apply, and the hash of exactly those bytes.
- * @throws `RangeError` when the schema is not a name llmswitch may own.
+ * @throws `RangeError` when the schema is not a name llmdispatch may own.
  */
 export function render(opts?: { schema?: string }): { sql: string; sha256: string } {
   const schema = quotedSchema(opts?.schema ?? DEFAULT_SCHEMA)

--- a/src/stores/postgres/migrations/index.ts
+++ b/src/stores/postgres/migrations/index.ts
@@ -1,7 +1,7 @@
 /**
  * The packaged migrations (spec §6b).
  *
- * llmswitch never runs DDL: it hands you the SQL and its hash, and you apply it with whatever
+ * llmdispatch never runs DDL: it hands you the SQL and its hash, and you apply it with whatever
  * tool you already use. The hash a version records is the hash of its template — the schema
  * placeholder still in place — so two adopters using different schema names still agree on
  * which version 1 they applied.
@@ -20,9 +20,9 @@ export const MIGRATIONS: readonly {
   /**
    * Renders this migration for one schema.
    *
-   * @param opts `schema` defaults to `llmswitch` and is validated, then quoted.
+   * @param opts `schema` defaults to `llmdispatch` and is validated, then quoted.
    * @returns The SQL to apply, and the hash of exactly those bytes.
-   * @throws `RangeError` when the schema is not a name llmswitch may own.
+   * @throws `RangeError` when the schema is not a name llmdispatch may own.
    */
   render(opts?: { schema?: string }): { sql: string; sha256: string }
 }[] = Object.freeze([Object.freeze({ version: 1, templateSha256, render })])
@@ -31,8 +31,8 @@ export const MIGRATIONS: readonly {
  * Every migration rendered for one schema and concatenated in version order, with the sha256
  * of exactly the bytes it hands back.
  *
- * @param opts `schema` defaults to `llmswitch` and is validated, then quoted.
- * @throws `RangeError` when the schema is not a name llmswitch may own.
+ * @param opts `schema` defaults to `llmdispatch` and is validated, then quoted.
+ * @throws `RangeError` when the schema is not a name llmdispatch may own.
  */
 export function migrationSql(opts?: { schema?: string }): { sql: string; sha256: string } {
   const sql = MIGRATIONS.map((migration) => migration.render(opts).sql).join('\n')

--- a/src/stores/postgres/sql.ts
+++ b/src/stores/postgres/sql.ts
@@ -14,7 +14,7 @@
  * Test harnesses that can only reach the store through an adopter-shaped pool recognise the
  * four usage statements by this prefix and substitute that trailing `null`.
  */
-export const USAGE_STORE_MARKER = '/* llmswitch:usage-store */'
+export const USAGE_STORE_MARKER = '/* llmdispatch:usage-store */'
 
 /** The four statements of the usage protocol. */
 export interface UsageStatements {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface Switch<Ops extends OperationsMap> {
   /**
    * Runs one operation end to end and resolves with its validated result.
    *
-   * @throws `LLMSwitchError` with the code the final classification maps to (spec §5b).
+   * @throws `LLMDispatchError` with the code the final classification maps to (spec §5b).
    */
   run<K extends keyof Ops & string>(
     operation: K,
@@ -261,7 +261,7 @@ export interface UsageStore {
 
 // ——— packaged operational surfaces (spec §6b) ———
 //
-// The shapes `llmswitch/postgres` and `llmswitch/conformance` publish are declared below this
+// The shapes `llmdispatch/postgres` and `llmdispatch/conformance` publish are declared below this
 // line and re-exported by those entry points alone, so the root surface stays exactly §6.
 
 /** What a conformance run reports. `passed` is true exactly when `failures` is empty. */

--- a/test/consumers/cjs/index.cjs
+++ b/test/consumers/cjs/index.cjs
@@ -1,9 +1,9 @@
 // Reaches every advertised entry point the way a CommonJS application does, then checks the
 // same recognition claim from this side: this build's error is recognised by the ESM build,
 // and the ESM build's error by this one.
-const conformance = require('llmswitch/conformance')
-const postgres = require('llmswitch/postgres')
-const root = require('llmswitch')
+const conformance = require('llmdispatch/conformance')
+const postgres = require('llmdispatch/postgres')
+const root = require('llmdispatch')
 
 for (const [name, entry] of Object.entries({ root, postgres, conformance })) {
   if (typeof entry !== 'object' || entry === null) {
@@ -18,7 +18,7 @@ function check(claim, held) {
 
 async function main() {
   // `import()` from CommonJS resolves the `import` condition, so this is the other build.
-  const esm = await import('llmswitch')
+  const esm = await import('llmdispatch')
 
   const fromCjs = new root.ProviderError('rate_limit', { status: 429 })
   const fromEsm = new esm.ProviderError('auth', { status: 401 })
@@ -51,7 +51,7 @@ async function main() {
     check(`${String(value)} was mistaken for a provider error`, !root.ProviderError.is(value))
   }
 
-  const brand = Symbol.for('llmswitch.ProviderError')
+  const brand = Symbol.for('llmdispatch.ProviderError')
   check(
     'an object carrying the brand with an unknown kind was accepted',
     !root.ProviderError.is({ [brand]: true, kind: 'overloaded', message: 'x' }),

--- a/test/consumers/esm/index.mjs
+++ b/test/consumers/esm/index.mjs
@@ -4,12 +4,12 @@
 // why recognition is brand-based rather than `instanceof`.
 import { createRequire } from 'node:module'
 
-import * as conformance from 'llmswitch/conformance'
-import * as postgres from 'llmswitch/postgres'
-import * as root from 'llmswitch'
+import * as conformance from 'llmdispatch/conformance'
+import * as postgres from 'llmdispatch/postgres'
+import * as root from 'llmdispatch'
 
 const requireFromHere = createRequire(import.meta.url)
-const commonjs = requireFromHere('llmswitch')
+const commonjs = requireFromHere('llmdispatch')
 
 for (const [name, entry] of Object.entries({ root, postgres, conformance })) {
   if (typeof entry !== 'object' || entry === null) {
@@ -54,7 +54,7 @@ for (const value of [
 }
 
 const forged = {
-  [Symbol.for('llmswitch.ProviderError')]: true,
+  [Symbol.for('llmdispatch.ProviderError')]: true,
   kind: 'overloaded',
   message: 'x',
 }

--- a/test/consumers/ts/a.mts
+++ b/test/consumers/ts/a.mts
@@ -1,24 +1,24 @@
 // An ES module: TypeScript must reach the `import` declarations of every entry point.
 import { Pool } from 'pg'
 
-import * as conformance from 'llmswitch/conformance'
-import * as postgres from 'llmswitch/postgres'
-import * as root from 'llmswitch'
+import * as conformance from 'llmdispatch/conformance'
+import * as postgres from 'llmdispatch/postgres'
+import * as root from 'llmdispatch'
 import {
-  LLMSwitchError,
+  LLMDispatchError,
   ProviderError,
   memoryStores,
   postgresStores,
   type OperationRoute,
   type StorePair,
-} from 'llmswitch'
+} from 'llmdispatch'
 
 export const reached = [root, postgres, conformance].length
 
 // The codes are a closed set, and this is what says so from outside the package: every one
 // of them is handled, and the `never` in the default arm refuses anything that is not on
 // the list. A code added to — or removed from — the union stops this file compiling.
-export function httpStatus(error: LLMSwitchError): number {
+export function httpStatus(error: LLMDispatchError): number {
   switch (error.code) {
     case 'INVALID_INPUT':
       return 400
@@ -47,7 +47,7 @@ export function httpStatus(error: LLMSwitchError): number {
 // not a discriminated union — so it is still `string | undefined` after this narrowing, and
 // the caller has to say what to do when it is absent.
 export function retryAfter(error: unknown): string | null {
-  if (error instanceof LLMSwitchError && error.code === 'QUOTA_EXCEEDED') {
+  if (error instanceof LLMDispatchError && error.code === 'QUOTA_EXCEEDED') {
     return error.resetsAt ?? null
   }
   return null
@@ -69,6 +69,6 @@ export async function reserveOne(): Promise<string | null> {
 
 // The driver pool an adopter already has, handed to the store factory as it is: no cast, no
 // adapter, no widening. This is the one claim only a real `pg` install can make.
-export const production: StorePair = postgresStores({ pool: new Pool(), schema: 'llmswitch' })
+export const production: StorePair = postgresStores({ pool: new Pool(), schema: 'llmdispatch' })
 
-export const migration: string = postgres.migrationSql({ schema: 'llmswitch' }).sql
+export const migration: string = postgres.migrationSql({ schema: 'llmdispatch' }).sql

--- a/test/consumers/ts/b.cts
+++ b/test/consumers/ts/b.cts
@@ -1,14 +1,14 @@
 // A CommonJS module: TypeScript must reach the `require` declarations of every entry point.
-import root = require('llmswitch')
-import postgres = require('llmswitch/postgres')
-import conformance = require('llmswitch/conformance')
+import root = require('llmdispatch')
+import postgres = require('llmdispatch/postgres')
+import conformance = require('llmdispatch/conformance')
 import pg = require('pg')
 
 export const reached = [root, postgres, conformance].length
 
 // The same closed set, reached through the `require` declarations rather than the `import`
 // ones: a consumer whose types resolved to the wrong half would not compile this.
-export function httpStatus(error: root.LLMSwitchError): number {
+export function httpStatus(error: root.LLMDispatchError): number {
   switch (error.code) {
     case 'INVALID_INPUT':
       return 400
@@ -36,7 +36,7 @@ export function httpStatus(error: root.LLMSwitchError): number {
 // `resetsAt` is optional on the class as a whole rather than tied to a code — the error is
 // not a discriminated union — so it is still `string | undefined` after this narrowing.
 export function retryAfter(error: unknown): string | null {
-  if (error instanceof root.LLMSwitchError && error.code === 'QUOTA_EXCEEDED') {
+  if (error instanceof root.LLMDispatchError && error.code === 'QUOTA_EXCEEDED') {
     return error.resetsAt ?? null
   }
   return null
@@ -58,4 +58,4 @@ export async function reserveOne(): Promise<string | null> {
 // The same pool, through the `require` declarations.
 export const production: root.StorePair = root.postgresStores({ pool: new pg.Pool() })
 
-export const migration: string = postgres.migrationSql({ schema: 'llmswitch' }).sql
+export const migration: string = postgres.migrationSql({ schema: 'llmdispatch' }).sql

--- a/test/fixtures/scan/near-misses.md
+++ b/test/fixtures/scan/near-misses.md
@@ -8,7 +8,7 @@ and deletes them.
 An address in the documentation domain: reader@example.com
 
 Links to hosts on the allowlist: <https://nodejs.org/en/download> and
-<https://github.com/parvezrob/llmswitch>.
+<https://github.com/parvezrob/llmdispatch>.
 
 An ordinary relative import, which must not read as a path alias:
 

--- a/test/types/negative/prompt-input.ts
+++ b/test/types/negative/prompt-input.ts
@@ -1,7 +1,7 @@
 // @targets spec, package
 // The typo the README promises is a compile error: `prompt` reads a field the input schema
 // does not declare.
-import { defineOperation, defineOperations } from 'llmswitch'
+import { defineOperation, defineOperations } from 'llmdispatch'
 import { z } from 'zod'
 
 export const operations = defineOperations({

--- a/test/types/negative/provider-error-kind.ts
+++ b/test/types/negative/provider-error-kind.ts
@@ -1,7 +1,7 @@
 // @targets spec, package
 // The classification set is closed: an adapter cannot invent a kind, because the fallback
 // matrix has no row for one.
-import { ProviderError } from 'llmswitch'
+import { ProviderError } from 'llmdispatch'
 
 // @expect TS2345
 export const invented = new ProviderError('overloaded')

--- a/test/types/negative/provider-response.ts
+++ b/test/types/negative/provider-response.ts
@@ -1,7 +1,7 @@
 // @targets spec, package
 // The response union is discriminated, so an adapter that invents a termination kind or
 // mistypes the payload is rejected rather than classified.
-import type { ProviderResponse } from 'llmswitch'
+import type { ProviderResponse } from 'llmdispatch'
 
 // @expect TS2322
 export const unknownKind: ProviderResponse = { kind: 'partial', text: '', usage: null }

--- a/test/types/negative/quality-data.ts
+++ b/test/types/negative/quality-data.ts
@@ -1,7 +1,7 @@
 // @targets spec, package
 // The quality gate sees the output schema's type, so a field that schema does not declare
 // cannot be read from `data`.
-import { defineOperation, defineOperations } from 'llmswitch'
+import { defineOperation, defineOperations } from 'llmdispatch'
 import { z } from 'zod'
 
 export const operations = defineOperations({

--- a/test/types/negative/quality-input.ts
+++ b/test/types/negative/quality-input.ts
@@ -1,7 +1,7 @@
 // @targets spec, package
 // The other half of the same rule: `input` in a quality gate is the input schema's parsed
 // type, not whatever the caller happened to pass.
-import { defineOperation, defineOperations } from 'llmswitch'
+import { defineOperation, defineOperations } from 'llmdispatch'
 import { z } from 'zod'
 
 export const operations = defineOperations({

--- a/test/types/negative/quality-verdict.ts
+++ b/test/types/negative/quality-verdict.ts
@@ -1,7 +1,7 @@
 // @targets spec, package
 // A quality gate answers `{ ok: true }` or `{ ok: false, reason? }`. Anything else is a
 // malformed verdict, and the type system says so before a run ever can.
-import { defineOperation, defineOperations } from 'llmswitch'
+import { defineOperation, defineOperations } from 'llmdispatch'
 import { z } from 'zod'
 
 export const operations = defineOperations({

--- a/test/types/negative/route-shape.ts
+++ b/test/types/negative/route-shape.ts
@@ -1,7 +1,7 @@
 // @targets spec, package
 // A route names a registered provider and a model. A missing half, a misspelt field, or a
 // field the shape does not have is a configuration bug worth catching where it is written.
-import type { OperationRoute } from 'llmswitch'
+import type { OperationRoute } from 'llmdispatch'
 
 // @expect TS2741
 export const missingModel: OperationRoute = { provider: 'claude' }

--- a/test/types/negative/run-input.ts
+++ b/test/types/negative/run-input.ts
@@ -1,7 +1,7 @@
 // @targets spec, package
 // `run` accepts the input schema's `z.input`, so a wrongly typed field is caught at the
 // call site rather than by the parse at stage 2.
-import { createSwitch, defineOperation, defineOperations, memoryStores } from 'llmswitch'
+import { createSwitch, defineOperation, defineOperations, memoryStores } from 'llmdispatch'
 import { z } from 'zod'
 
 const ai = createSwitch({

--- a/test/types/negative/unknown-operation.ts
+++ b/test/types/negative/unknown-operation.ts
@@ -1,7 +1,7 @@
 // @targets spec, package
 // Operation names are typed: a misspelt one does not compile, which is why INVALID_INPUT
 // for an unknown name is documented as a JavaScript caller's failure.
-import { createSwitch, defineOperation, defineOperations, memoryStores } from 'llmswitch'
+import { createSwitch, defineOperation, defineOperations, memoryStores } from 'llmdispatch'
 import { z } from 'zod'
 
 const ai = createSwitch({

--- a/test/types/positive/core-switch.ts
+++ b/test/types/positive/core-switch.ts
@@ -9,7 +9,7 @@ import {
   memoryStores,
   ProviderError,
   type Provider,
-} from 'llmswitch'
+} from 'llmdispatch'
 import { z } from 'zod'
 
 const custom: Provider = {

--- a/test/types/positive/custom-provider.ts
+++ b/test/types/positive/custom-provider.ts
@@ -2,7 +2,7 @@
 // The README's custom provider adapter, compiled as it is printed there. It is the shape
 // every adopter writing their own transport starts from, so both the interface it
 // implements and the error it throws have to be reachable from the package root.
-import { ProviderError, type Provider } from 'llmswitch'
+import { ProviderError, type Provider } from 'llmdispatch'
 
 export const myProvider: Provider = {
   async complete(req) {

--- a/test/types/positive/postgres-pool.ts
+++ b/test/types/positive/postgres-pool.ts
@@ -5,18 +5,18 @@
 // migrations come from the subpath, where the DDL stays out of an application that has none.
 import { Pool } from 'pg'
 
-import { MIGRATIONS, migrationSql } from 'llmswitch/postgres'
-import { postgresStores, type StorePair } from 'llmswitch'
+import { MIGRATIONS, migrationSql } from 'llmdispatch/postgres'
+import { postgresStores, type StorePair } from 'llmdispatch'
 
 export const stores: StorePair = postgresStores({ pool: new Pool() })
 
 export const configured: StorePair = postgresStores({
   pool: new Pool({ connectionString: process.env.DATABASE_URL }),
-  schema: 'llmswitch',
+  schema: 'llmdispatch',
   leaseMs: 60_000,
 })
 
-export const sql: string = migrationSql({ schema: 'llmswitch' }).sql
+export const sql: string = migrationSql({ schema: 'llmdispatch' }).sql
 
 export const published: { version: number; sha256: string }[] = MIGRATIONS.map((migration) => ({
   version: migration.version,

--- a/test/types/positive/results.ts
+++ b/test/types/positive/results.ts
@@ -3,7 +3,7 @@
 // attempt records, read a quota view, and switch over a provider response without a
 // default arm. The last one is the check that matters — an added `ProviderResponse` member
 // has to break this file rather than fall through it silently.
-import type { AttemptRecord, ProviderResponse, QuotaView, RunResult } from 'llmswitch'
+import type { AttemptRecord, ProviderResponse, QuotaView, RunResult } from 'llmdispatch'
 
 export function summaryOf(result: RunResult<{ summary: string }>): string {
   const suffix = result.usedFallback ? ' (fallback)' : ''

--- a/test/types/positive/spec-identity.ts
+++ b/test/types/positive/spec-identity.ts
@@ -9,9 +9,9 @@
 // members are.
 import type { z } from 'zod'
 
-import type * as Conformance from 'llmswitch/conformance'
-import type * as Postgres from 'llmswitch/postgres'
-import type * as Package from 'llmswitch'
+import type * as Conformance from 'llmdispatch/conformance'
+import type * as Postgres from 'llmdispatch/postgres'
+import type * as Package from 'llmdispatch'
 
 import type * as SpecConformance from '../spec-surface-conformance'
 import type * as SpecPostgres from '../spec-surface-postgres'
@@ -71,7 +71,7 @@ export type SectionSix = [
 ]
 
 export type SectionSixValues = [
-  Holds<Identical<Members<Package.LLMSwitchError>, Members<Spec.LLMSwitchError>>>,
+  Holds<Identical<Members<Package.LLMDispatchError>, Members<Spec.LLMDispatchError>>>,
   Holds<Identical<Members<Package.ProviderError>, Members<Spec.ProviderError>>>,
   Holds<Identical<Members<typeof Package.ProviderError>, Members<typeof Spec.ProviderError>>>,
   Holds<

--- a/test/types/positive/transformed-schema.ts
+++ b/test/types/positive/transformed-schema.ts
@@ -2,7 +2,7 @@
 // A schema that transforms, which is where the three sides of an operation are easiest to
 // get wrong: `run` takes what the caller writes (`z.input`), while `prompt`, `quality` and
 // `result.data` all see what the schema produced (`z.output`).
-import { createSwitch, defineOperation, defineOperations, memoryStores } from 'llmswitch'
+import { createSwitch, defineOperation, defineOperations, memoryStores } from 'llmdispatch'
 import { z } from 'zod'
 
 const ai = createSwitch({

--- a/test/types/scaffold.d.ts
+++ b/test/types/scaffold.d.ts
@@ -4,7 +4,7 @@
 // quickstart needs no scaffold: its fence is self-contained, and the fixture checker
 // compiles it straight out of README.md.)
 
-import type { ProviderRequest, TokenUsage } from 'llmswitch'
+import type { ProviderRequest, TokenUsage } from 'llmdispatch'
 
 declare global {
   /** The backend the README's custom provider adapter calls. */

--- a/test/types/spec-surface-conformance.d.ts
+++ b/test/types/spec-surface-conformance.d.ts
@@ -3,7 +3,7 @@
 
 import type { AttemptRecord, ConfigStore, Provider, ProviderRequest, ReservationEnvelope, UsageStore } from './spec-surface'
 
-// subpath: llmswitch/conformance
+// subpath: llmdispatch/conformance
 export interface ConformanceResult { passed: boolean; failures: string[]; skipped: string[] }
 export declare function runUsageStoreConformance(opts: {
   // create returns the store under test plus REQUIRED test controls:

--- a/test/types/spec-surface-postgres.d.ts
+++ b/test/types/spec-surface-postgres.d.ts
@@ -1,7 +1,7 @@
 // Generated from the code fences of docs/spec.md by scripts/check-spec-surface.mjs.
 // Edit the spec, then run `npm run surface:update`.
 
-// subpath: llmswitch/postgres
+// subpath: llmdispatch/postgres
 export declare const MIGRATIONS: ReadonlyArray<{
   version: number
   templateSha256: string                                  // hash of the canonical template (schema placeholder form)

--- a/test/types/spec-surface.d.ts
+++ b/test/types/spec-surface.d.ts
@@ -177,12 +177,12 @@ export interface UsageStore {
 export declare function memoryStores(): StorePair
 export declare function postgresStores(opts: {
   pool: { query(sql: string, params?: unknown[]): Promise<{ rows: unknown[] }> }
-  schema?: string                                        // default 'llmswitch'; validated identifier
+  schema?: string                                        // default 'llmdispatch'; validated identifier
   leaseMs?: number                                       // default 120_000; 5_000–600_000
 }): StorePair
 
 // ——— errors ———
-export declare class LLMSwitchError extends Error {
+export declare class LLMDispatchError extends Error {
   private constructor()                                  // instances come from the package; narrow on `code`
   readonly code: 'INVALID_INPUT' | 'MISSING_SUBJECT' | 'QUOTA_EXCEEDED'
     | 'USAGE_STORE_UNAVAILABLE' | 'CONFIG_STORE_UNAVAILABLE' | 'INVALID_CONFIG'

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -4,7 +4,7 @@
   // to fail and a single program would simply report their errors as build errors.
   //
   // The `paths` below point at the generated spec surfaces. That is what an editor and
-  // ESLint resolve `llmswitch` to; the runner substitutes `dist/*.d.ts` in memory when it
+  // ESLint resolve `llmdispatch` to; the runner substitutes `dist/*.d.ts` in memory when it
   // checks a fixture against the built package instead.
   "compilerOptions": {
     "target": "ES2022",
@@ -34,9 +34,9 @@
 
     "baseUrl": ".",
     "paths": {
-      "llmswitch": ["./spec-surface.d.ts"],
-      "llmswitch/postgres": ["./spec-surface-postgres.d.ts"],
-      "llmswitch/conformance": ["./spec-surface-conformance.d.ts"]
+      "llmdispatch": ["./spec-surface.d.ts"],
+      "llmdispatch/postgres": ["./spec-surface-postgres.d.ts"],
+      "llmdispatch/conformance": ["./spec-surface-conformance.d.ts"]
     }
   },
   "include": ["."]

--- a/test/unit/composition/concurrency.test.ts
+++ b/test/unit/composition/concurrency.test.ts
@@ -10,7 +10,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 
-import { LLMSwitchError } from '../../../src/errors'
+import { LLMDispatchError } from '../../../src/errors'
 import { createSwitch } from '../../../src/index'
 import { openaiCompatible } from '../../../src/providers/openai-compatible'
 import { createMemoryStores } from '../../../src/stores/memory'
@@ -286,8 +286,8 @@ describe('seeded stochastic smoke', () => {
         expect(run.value?.attempts.map((a) => a.outcome)).toEqual([primary, 'succeeded'])
       } else {
         expect(run.state).toBe('rejected')
-        expect(run.error).toBeInstanceOf(LLMSwitchError)
-        const error = run.error as LLMSwitchError
+        expect(run.error).toBeInstanceOf(LLMDispatchError)
+        const error = run.error as LLMDispatchError
         expect(error.code).toBe('PROVIDER_FAILED')
         expect(error.retryable).toBe(true)
         expect(error.attempts?.map((a) => a.outcome)).toEqual([primary, 'transient'])

--- a/test/unit/composition/matrix.test.ts
+++ b/test/unit/composition/matrix.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { LLMSwitchError, ProviderError } from '../../../src/errors'
+import { LLMDispatchError, ProviderError } from '../../../src/errors'
 import type {
   AttemptOutcome,
   OperationsMap,
@@ -120,7 +120,7 @@ function classify(outcome: AttemptOutcome): RowClass {
 interface FailureRow {
   outcome: AttemptOutcome
   eligible: boolean
-  code: LLMSwitchError['code']
+  code: LLMDispatchError['code']
   retryable: boolean
   detectedAt?: 'provider'
   arrange: (f: Fixture, which: 'p1' | 'p2') => void
@@ -263,9 +263,9 @@ async function landAttempt(f: Fixture, row: FailureRow): Promise<void> {
   await flushMicrotasks()
 }
 
-function asSwitchError(error: unknown, code: LLMSwitchError['code']): LLMSwitchError {
-  expect(error).toBeInstanceOf(LLMSwitchError)
-  const typed = error as LLMSwitchError
+function asSwitchError(error: unknown, code: LLMDispatchError['code']): LLMDispatchError {
+  expect(error).toBeInstanceOf(LLMDispatchError)
+  const typed = error as LLMDispatchError
   expect(typed.code).toBe(code)
   return typed
 }

--- a/test/unit/core/abort.test.ts
+++ b/test/unit/core/abort.test.ts
@@ -8,7 +8,7 @@
 import { getEventListeners } from 'node:events'
 import { describe, expect, it } from 'vitest'
 
-import type { LLMSwitchError } from '../../../src/errors'
+import type { LLMDispatchError } from '../../../src/errors'
 import { ProviderError } from '../../../src/errors'
 import { createSwitchCore } from '../../../src/core/create-switch'
 import type { OperationsMap } from '../../../src/types'
@@ -82,7 +82,7 @@ describe('cancellation while each raced seam is pending', () => {
       controller.abort()
       await flushMicrotasks()
       expect(run.state).toBe('rejected') // the seam is still open; the core stopped waiting
-      expect((run.error as LLMSwitchError).code).toBe('ABORTED')
+      expect((run.error as LLMDispatchError).code).toBe('ABORTED')
       // The loser provably rejects only after the run has ended, and stays silent.
       gate.reject(new Error(`late ${seam} failure`))
       await macrotask()
@@ -136,8 +136,8 @@ describe('abort at stage boundaries', () => {
     })
     await flushMicrotasks()
     expect(run.state).toBe('rejected')
-    expect((run.error as LLMSwitchError).code).toBe('ABORTED')
-    expect((run.error as LLMSwitchError).attempts).toBeUndefined()
+    expect((run.error as LLMDispatchError).code).toBe('ABORTED')
+    expect((run.error as LLMDispatchError).attempts).toBeUndefined()
     // Pre-commit: the pending envelope stands and expires on its own; nothing was settled.
     expect(s.log).toEqual(['getAll', 'reserve u 5'])
   })
@@ -157,7 +157,7 @@ describe('abort at stage boundaries', () => {
     gate.resolve('committed')
     await flushMicrotasks()
     expect(run.state).toBe('rejected')
-    expect((run.error as LLMSwitchError).code).toBe('ABORTED')
+    expect((run.error as LLMDispatchError).code).toBe('ABORTED')
     // Committed counts: the post-commit path settles, failed, with no attempts.
     expect(f.p1.requests.length).toBe(0)
     expect(f.s.settle.calls.length).toBe(1)
@@ -182,8 +182,8 @@ describe('abort precedence over non-successful awaited quota results', () => {
     gate.resolve({ ok: false, used: 5, resetsAt: '2026-08-27T00:00:00.000Z' })
     await flushMicrotasks()
     expect(run.state).toBe('rejected')
-    expect((run.error as LLMSwitchError).code).toBe('ABORTED') // the abort wins over the denial
-    expect((run.error as LLMSwitchError).attempts).toBeUndefined()
+    expect((run.error as LLMDispatchError).code).toBe('ABORTED') // the abort wins over the denial
+    expect((run.error as LLMDispatchError).attempts).toBeUndefined()
     expect(s.log).toEqual(['getAll', 'reserve u 5']) // no commit, no settle
   })
 
@@ -201,7 +201,7 @@ describe('abort precedence over non-successful awaited quota results', () => {
     gate.reject(new Error('store down'))
     await flushMicrotasks()
     expect(run.state).toBe('rejected')
-    expect((run.error as LLMSwitchError).code).toBe('ABORTED')
+    expect((run.error as LLMDispatchError).code).toBe('ABORTED')
     expect(s.log).toEqual(['getAll', 'reserve u 5'])
   })
 
@@ -220,7 +220,7 @@ describe('abort precedence over non-successful awaited quota results', () => {
     gate.resolve('missing')
     await flushMicrotasks()
     expect(run.state).toBe('rejected')
-    expect((run.error as LLMSwitchError).code).toBe('ABORTED')
+    expect((run.error as LLMDispatchError).code).toBe('ABORTED')
     // Nothing was validated committed, so nothing settles; quota state stands as reached.
     expect(f.s.settle.calls.length).toBe(0)
     expect(f.p1.requests.length).toBe(0)
@@ -351,7 +351,7 @@ describe('adapter-reported aborts and the composed signal', () => {
     // The provider promise is still pending; the core classified from its own flags.
     expect(request.signal.aborted).toBe(true)
     expect(run.state).toBe('rejected')
-    const error = run.error as LLMSwitchError
+    const error = run.error as LLMDispatchError
     expect(error.code).toBe('ABORTED')
     expect(error.attempts?.map((a) => a.outcome)).toEqual(['aborted'])
     expect(f.runtime.pending('referenced')).toBe(0) // the timeout timer was cancelled
@@ -370,7 +370,7 @@ describe('adapter-reported aborts and the composed signal', () => {
     expect(controller.signal.aborted).toBe(false) // this source alone fired
     await flushMicrotasks()
     expect(run.state).toBe('rejected')
-    const error = run.error as LLMSwitchError
+    const error = run.error as LLMDispatchError
     expect(error.code).toBe('PROVIDER_FAILED')
     expect(error.attempts?.map((a) => a.outcome)).toEqual(['timeout'])
     void hang
@@ -395,7 +395,7 @@ describe('adapter-reported aborts and the composed signal', () => {
     await f.runtime.advance(2000)
     await flushMicrotasks()
     expect(run.state).toBe('rejected')
-    const error = run.error as LLMSwitchError
+    const error = run.error as LLMDispatchError
     expect(error.code).toBe('PROVIDER_FAILED')
     expect(error.retryable).toBe(true)
     expect(error.attempts?.map((a) => a.outcome)).toEqual(['timeout'])

--- a/test/unit/core/classification.test.ts
+++ b/test/unit/core/classification.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
-import type { LLMSwitchError } from '../../../src/errors'
+import type { LLMDispatchError } from '../../../src/errors'
 import { ProviderError } from '../../../src/errors'
 import type { OperationsMap, ProviderResponse } from '../../../src/types'
 import {
@@ -27,7 +27,7 @@ interface Row {
   name: string
   arrange: (f: ReturnType<typeof fixture>, which: 'p1' | 'p2') => void
   outcome: string
-  code: LLMSwitchError['code']
+  code: LLMDispatchError['code']
   retryable: boolean
   fallback: boolean
 }
@@ -217,7 +217,7 @@ describe('read-once TOCTOU defence', () => {
     let kindReads = 0
     let statusReads = 0
     const value = { message: 'shifty' } as Record<PropertyKey, unknown>
-    value[Symbol.for('llmswitch.ProviderError')] = true
+    value[Symbol.for('llmdispatch.ProviderError')] = true
     Object.defineProperty(value, 'kind', {
       enumerable: true,
       get(): unknown {

--- a/test/unit/core/config.test.ts
+++ b/test/unit/core/config.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { LLMSwitchError } from '../../../src/errors'
+import { LLMDispatchError } from '../../../src/errors'
 import { createSwitchCore } from '../../../src/core/create-switch'
 import type { CreateSwitchConfig, OperationsMap } from '../../../src/types'
 import {
@@ -203,8 +203,8 @@ describe('generation coherence', () => {
       )
       await f.runtime.advance(10_000)
       expect(mutation.state).toBe('rejected')
-      expect((mutation.error as LLMSwitchError).code).toBe('CONFIG_STORE_UNAVAILABLE')
-      expect((mutation.error as LLMSwitchError).retryable).toBe(true)
+      expect((mutation.error as LLMDispatchError).code).toBe('CONFIG_STORE_UNAVAILABLE')
+      expect((mutation.error as LLMDispatchError).retryable).toBe(true)
       await f.ai.run('echo', INPUT) // invalidated by the timeout outcome
       expect(getAllCount(f.s)).toBe(2)
       gate.resolve(undefined) // the ack lands after the deadline released the mutex
@@ -260,7 +260,7 @@ describe('generation coherence', () => {
     gate.resolve({ echo: { provider: 'p1' } }) // malformed
     await flushMicrotasks()
     expect(oldRun.state).toBe('rejected')
-    expect((oldRun.error as LLMSwitchError).code).toBe('INVALID_CONFIG')
+    expect((oldRun.error as LLMDispatchError).code).toBe('INVALID_CONFIG')
     await f.ai.run('echo', INPUT)
     expect(getAllCount(f.s)).toBe(reads) // the newer entry survived
   })
@@ -280,7 +280,7 @@ describe('the mutation mutex', () => {
     expect(f.s.set.calls.length).toBe(1) // B is queued behind the mutex
     await f.runtime.advance(8000) // A's store call reaches its deadline (10 s after it began)
     expect(a.state).toBe('rejected') // A's public promise rejects at the deadline …
-    expect((a.error as LLMSwitchError).code).toBe('CONFIG_STORE_UNAVAILABLE')
+    expect((a.error as LLMDispatchError).code).toBe('CONFIG_STORE_UNAVAILABLE')
     await flushMicrotasks()
     expect(f.s.set.calls.length).toBe(2) // … and B's set is observed …
     expect(b.state).toBe('pending') // … while A's store promise is still pending
@@ -291,7 +291,7 @@ describe('the mutation mutex', () => {
     expect(b.state).toBe('pending')
     await f.runtime.advance(1) // t = 20 s: 10 s after B's store call began
     expect(b.state).toBe('rejected')
-    expect((b.error as LLMSwitchError).code).toBe('CONFIG_STORE_UNAVAILABLE')
+    expect((b.error as LLMDispatchError).code).toBe('CONFIG_STORE_UNAVAILABLE')
     void gateA
     void gateB
   })
@@ -361,9 +361,9 @@ describe('numeric validation at createSwitch and setConfig (per-field §6 domain
     } catch (error) {
       caught = error
     }
-    expect(caught).toBeInstanceOf(LLMSwitchError)
-    expect((caught as LLMSwitchError).code).toBe('INVALID_CONFIG')
-    expect((caught as LLMSwitchError).message).toContain(field)
+    expect(caught).toBeInstanceOf(LLMDispatchError)
+    expect((caught as LLMDispatchError).code).toBe('INVALID_CONFIG')
+    expect((caught as LLMDispatchError).message).toContain(field)
   }
 
   const op = (config: Record<string, unknown>): Record<string, unknown> =>
@@ -644,7 +644,7 @@ describe('getQuota', () => {
     await flushMicrotasks()
     await f.runtime.advance(5000) // the 5 s getAll deadline
     expect(slow.state).toBe('rejected')
-    expect((slow.error as LLMSwitchError).code).toBe('CONFIG_STORE_UNAVAILABLE')
+    expect((slow.error as LLMDispatchError).code).toBe('CONFIG_STORE_UNAVAILABLE')
     void configGate
 
     const f2 = quotaFixture()
@@ -655,7 +655,7 @@ describe('getQuota', () => {
     expect(slow2.state).toBe('pending')
     await f2.runtime.advance(1) // the 10 s snapshot deadline, started at the snapshot call
     expect(slow2.state).toBe('rejected')
-    expect((slow2.error as LLMSwitchError).code).toBe('USAGE_STORE_UNAVAILABLE')
+    expect((slow2.error as LLMDispatchError).code).toBe('USAGE_STORE_UNAVAILABLE')
     void snapshotGate
   })
 })
@@ -713,7 +713,7 @@ describe('strict route validation at all three seats', () => {
           } as unknown as CreateSwitchConfig<OperationsMap>,
           runtime,
         ),
-      ).toThrow(LLMSwitchError)
+      ).toThrow(LLMDispatchError)
     })
 
     it(`rejects ${name} at setConfig, before any store call`, async () => {

--- a/test/unit/core/edge-cases.test.ts
+++ b/test/unit/core/edge-cases.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest'
 import { AbortRaceLost, raceWithAbort } from '../../../src/core/abort'
 import { createSwitchCore } from '../../../src/core/create-switch'
 import { normalizeUsage } from '../../../src/core/usage'
-import { LLMSwitchError } from '../../../src/errors'
+import { LLMDispatchError } from '../../../src/errors'
 import type { OperationsMap } from '../../../src/types'
 import {
   expectCode,
@@ -124,9 +124,9 @@ describe('the remaining createSwitch shape checks', () => {
     } catch (error) {
       caught = error
     }
-    expect(caught).toBeInstanceOf(LLMSwitchError)
-    expect((caught as LLMSwitchError).code).toBe('INVALID_CONFIG')
-    expect((caught as LLMSwitchError).message).toContain('config')
+    expect(caught).toBeInstanceOf(LLMDispatchError)
+    expect((caught as LLMDispatchError).code).toBe('INVALID_CONFIG')
+    expect((caught as LLMDispatchError).message).toContain('config')
   })
 
   function build(config: Record<string, unknown>): () => unknown {
@@ -244,9 +244,9 @@ describe('the remaining createSwitch shape checks', () => {
       } catch (error) {
         caught = error
       }
-      expect(caught).toBeInstanceOf(LLMSwitchError)
-      expect((caught as LLMSwitchError).code).toBe('INVALID_CONFIG')
-      expect((caught as LLMSwitchError).message).toContain(field)
+      expect(caught).toBeInstanceOf(LLMDispatchError)
+      expect((caught as LLMDispatchError).code).toBe('INVALID_CONFIG')
+      expect((caught as LLMDispatchError).message).toContain(field)
     })
   }
 })

--- a/test/unit/core/helpers.ts
+++ b/test/unit/core/helpers.ts
@@ -11,7 +11,7 @@
 import { z } from 'zod'
 import { expect } from 'vitest'
 
-import { LLMSwitchError } from '../../../src/errors'
+import { LLMDispatchError } from '../../../src/errors'
 import { createSwitchCore } from '../../../src/core/create-switch'
 import type { CoreRuntime, TimerMode } from '../../../src/core/runtime'
 import type {
@@ -430,16 +430,16 @@ export function fixture(options: FixtureOptions = {}): Fixture {
   return { ai, runtime, s, p1, p2 }
 }
 
-/** Awaits a rejection and asserts it is an `LLMSwitchError` with the given code. */
+/** Awaits a rejection and asserts it is an `LLMDispatchError` with the given code. */
 export async function expectCode(
   promise: Promise<unknown>,
-  code: LLMSwitchError['code'],
-): Promise<LLMSwitchError> {
+  code: LLMDispatchError['code'],
+): Promise<LLMDispatchError> {
   try {
     await promise
   } catch (error) {
-    expect(error).toBeInstanceOf(LLMSwitchError)
-    const typed = error as LLMSwitchError
+    expect(error).toBeInstanceOf(LLMDispatchError)
+    const typed = error as LLMDispatchError
     expect(typed.code).toBe(code)
     return typed
   }

--- a/test/unit/core/output-pipeline.test.ts
+++ b/test/unit/core/output-pipeline.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
-import { LLMSwitchError } from '../../../src/errors'
+import { LLMDispatchError } from '../../../src/errors'
 import type { OperationsMap, ProviderResponse } from '../../../src/types'
 import {
   expectCode,
@@ -224,7 +224,7 @@ describe('the quality gate', () => {
         caught = error
       }
       expect(caught).toBeInstanceOf(TypeError)
-      expect(caught).not.toBeInstanceOf(LLMSwitchError)
+      expect(caught).not.toBeInstanceOf(LLMDispatchError)
       expect((caught as TypeError).message).toContain('malformed verdict')
       expect(f.s.settle.calls.length).toBe(1) // settled before the throw reached the caller
       expect(f.s.settle.calls[0]![1]).toBe('failed')
@@ -365,7 +365,7 @@ describe('request forwarding', () => {
     await f.runtime.advance(1)
     await flushMicrotasks()
     expect(run.state).toBe('rejected')
-    expect((run.error as LLMSwitchError).attempts?.map((a) => a.outcome)).toEqual([
+    expect((run.error as LLMDispatchError).attempts?.map((a) => a.outcome)).toEqual([
       'timeout',
       'timeout',
     ])

--- a/test/unit/core/quota.test.ts
+++ b/test/unit/core/quota.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import type { LLMSwitchError } from '../../../src/errors'
+import type { LLMDispatchError } from '../../../src/errors'
 import { ProviderError } from '../../../src/errors'
 import { createGlobalRuntime } from '../../../src/runtime'
 import { createSwitchCore } from '../../../src/core/create-switch'
@@ -81,7 +81,7 @@ describe('commit recovery', () => {
     await f.runtime.advance(1000)
     expect(f.s.commit.calls.length).toBe(4)
     expect(run.state).toBe('rejected')
-    expect((run.error as LLMSwitchError).code).toBe('USAGE_STORE_UNAVAILABLE')
+    expect((run.error as LLMDispatchError).code).toBe('USAGE_STORE_UNAVAILABLE')
     const ids = new Set(f.s.commit.calls.map((call) => call[0]))
     expect(ids.size).toBe(1) // always the same reservation id
     expect(f.s.settle.calls.length).toBe(0)
@@ -115,7 +115,7 @@ describe('abort × recovery interleavings', () => {
     controller.abort() // inside the 250 ms backoff window
     await f.runtime.advance(1000)
     expect(run.state).toBe('rejected')
-    expect((run.error as LLMSwitchError).code).toBe('ABORTED')
+    expect((run.error as LLMDispatchError).code).toBe('ABORTED')
     expect(f.s.commit.calls.length).toBe(1) // the retry never started
     expect(f.s.settle.calls.length).toBe(0) // nothing was committed
     expect(f.s.log.filter((e) => e.startsWith('reserve')).length).toBe(1)
@@ -512,7 +512,7 @@ describe('settlement hook isolation', () => {
       return { value: JSON.parse(JSON.stringify(run.value)) as unknown }
     }
     expect(run.state).toBe('rejected')
-    const error = run.error as LLMSwitchError
+    const error = run.error as LLMDispatchError
     return {
       code: error.code,
       message: error.message,
@@ -686,7 +686,7 @@ describe('§6a deadlines on the usage store', () => {
     expect(run.state).toBe('pending')
     await f.runtime.advance(1)
     expect(run.state).toBe('rejected')
-    expect((run.error as LLMSwitchError).code).toBe('USAGE_STORE_UNAVAILABLE')
+    expect((run.error as LLMDispatchError).code).toBe('USAGE_STORE_UNAVAILABLE')
     void gate
   })
 

--- a/test/unit/core/sanitization.test.ts
+++ b/test/unit/core/sanitization.test.ts
@@ -1,14 +1,14 @@
 /**
  * Sanitization: sentinel strings seeded into prompt text, input,
  * provider error messages and model output must never appear in any core-constructed field
- * of any `LLMSwitchError` — message, own enumerable properties, attempts, or the cause
+ * of any `LLMDispatchError` — message, own enumerable properties, attempts, or the cause
  * chain — while an adopter's own thrown value passes into `cause` verbatim, which is the
  * documented scope boundary, not a leak. Logger payloads are swept too.
  */
 
 import { describe, expect, it } from 'vitest'
 
-import { LLMSwitchError, ProviderError } from '../../../src/errors'
+import { LLMDispatchError, ProviderError } from '../../../src/errors'
 import type { OperationsMap } from '../../../src/types'
 import { createSwitchCore } from '../../../src/core/create-switch'
 import {
@@ -45,7 +45,7 @@ function reachableStrings(value: unknown, seen = new Set<object>()): string[] {
 }
 
 /** The same walk, excluding everything below `cause` — the core-constructed fields only. */
-function coreConstructedStrings(error: LLMSwitchError): string[] {
+function coreConstructedStrings(error: LLMDispatchError): string[] {
   const found: string[] = [error.message]
   for (const [key, entry] of Object.entries(error)) {
     if (key === 'cause') continue
@@ -97,7 +97,7 @@ function sentinelFixture(options: { quota?: { perDay: number } } = {}) {
 const ARGS = { input: { text: INPUT_SENTINEL }, subjectId: 'u' }
 
 describe('the sentinel sweep over the whole error matrix', () => {
-  /** Each scenario produces one LLMSwitchError under sentinel-laden dispatch content. */
+  /** Each scenario produces one LLMDispatchError under sentinel-laden dispatch content. */
   const scenarios: {
     name: string
     postDispatch: boolean
@@ -188,8 +188,8 @@ describe('the sentinel sweep over the whole error matrix', () => {
       } catch (error) {
         caught = error
       }
-      expect(caught).toBeInstanceOf(LLMSwitchError)
-      const error = caught as LLMSwitchError
+      expect(caught).toBeInstanceOf(LLMDispatchError)
+      const error = caught as LLMDispatchError
       // Core-constructed fields: no dispatch content, ever.
       expectNoSentinels(coreConstructedStrings(error), DISPATCH_SENTINELS)
       // The full chain, cause included: still no dispatch content with core-safe doubles —
@@ -240,7 +240,7 @@ describe('the sentinel sweep over the whole error matrix', () => {
     } catch (error) {
       caught = error
     }
-    const error = caught as LLMSwitchError
+    const error = caught as LLMDispatchError
     expect(error.code).toBe('INVALID_CONFIG')
     expect(error.retryable).toBe(true)
     expect(error.cause).toBe(prepareFailure) // verbatim — prepare ran before the prompt
@@ -257,7 +257,7 @@ describe('the sentinel sweep over the whole error matrix', () => {
     } catch (error) {
       caught = error
     }
-    const error = caught as LLMSwitchError
+    const error = caught as LLMDispatchError
     expect(error.code).toBe('USAGE_STORE_UNAVAILABLE')
     expect(error.cause).toBe(adopterFailure) // exactly what the adopter threw, verbatim
     // …and nowhere else: the core injected nothing.

--- a/test/unit/core/state-machine-property.test.ts
+++ b/test/unit/core/state-machine-property.test.ts
@@ -10,7 +10,7 @@ import { getEventListeners } from 'node:events'
 import fc from 'fast-check'
 import { describe, expect, it } from 'vitest'
 
-import { LLMSwitchError, ProviderError } from '../../../src/errors'
+import { LLMDispatchError, ProviderError } from '../../../src/errors'
 import type { ProviderResponse } from '../../../src/types'
 import { fixture, flushMicrotasks, grantFor, observe } from './helpers'
 
@@ -29,19 +29,20 @@ type AttemptScript =
   | 'unclassified'
 
 /** The §5b terminal columns, keyed by a recorded attempt outcome. */
-const OUTCOME_MEANING: Record<string, { code: LLMSwitchError['code']; retryable: boolean }> = {
-  output_rejected: { code: 'OUTPUT_REJECTED', retryable: true },
-  truncated: { code: 'OUTPUT_REJECTED', retryable: true },
-  refused: { code: 'PROVIDER_FAILED', retryable: false },
-  transient: { code: 'PROVIDER_FAILED', retryable: true },
-  rate_limit: { code: 'PROVIDER_FAILED', retryable: true },
-  malformed_response: { code: 'PROVIDER_FAILED', retryable: true },
-  timeout: { code: 'PROVIDER_FAILED', retryable: true },
-  auth: { code: 'INVALID_CONFIG', retryable: false },
-  model_not_found: { code: 'INVALID_CONFIG', retryable: false },
-  invalid_request: { code: 'PROVIDER_FAILED', retryable: false },
-  provider_unclassified: { code: 'PROVIDER_FAILED', retryable: false },
-}
+const OUTCOME_MEANING: Record<string, { code: LLMDispatchError['code']; retryable: boolean }> =
+  {
+    output_rejected: { code: 'OUTPUT_REJECTED', retryable: true },
+    truncated: { code: 'OUTPUT_REJECTED', retryable: true },
+    refused: { code: 'PROVIDER_FAILED', retryable: false },
+    transient: { code: 'PROVIDER_FAILED', retryable: true },
+    rate_limit: { code: 'PROVIDER_FAILED', retryable: true },
+    malformed_response: { code: 'PROVIDER_FAILED', retryable: true },
+    timeout: { code: 'PROVIDER_FAILED', retryable: true },
+    auth: { code: 'INVALID_CONFIG', retryable: false },
+    model_not_found: { code: 'INVALID_CONFIG', retryable: false },
+    invalid_request: { code: 'PROVIDER_FAILED', retryable: false },
+    provider_unclassified: { code: 'PROVIDER_FAILED', retryable: false },
+  }
 
 interface Scenario {
   reserve: 'grant' | 'deny' | 'reject'
@@ -183,8 +184,8 @@ async function runScenario(scenario: Scenario): Promise<void> {
   expect(getEventListeners(controller.signal, 'abort').length).toBe(0)
 
   if (run.state === 'resolved') return
-  const error = run.error as LLMSwitchError
-  expect(error).toBeInstanceOf(LLMSwitchError)
+  const error = run.error as LLMDispatchError
+  expect(error).toBeInstanceOf(LLMDispatchError)
 
   // `retryable` is always the literal of the code/classification tables.
   const attemptDetermined = error.attempts !== undefined && error.code !== 'ABORTED'
@@ -277,7 +278,7 @@ describe('the run state machine, property-tested', () => {
     const run = observe(f.ai.run('echo', ARGS, { signal: controller.signal }))
     await flushMicrotasks()
     expect(run.state).toBe('rejected')
-    const error = run.error as LLMSwitchError
+    const error = run.error as LLMDispatchError
     expect(error.code).toBe('ABORTED') // the abort rule wins over the fallback decision
     expect(error.attempts?.map((a) => a.outcome)).toEqual(['transient'])
     expect(f.p2.requests.length).toBe(0) // the fallback never dispatched
@@ -300,7 +301,7 @@ describe('the run state machine, property-tested', () => {
     const run = observe(f.ai.run('echo', ARGS, { signal: controller.signal }))
     await flushMicrotasks()
     expect(run.state).toBe('rejected')
-    const error = run.error as LLMSwitchError
+    const error = run.error as LLMDispatchError
     expect(error.code).toBe('ABORTED') // only abort after a successful attempt is outcome-immune
     expect(error.attempts?.map((a) => a.outcome)).toEqual(['invalid_request'])
     expect(f.s.settle.calls[0]![1]).toBe('failed')

--- a/test/unit/core/string-domain.test.ts
+++ b/test/unit/core/string-domain.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { LLMSwitchError } from '../../../src/errors'
+import { LLMDispatchError } from '../../../src/errors'
 import { createSwitchCore } from '../../../src/core/create-switch'
 import { settleDetached } from '../../../src/core/quota'
 import type { CreateSwitchConfig, OperationsMap } from '../../../src/types'
@@ -61,8 +61,8 @@ function expectInvalidConfigThrow(make: () => unknown): void {
   } catch (error) {
     caught = error
   }
-  expect(caught).toBeInstanceOf(LLMSwitchError)
-  expect((caught as LLMSwitchError).code).toBe('INVALID_CONFIG')
+  expect(caught).toBeInstanceOf(LLMDispatchError)
+  expect((caught as LLMDispatchError).code).toBe('INVALID_CONFIG')
 }
 
 describe('violations at the createSwitch boundary — no store method called at all', () => {

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -3,7 +3,7 @@ import { runInNewContext } from 'node:vm'
 import { describe, expect, it } from 'vitest'
 
 import {
-  LLMSwitchError,
+  LLMDispatchError,
   ProviderError,
   aborted,
   configStoreUnavailable,
@@ -21,7 +21,7 @@ import type { OutputRejectionKind, ProviderFailureKind } from '../../src/errors/
 import type { AttemptRecord, ProviderErrorKind } from '../../src/types'
 
 /** The brand is looked up the same way the class installs it: from the global registry. */
-const brand = Symbol.for('llmswitch.ProviderError')
+const brand = Symbol.for('llmdispatch.ProviderError')
 
 const attempts: AttemptRecord[] = [
   {
@@ -71,7 +71,7 @@ describe('the codes raised before dispatch', () => {
   for (const row of rows) {
     it(`reports ${row.code} as retryable ${String(row.retryable)}`, () => {
       const error = row.error()
-      expect(error).toBeInstanceOf(LLMSwitchError)
+      expect(error).toBeInstanceOf(LLMDispatchError)
       expect(error.code).toBe(row.code)
       expect(error.retryable).toBe(row.retryable)
       expect(error.operation).toBe('summarize')
@@ -192,7 +192,7 @@ describe('the fields an error carries', () => {
   })
 
   it('names itself so a log line says which error it is', () => {
-    expect(missingSubject('summarize').name).toBe('LLMSwitchError')
+    expect(missingSubject('summarize').name).toBe('LLMDispatchError')
     expect(new ProviderError('auth').name).toBe('ProviderError')
   })
 
@@ -280,7 +280,7 @@ describe('recognising a provider error', () => {
 
   it('recognises one thrown from another realm, where instanceof cannot', () => {
     const foreign: object = runInNewContext(`
-      const brand = Symbol.for('llmswitch.ProviderError')
+      const brand = Symbol.for('llmdispatch.ProviderError')
       class ForeignProviderError extends Error {
         constructor(kind, status) {
           super('the other realm failed')

--- a/test/unit/providers/prepare.test.ts
+++ b/test/unit/providers/prepare.test.ts
@@ -7,7 +7,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 
-import { LLMSwitchError, ProviderError } from '../../../src/errors'
+import { LLMDispatchError, ProviderError } from '../../../src/errors'
 import { openaiCompatible } from '../../../src/providers/openai-compatible'
 import { memoryStores } from '../../../src/stores/memory'
 import type {
@@ -80,7 +80,7 @@ describe('a resolver that throws', () => {
     })
     await expect(run(provider, stores)).rejects.toSatisfy(
       (error: unknown) =>
-        error instanceof LLMSwitchError &&
+        error instanceof LLMDispatchError &&
         error.code === 'INVALID_CONFIG' &&
         error.retryable &&
         error.cause === thrown,
@@ -93,7 +93,7 @@ describe('a resolver that throws', () => {
     const provider = openaiCompatible({ apiKey: () => Promise.reject(thrown) })
     await expect(run(provider, stores)).rejects.toSatisfy(
       (error: unknown) =>
-        error instanceof LLMSwitchError &&
+        error instanceof LLMDispatchError &&
         error.code === 'INVALID_CONFIG' &&
         !error.retryable &&
         error.cause === thrown,

--- a/test/unit/smoke.test.ts
+++ b/test/unit/smoke.test.ts
@@ -9,7 +9,7 @@ describe('entry points', () => {
     // Compared sorted: this is the published set of runtime exports, not an artefact of how
     // the entry file happens to be written (or of the test runner's module transform).
     expect(Object.keys(index).sort()).toEqual([
-      'LLMSwitchError',
+      'LLMDispatchError',
       'ProviderError',
       'anthropic',
       'createSwitch',

--- a/test/unit/stores/postgres-static.test.ts
+++ b/test/unit/stores/postgres-static.test.ts
@@ -16,7 +16,7 @@ import type { QueryablePool } from '../../../src/stores/postgres/driver'
  * Pinned so that editing the template is a decision: the template's own hash is what the
  * database records, and a change to it makes every applied version-1 schema a different one.
  */
-const TEMPLATE_SHA256 = '4045ea8ccbd3c2102a733d379e27927451b65a62806e7cd8dd4fb0337ef9661e'
+const TEMPLATE_SHA256 = '404877cedf22ce3ed1ce6070f2d4710f9601e36cc4ac098385f1ac7216bd163f'
 
 const KEY = { operation: 'summarize', subjectId: 'user-1' }
 
@@ -66,11 +66,11 @@ describe('the packaged migration', () => {
     expect(aggregate.sha256).toBe(
       createHash('sha256').update(aggregate.sql, 'utf8').digest('hex'),
     )
-    expect(migrationSql({ schema: 'llmswitch' })).toEqual(aggregate)
+    expect(migrationSql({ schema: 'llmdispatch' })).toEqual(aggregate)
   })
 
   it('renders for a different schema without changing the version it records', () => {
-    const here = migrationSql({ schema: 'llmswitch' })
+    const here = migrationSql({ schema: 'llmdispatch' })
     const there = migrationSql({ schema: 'other_schema' })
 
     expect(there.sql).not.toBe(here.sql)
@@ -87,10 +87,10 @@ describe('the statements the usage store sends', () => {
    * correct against a real database, so editing one has to be a decision and not a detail.
    */
   const STATEMENT_SHA256 = {
-    reserve: '9e055a7852fa670ea49dfbc3011f7c3a98136ba5faddcffa6c2fd2b7f77d52aa',
-    commit: '283a0f4d21055b81bd810461318cdf3335e1c4110758a11a28e64a5767f244c9',
-    settle: '97e9c82200ee2505ebd4cfddfc3354f77e3d3e8b07570e683702370a90724a2b',
-    snapshot: '0eae1ed1c274af515cce9fb4c3adcc8447c1221f966187e46030eb3213fb54ba',
+    reserve: '7485e2f259a7b7f723d16a89105f52a7b53f64802f8521abe66344c239c7e1e5',
+    commit: '51fa87eefc789b7fe38ec3d1eeb8f4656706462e321b0decc9247053b80b075e',
+    settle: '9567bc8b7c3f5de07961cbf5dce807c5e735e2a43a1f8fc1bd4b774e3305a481',
+    snapshot: '77a2cbc2a56056a69175872255c385426643edcd9aa21440fe0649852a0533c4',
   }
 
   it('are the ones this test pins', () => {
@@ -149,7 +149,7 @@ describe('the store pair', () => {
   it('asks the database nothing at all while it is being built', () => {
     const pool = recordingPool()
 
-    postgresStores({ pool, schema: 'llmswitch', leaseMs: 60_000 })
+    postgresStores({ pool, schema: 'llmdispatch', leaseMs: 60_000 })
 
     expect(pool.calls).toEqual([])
   })
@@ -194,7 +194,7 @@ describe('the store pair', () => {
     await sent(stores.config.getAll())
 
     const marked = pool.calls.filter((call) =>
-      call.sql.startsWith('/* llmswitch:usage-store */'),
+      call.sql.startsWith('/* llmdispatch:usage-store */'),
     )
     expect(marked).toHaveLength(3)
     for (const call of marked) expect(call.params.at(-1)).toBeNull()
@@ -223,7 +223,7 @@ describe('the public factory', () => {
     // pattern test and spell something else into the SQL.
     const twoFaced = {
       startsWith: () => false,
-      toString: () => 'llmswitch"; DROP SCHEMA public CASCADE; --',
+      toString: () => 'llmdispatch"; DROP SCHEMA public CASCADE; --',
     }
 
     expect(() =>

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -15,9 +15,9 @@
     // first — it has not in CI, where typecheck runs before build. Pointed at the sources
     // instead, which are what `dist/` is generated from.
     "paths": {
-      "llmswitch": ["./src/index.ts"],
-      "llmswitch/postgres": ["./src/postgres.ts"],
-      "llmswitch/conformance": ["./src/conformance.ts"]
+      "llmdispatch": ["./src/index.ts"],
+      "llmdispatch/postgres": ["./src/postgres.ts"],
+      "llmdispatch/conformance": ["./src/conformance.ts"]
     }
   },
   "include": ["test", "scripts", "*.config.ts", "eslint.config.js"],


### PR DESCRIPTION
npm's name-similarity rule blocks publishing as the old name (a third-party package with a near-identical spelling predates us), so the package is now llmdispatch — the name is already reserved on the registry by a placeholder. This renames everything: the manifest and both lockfile entries, every import specifier and its subpaths, the error class and its file, the default Postgres schema and the usage-store marker (pinned statement hashes recomputed), docs and the release runbook (whose name recheck now verifies ownership of the placeholder rather than absence), both examples and their regenerated lockfiles, scripts, container and temp-directory names, and all generated API/spec-surface artifacts. Zero occurrences of the old name remain in the tree, the built output, or the packed tarball. Full battery green (768 tests); end-to-end verified against a dockerized PostgreSQL; both examples install and run the renamed tarball.