### PR TITLE
docs: rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,113 +1,97 @@
 # llmdispatch
 
-**Control which LLM handles each operation in your app. Swap providers at runtime, fall back on failure, enforce per-user quotas.**
+llmdispatch is a model-agnostic Node.js library for named AI operations.
 
-Works with any Node.js server framework — Next.js, Express, Fastify, or none at all. No proxy to deploy, no SaaS to sign up for. It's a library: `npm install`, wire it to your database, done.
+Most apps hard-code one vendor's SDK and scatter model names through the code, so changing the model means a deploy. llmdispatch puts that choice in your database instead.
 
+Define each operation with Zod input and output schemas plus a prompt. llmdispatch routes the call to a provider and model, then validates the response before it reaches you.
 
-## Why
+- Change routes and daily per-user limits from your own Postgres, with no deploy.
+- Retry once on a fallback model when the failure is worth retrying.
+- Keep API keys in environment variables or a secrets manager. You pass a resolver function; the library never stores a key.
+- Call Anthropic, Gemini, or any OpenAI-compatible API through built-in `fetch` adapters. No vendor SDKs.
 
-Apps that use AI usually have several distinct AI *operations* — parse a document, generate content, rewrite text. Each wants a different model, and the right answer keeps changing: prices drop, new models ship, a provider has an outage. Most codebases hard-code one vendor SDK and scatter model names through the code, so changing any of it means a deploy, and adding limits means building rate limiting from scratch.
-
-llmdispatch gives you one place to declare your operations and one function call to run them. Each operation gets its own provider and model, editable at runtime from your own database. Output is validated against a [Zod](https://zod.dev) schema before you see it. A retry-worthy failure falls back once, on an explicit classification. Daily per-user limits are counted atomically where your data already lives.
-
-It's a switchboard, not a brain: it won't pick models for you, it doesn't proxy your traffic through anyone's servers, and v0.1 is text-only — no streaming, no PDF or image input yet (both on the [roadmap](#roadmap)).
+There is no hosted proxy. Your server calls the providers directly.
 
 ## Quickstart
 
-Two packages. That's the whole install — built-in adapters are plain-`fetch`, **zero vendor SDKs**:
+Install llmdispatch and its Zod 4 peer dependency:
 
 ```bash
 npm install llmdispatch zod
 ```
 
-Any package manager works — `pnpm add llmdispatch zod` or `yarn add llmdispatch zod`.
-
-The snippet uses top-level `await`, so it needs an ESM project. In a fresh directory, run `npm pkg set type=module` first, or save the file as `.mts`.
+The example uses top-level `await`, so run it in an ESM project. Set `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` first.
 
 ```ts
-import { createSwitch, defineOperation, defineOperations, anthropic, openaiCompatible, memoryStores } from 'llmdispatch'
+import {
+  anthropic,
+  createSwitch,
+  defineOperation,
+  defineOperations,
+  memoryStores,
+  openaiCompatible,
+} from 'llmdispatch'
 import { z } from 'zod'
 
 const ai = createSwitch({
-  // 1. Register providers in code. Credentials and endpoints live HERE,
-  //    never in runtime config or the database.
   providers: {
     claude: anthropic({ apiKey: () => process.env.ANTHROPIC_API_KEY }),
     openai: openaiCompatible({ apiKey: () => process.env.OPENAI_API_KEY }),
   },
 
-  // 2. Declare operations: typed input, expected output, and how to build the prompt.
-  //    Wrap each operation in defineOperation — that's what ties your schemas to your
-  //    callbacks, so a typo inside `prompt` is a compile error, not a runtime surprise.
   operations: defineOperations({
     summarize: defineOperation({
       input: z.object({ text: z.string().max(50_000) }),
-      output: z.object({ summary: z.string(), keyPoints: z.array(z.string()) }),
-      prompt: ({ text }) => `Summarize the following article as JSON with "summary" and "keyPoints".\n\n${text}`,
+      output: z.object({
+        summary: z.string(),
+        keyPoints: z.array(z.string()),
+      }),
+      prompt: ({ text }) =>
+        `Summarize this as JSON with "summary" and "keyPoints".\n\n${text}`,
       quota: { perDay: 10 },
-      // Used when the config store has no row for this operation (bootstrap-friendly).
       defaultRoute: {
         provider: 'claude',
         model: 'claude-sonnet-4-6',
-        // The fallback needs its own API key. Only have one provider? Delete this line.
         fallback: { provider: 'openai', model: 'gpt-4.1-mini' },
       },
     }),
   }),
 
-  // 3. Wire storage: runtime config (routes and limits) + quota counters.
-  //    Memory for dev, Postgres for prod.
   stores: memoryStores(),
 })
 
-// The inputs your app supplies: the text to process, and whose quota to count.
-const articleText =
-  'Rooftop solar keeps climbing: panel efficiency has improved for a decade, perovskite cells promise cheaper manufacturing, and falling battery prices finally make home storage practical. Analysts expect residential installations to double within five years.'
-const user = { id: 'user-123' }
-
 const result = await ai.run('summarize', {
-  input: { text: articleText },
-  subjectId: user.id, // required whenever the operation has an effective quota
+  input: { text: 'Solar panel efficiency keeps rising and battery prices keep falling.' },
+  subjectId: 'user-123',
 })
 
-result.data          // { summary, keyPoints } — typed, validated against your output schema
-result.route         // { provider: 'claude', model: 'claude-sonnet-4-6' } — who actually answered
-result.usedFallback  // true if the fallback route saved this call
-result.attempts      // per-attempt detail: route, outcome, usage (null when the provider didn't report)
-result.usage         // token totals across attempts with known usage
-result.usageComplete // false if any attempt's usage was unreported (or totals overflowed)
-result.cost          // estimated USD, or null unless every dispatched attempt is priced with known usage
+console.log(result.data)
 ```
 
-Three parts: **providers** (who you can call), **operations** (what your app does), **stores** (where config and counters live). `run` does the rest, in a fixed, documented order — validate input, resolve config, check readiness, reserve and commit quota, call, parse, validate output, fall back if warranted, settle. The exact state machine is spec §1 in [docs/spec.md](./docs/spec.md).
+`result.data` is inferred as `{ summary: string; keyPoints: string[] }` and has already passed your output schema. The result also reports which route answered, whether the fallback was used, and what the call cost.
 
-> **Planning to switch providers later?** Register every provider you might ever want on day one — it costs nothing. API keys resolve lazily, so a registered provider without a key only errors if you actually route to it. A `fallback` on your route counts as routed: its key is checked before anything runs. If you only have one key today, drop the quickstart's `fallback` line. Enabling Anthropic next year is then: set `ANTHROPIC_API_KEY` (a restart/redeploy for the new env var, as with any env change), flip the route in your admin config. **No code push.** (And `openaiCompatible` pointed at OpenRouter reaches virtually every model on the market through one registration.)
+The fallback needs its own API key. Delete the `fallback` line and the second provider if you only have one.
 
-## What else you get
+## Production
 
-Each of these is covered in full in [the guide](./docs/guide.md).
+`memoryStores()` holds routes and quota counters in one process. It is for development and it resets on restart.
 
-- **[Typed output](./docs/guide.md#output-from-model-text-to-typed-data)** — responses are unwrapped, parsed and validated against your schema, with an optional quality gate; a failure is a rejection, never bad data handed back.
-- **[Errors worth routing on](./docs/guide.md#errors)** — one `LLMDispatchError` with a stable code per failure mode, each with a sensible HTTP status and sanitized fields.
-- **[Fallback rules](./docs/guide.md#when-fallback-fires)** — an explicit matrix decides which failures retry on the fallback route; credential and unknown-model errors stay loud by default.
-- **[Per-user quotas](./docs/guide.md#quotas)** — daily limits per operation per subject, reserved and committed atomically in your database, fail-closed, never refunded after dispatch.
-- **[Runtime config](./docs/guide.md#runtime-config)** — three functions to read and write routes and limits, so an admin screen can change either without a deploy.
-- **[Stores](./docs/guide.md#stores)** — memory for dev, Postgres for production, or your own adapter behind two small interfaces, with a conformance suite that proves it.
-- **[Providers](./docs/guide.md#providers)** — `anthropic()`, `gemini()` and `openaiCompatible()`, all plain `fetch` against pinned API versions, plus the contract for writing your own.
-- **[Cost](./docs/guide.md#cost)** — per-attempt token usage, and dollar estimates from prices you supply; `null` rather than a misleading zero.
-- **[TypeScript](./docs/guide.md#typescript)** — operation names, inputs and `result.data` are all inferred, and every public type is exported.
-- **[Compatibility](./docs/guide.md#compatibility)** — Node.js ≥ 20, ESM and CJS, Zod 4 as the one peer dependency, PostgreSQL ≥ 14 for the Postgres adapter.
-- **[Using it in your framework](./docs/guide.md#using-it-in-your-framework)** — one instance, called from a route handler; runnable Next.js and Express examples ship in the repository.
+In production use `postgresStores({ pool, schema: 'llmdispatch' })` with your own pool. Apply the SQL from `migrationSql()` in `llmdispatch/postgres` with your usual migration tool; the library never touches your schema itself.
 
-## Roadmap
+Admin code on your server calls `ai.setConfig()` to change a route or a daily limit without a deploy. Postgres holds config and usage metadata only, never prompts, model output, or keys.
 
-- **v0.1** — everything above
-- **v0.2 candidates** — PDF/image input (provider-neutral content parts), per-subject quota overrides, headless admin UI kit, eval CLI for testing a provider switch before committing, streaming, Redis/SQLite stores
+## Limits
+
+Server-side only, Node.js 20 or newer, ESM and CJS. Input is text, output is text or validated JSON. No streaming, no PDF or image input yet. Those are the v0.2 candidates.
+
+## Documentation
+
+The [guide](./docs/guide.md) covers Postgres setup, runtime config, the fallback rules, quotas, errors, cost, custom stores, and framework examples. The exact contract is in the [specification](./docs/spec.md).
 
 ## Contributing
 
-Issues and PRs welcome — the project is actively developed and maintained. For API changes, open an issue to discuss before building; [docs/spec.md](./docs/spec.md) is the contract under discussion. Security problems go through private vulnerability reporting instead — see [SECURITY.md](./SECURITY.md). Stable releases will carry provenance.
+Issues and pull requests are welcome. For API changes, open an issue before building, since [docs/spec.md](./docs/spec.md) is the contract under discussion. Report security problems privately through [SECURITY.md](./SECURITY.md), not in a public issue. Releases are published from CI with provenance.
 
 ## License
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,10 +1,10 @@
 # Guide
 
-Everything llmdispatch does past the [README](../README.md) quickstart, in roughly the order you will need it. This is the working reference; the exact contract — state machine, store protocol, wire formats — is [spec.md](./spec.md).
+Everything llmdispatch does past the [README](../README.md) quickstart, in roughly the order you will need it. This is the working reference. The exact contract (state machine, store protocol, wire formats) is [spec.md](./spec.md).
 
 ## Output: from model text to typed data
 
-Each operation declares its `format`: `'json'` (default — a top-level JSON object), `'json-any'` (arrays/scalars), or `'text'`. Built-in adapters enable the provider's native JSON mode when the format is a top-level object and the provider genuinely supports it (that's per-provider verified — spec §5c). Responses are unwrapped from a whole-response code fence if present, parsed, then validated with your Zod schema (async transforms supported). A parse or validation failure is an **output rejection** — fallback-eligible, never silently returned. An optional `quality` gate runs after validation:
+Each operation declares its `format`: `'json'` (the default, a top-level JSON object), `'json-any'` (arrays and scalars), or `'text'`. Built-in adapters enable the provider's native JSON mode when the format is a top-level object and the provider genuinely supports it (verified per provider, spec §5c). Responses are unwrapped from a whole-response code fence if present, parsed, then validated with your Zod schema (async transforms supported). A parse or validation failure is an **output rejection**: fallback-eligible, never silently returned. An optional `quality` gate runs after validation:
 
 ```ts
 summarize: {
@@ -20,23 +20,23 @@ The exact pipeline is spec §3.
 
 ## Errors
 
-Classified llmdispatch failures throw `LLMDispatchError` with a stable `code` (exceptions from *your own* callbacks pass through raw — see below):
+Classified llmdispatch failures throw `LLMDispatchError` with a stable `code`. Exceptions from *your own* callbacks pass through raw (see below):
 
 | Code | Meaning | Retryable | Sensible HTTP |
 | --- | --- | --- | --- |
 | `INVALID_INPUT` | input failed the operation's input schema, or unknown operation name (JS callers) | no | 400 |
-| `MISSING_SUBJECT` | operation has an effective quota — declared in code or set on its route — but no `subjectId` was passed | no | 500 (caller bug) |
-| `CONFIG_STORE_UNAVAILABLE` | no fresh cached route and the config store is unreachable — refused, fail-closed; `getQuota` can report it too, since the limit lives in config | yes | 503 |
-| `INVALID_CONFIG` | bad or missing route, unregistered provider, unresolvable API key (`detectedAt: 'local'`) — or the provider rejected credentials/model (`detectedAt: 'provider'`); `getQuota` can report it too, for the same route problems, even when the limit itself is declared in code | no — except a transient local `prepare()` failure (e.g. secrets service briefly down): yes | 500 |
-| `QUOTA_EXCEEDED` | subject hit the daily limit; `error.resetsAt` attached | no (`resetsAt` says when to try again) | 429 |
-| `USAGE_STORE_UNAVAILABLE` | quota store unreachable — refused, fail-closed | yes | 503 |
-| `ABORTED` | your `AbortSignal` fired — no fallback attempted | no | 499 |
+| `MISSING_SUBJECT` | operation has an effective quota, declared in code or set on its route, but no `subjectId` was passed | no | 500 (caller bug) |
+| `CONFIG_STORE_UNAVAILABLE` | no fresh cached route and the config store is unreachable, so the call is refused, fail-closed. `getQuota` can report it too, since the limit lives in config | yes | 503 |
+| `INVALID_CONFIG` | bad or missing route, unregistered provider, unresolvable API key (`detectedAt: 'local'`), or the provider rejected credentials or model (`detectedAt: 'provider'`). `getQuota` can report it too, for the same route problems, even when the limit itself is declared in code | no, except a transient local `prepare()` failure (e.g. secrets service briefly down), which is retryable | 500 |
+| `QUOTA_EXCEEDED` | subject hit the daily limit. `error.resetsAt` attached | no (`resetsAt` says when to try again) | 429 |
+| `USAGE_STORE_UNAVAILABLE` | quota store unreachable, so the call is refused, fail-closed | yes | 503 |
+| `ABORTED` | your `AbortSignal` fired. No fallback attempted | no | 499 |
 | `PROVIDER_FAILED` | the final attempt failed at the provider level (see `error.attempts` for the full path) | per final classification (spec §5b) | 502 |
-| `OUTPUT_REJECTED` | the final attempt's output failed schema/quality validation, or was truncated by a token limit | yes | 502 |
+| `OUTPUT_REJECTED` | the final attempt's output failed schema or quality validation, or was truncated by a token limit | yes | 502 |
 
-The table is ordered: pre-dispatch checks run top-to-bottom (config before quota — a misconfigured operation never consumes quota). One nuance for an operation whose *code* declares no quota and gets one only from its route: llmdispatch can't know it is quota'd until config resolves, so for that case `CONFIG_STORE_UNAVAILABLE`/`INVALID_CONFIG` surfaces before `MISSING_SUBJECT`. An operation that declares a quota in code keeps the early check even when a route overrides the number. For post-dispatch failures the code reflects the **final attempt's** classification, with every attempt detailed in `error.attempts` (including token usage of failed runs). A fallback attempt can itself end in `INVALID_CONFIG` or `ABORTED` — the terminal-code mapping is spec §5b.
+The table is ordered: pre-dispatch checks run top to bottom, config before quota, so a misconfigured operation never consumes quota. One nuance for an operation whose *code* declares no quota and gets one only from its route: llmdispatch can't know it is quota'd until config resolves, so for that case `CONFIG_STORE_UNAVAILABLE` and `INVALID_CONFIG` surface before `MISSING_SUBJECT`. An operation that declares a quota in code keeps the early check even when a route overrides the number. For post-dispatch failures the code reflects the **final attempt's** classification, with every attempt detailed in `error.attempts` (including token usage of failed runs). A fallback attempt can itself end in `INVALID_CONFIG` or `ABORTED`. The terminal-code mapping is spec §5b.
 
-**`LLMDispatchError`'s package-owned fields are sanitized by design**: classifications, HTTP status codes, safe metadata — never prompts, model output, or raw provider errors from a dispatched attempt. One deliberate pass-through: a pre-dispatch error may chain the underlying store or `prepare()` failure as `cause`, verbatim — your own thrown error, or a provider adapter's readiness failure; do not treat that `cause` as sanitized. Exceptions thrown by *your own* code (prompt builder, quality gate, schema transforms) pass through unwrapped; they're your bugs to see in full.
+**`LLMDispatchError`'s package-owned fields are sanitized by design**: classifications, HTTP status codes, safe metadata, never prompts, model output, or raw provider errors from a dispatched attempt. One deliberate pass-through: a pre-dispatch error may chain the underlying store or `prepare()` failure as `cause`, verbatim. That is your own thrown error, or a provider adapter's readiness failure, so do not treat that `cause` as sanitized. Exceptions thrown by *your own* code (prompt builder, quality gate, schema transforms) pass through unwrapped. They're your bugs to see in full.
 
 ## When fallback fires
 
@@ -45,18 +45,18 @@ One fallback route per operation, one retry, decided by failure *classification*
 | Primary outcome | Fallback? |
 | --- | --- |
 | `transient` (network, 5xx), `rate_limit` (429), `malformed_response`, or attempt timeout | ✅ |
-| Output rejected (JSON/schema/quality) | ✅ |
-| `truncated` (provider signaled a max-token/context cutoff) | ✅ |
-| `refused` (provider refusal/safety block — another model will likely refuse too) | ❌ `PROVIDER_FAILED` |
-| `auth`, `model_not_found` (config problems — retrying elsewhere hides them) | ❌ `INVALID_CONFIG` by default — opt in via `fallbackOnAuthOrModelNotFound` |
+| Output rejected (JSON, schema, quality) | ✅ |
+| `truncated` (provider signaled a max-token or context cutoff) | ✅ |
+| `refused` (provider refusal or safety block, another model will likely refuse too) | ❌ `PROVIDER_FAILED` |
+| `auth`, `model_not_found` (config problems, retrying elsewhere hides them) | ❌ `INVALID_CONFIG` by default. Opt in via `fallbackOnAuthOrModelNotFound` |
 | `invalid_request` (content-dependent rejection, e.g. context length) | ❌ `PROVIDER_FAILED` |
-| Unclassified exception from a custom provider (adapter bug until proven otherwise) | ❌ by default — opt in via `treatUnclassifiedAsTransient` |
+| Unclassified exception from a custom provider (adapter bug until proven otherwise) | ❌ by default. Opt in via `treatUnclassifiedAsTransient` |
 | Your `AbortSignal` fired | ❌ `ABORTED` |
 | Anything failing before dispatch (input, config, quota, stores) | ❌ |
 
-`fallbackOnAuthOrModelNotFound: true` on `createSwitch` (off by default) lets a *primary* attempt that dies on bad credentials or an unrecognized model name fall back anyway — availability over noise, when a stale key shouldn't take an operation down. It's off by default because a broken route is worth finding out about immediately, rather than paying another provider to hide it, and it changes nothing else: when the fallback *also* dies on credentials or an unknown model the terminal code is still `INVALID_CONFIG`, and otherwise the final attempt's own classification decides it, as always (spec §5b).
+`fallbackOnAuthOrModelNotFound: true` on `createSwitch` (off by default) lets a *primary* attempt that dies on bad credentials or an unrecognized model name fall back anyway. That buys availability over noise, for when a stale key shouldn't take an operation down. It's off by default because a broken route is worth finding out about immediately, rather than paying another provider to hide it. It changes nothing else: when the fallback *also* dies on credentials or an unknown model the terminal code is still `INVALID_CONFIG`, and otherwise the final attempt's own classification decides it, as always (spec §5b).
 
-Built-in adapters make exactly one client-side HTTP request per attempt — no retries in llmdispatch's own HTTP layer, so `timeoutMs` and `attempts[]` mean what they say (a gateway host may retry upstream internally; that's outside our boundary). Truncated responses and provider refusals are detected from termination metadata (`finish_reason`/`stop_reason`), never passed off as good data — truncation falls back, refusals don't. Timeouts and caller cancellation are classified by llmdispatch itself, not the adapter: a timeout is retry-worthy, a caller who hung up is not.
+Built-in adapters make exactly one client-side HTTP request per attempt. There are no retries in llmdispatch's own HTTP layer, so `timeoutMs` and `attempts[]` mean what they say (a gateway host may retry upstream internally, which is outside our boundary). Truncated responses and provider refusals are detected from termination metadata (`finish_reason`, `stop_reason`), never passed off as good data: truncation falls back, refusals don't. Timeouts and caller cancellation are classified by llmdispatch itself, not the adapter. A timeout is retry-worthy, a caller who hung up is not.
 
 ```ts
 operations: { summarize: { /* ... */ timeoutMs: 60_000 } }   // provider I/O timeout per attempt; default 60s
@@ -65,30 +65,30 @@ await ai.run('summarize', { input, subjectId }, { signal: controller.signal })
 
 ## Quotas
 
-Limits are per operation, per `subjectId`, per UTC day — and the *store's* clock owns the day boundary. A limit can be declared in code and overridden at runtime from the config store, exactly like a route ([Runtime config](#runtime-config)). The accounting unit is one **run**: a run and its fallback attempt share one slot. Lifecycle (spec §4 has the exact store contract):
+Limits are per operation, per `subjectId`, per UTC day, and the *store's* clock owns the day boundary. A limit can be declared in code and overridden at runtime from the config store, exactly like a route ([Runtime config](#runtime-config)). The accounting unit is one **run**: a run and its fallback attempt share one slot. Lifecycle (spec §4 has the exact store contract):
 
-1. **Reserve** — after config checks pass, one slot is atomically reserved. Over the limit → `QUOTA_EXCEEDED`, nothing dispatched.
-2. **Commit** — an idempotent, confirmed transition immediately before the first provider request. **Committed slots are never refunded** — a run that reaches a provider counts even if it fails, because refunding failures would let a failing user burn unlimited provider spend. llmdispatch never dispatches without a confirmed commit.
-3. **Expire** — a reservation that never commits (crash before dispatch) expires after its lease and frees the slot — safe, because no provider was called.
-4. **Settle** — attempt records are written idempotently, best-effort with bounded retries and an `onSettlementError` hook. Settlement is accounting only: quota correctness was fixed at commit, and a settlement failure never changes an otherwise successful outcome (the initial write may delay delivery by up to its 10s deadline in the worst case).
+1. **Reserve.** After config checks pass, one slot is atomically reserved. Over the limit gives `QUOTA_EXCEEDED`, with nothing dispatched.
+2. **Commit.** An idempotent, confirmed transition immediately before the first provider request. **Committed slots are never refunded**: a run that reaches a provider counts even if it fails, because refunding failures would let a failing user burn unlimited provider spend. llmdispatch never dispatches without a confirmed commit.
+3. **Expire.** A reservation that never commits (crash before dispatch) expires after its lease and frees the slot. That is safe, because no provider was called.
+4. **Settle.** Attempt records are written idempotently, best-effort with bounded retries and an `onSettlementError` hook. Settlement is accounting only: quota correctness was fixed at commit, and a settlement failure never changes an otherwise successful outcome (the initial write may delay delivery by up to its 10s deadline in the worst case).
 
-**Fail-closed** end to end: unreachable stores refuse calls; operations with an effective quota refuse without a `subjectId`. Derive `subjectId` server-side from your authenticated session — never accept it from the client, or users can spend each other's allowance.
+**Fail-closed** end to end: unreachable stores refuse calls, and operations with an effective quota refuse without a `subjectId`. Derive `subjectId` server-side from your authenticated session. Never accept it from the client, or users can spend each other's allowance.
 
 ```ts
 const q = await ai.getQuota('summarize', user.id)
 // { limit: 10, used: 3, remaining: 7, resetsAt: '2026-08-11T00:00:00.000Z' }
-// used and resetsAt come from the store (authoritative); limit is the effective limit —
+// used and resetsAt come from the store (authoritative). limit is the effective limit:
 // the route's override if it sets one, otherwise the value declared in code, so getQuota
 // reads config before usage.
 ```
 
-Set `perDay: 0` to halt an operation during an incident: every reservation is denied, no reservation is recorded, and callers get `QUOTA_EXCEEDED` whenever the usage store answers — if that store is itself unreachable the call still refuses, as `USAGE_STORE_UNAVAILABLE`. It takes effect like any other config change (see the cache note under [Runtime config](#runtime-config)), and `getQuota` keeps reporting the day's real `used` while `limit` and `remaining` read 0.
+Set `perDay: 0` to halt an operation during an incident. Every reservation is denied, no reservation is recorded, and callers get `QUOTA_EXCEEDED` whenever the usage store answers. If that store is itself unreachable the call still refuses, as `USAGE_STORE_UNAVAILABLE`. It takes effect like any other config change (see the cache note under [Runtime config](#runtime-config)), and `getQuota` keeps reporting the day's real `used` while `limit` and `remaining` read 0.
 
-The Postgres adapter stores metadata only — operation, subject, day, states, token counts — **never prompts or outputs**, and ships with pruning guidance (spec §4).
+The Postgres adapter stores metadata only (operation, subject, day, states, token counts), **never prompts or outputs**, and ships with pruning guidance (spec §4).
 
 ## Runtime config
 
-Routing and daily limits live in the config store, with code-declared defaults underneath. Three functions — build any admin screen on top:
+Routing and daily limits live in the config store, with code-declared defaults underneath. Three functions, enough to build any admin screen on top:
 
 ```ts
 await ai.getConfig()                    // authoritative: { stored, effective } per operation
@@ -98,34 +98,34 @@ await ai.setConfig('summarize', {       // replace-only, validated, last-write-w
   quota: { perDay: 50 },                // optional: overrides the limit declared in code
   fallback: null,
 })
-await ai.resetConfig('summarize')       // delete the stored row → defaultRoute applies again
+await ai.resetConfig('summarize')       // delete the stored row, so defaultRoute applies again
 ```
 
-Because the limit rides on the route, changing a daily allowance is an edit on your admin surface, not a deploy: raise it for a customer who needs more, or set it to 0 to stop an operation while you investigate. Leave `quota` off the row and the operation uses the limit declared in its code — a stored row never inherits a `defaultRoute`'s limit — and `resetConfig` puts route and limit back together.
+Because the limit rides on the route, changing a daily allowance is an edit on your admin surface, not a deploy: raise it for a customer who needs more, or set it to 0 to stop an operation while you investigate. Leave `quota` off the row and the operation uses the limit declared in its code, since a stored row never inherits a `defaultRoute`'s limit. `resetConfig` puts route and limit back together.
 
 The rules, stated plainly:
 
-- **Config can only reference registered provider IDs**, and secrets never enter the store. With built-in adapters, a tampered row can misroute among *your* registered endpoints but cannot redirect traffic to an arbitrary attacker URL. Scope honestly: for gateway-style providers (e.g. OpenRouter) the model string itself selects downstream infrastructure — protect store write access like the privileged surface it is.
-- Rows are **validated on every read**; a malformed row fails its own operation (`INVALID_CONFIG`) without poisoning others.
-- `defaultRoute` applies **only when a successful store read finds no row** — never as an outage fallback. Expired cache + unreachable store = `CONFIG_STORE_UNAVAILABLE`, fail-closed, so an outage can't silently undo an operator's route switch. Full resolution matrix: spec §2.
-- Reads are cached per process (default 5s, `configTtlMs`), and a change — to a route or a limit — reaches another instance when that instance's cached entry expires and it re-reads. This is not an upper bound: an instance that read just before your write can keep serving the old value for one more TTL after that read finishes, and how fast your write becomes visible to other instances' reads is your store's business, not llmdispatch's. Your own process sees its own writes immediately. In-flight runs always finish on the route and limit they resolved with.
+- **Config can only reference registered provider IDs**, and secrets never enter the store. With built-in adapters, a tampered row can misroute among *your* registered endpoints but cannot redirect traffic to an arbitrary attacker URL. Scope that honestly: for gateway-style providers (e.g. OpenRouter) the model string itself selects downstream infrastructure, so protect store write access like the privileged surface it is.
+- Rows are **validated on every read**. A malformed row fails its own operation (`INVALID_CONFIG`) without poisoning others.
+- `defaultRoute` applies **only when a successful store read finds no row**, never as an outage fallback. Expired cache plus unreachable store gives `CONFIG_STORE_UNAVAILABLE`, fail-closed, so an outage can't silently undo an operator's route switch. Full resolution matrix: spec §2.
+- Reads are cached per process (default 5s, `configTtlMs`), and a change to a route or a limit reaches another instance when that instance's cached entry expires and it re-reads. This is not an upper bound: an instance that read just before your write can keep serving the old value for one more TTL after that read finishes, and how fast your write becomes visible to other instances' reads is your store's business, not llmdispatch's. Your own process sees its own writes immediately. In-flight runs always finish on the route and limit they resolved with.
 
 ## Stores
 
-Two interfaces; implement them for any database, or use the built-in pairs:
+Two interfaces. Implement them for any database, or use the built-in pairs:
 
 ```ts
 import { memoryStores, postgresStores } from 'llmdispatch'
 
-stores: memoryStores()                                 // dev & tests — resets on restart
-stores: postgresStores({ pool, schema: 'llmdispatch' })  // production — plain SQL, bring your own pg.Pool
+stores: memoryStores()                                 // dev & tests, resets on restart
+stores: postgresStores({ pool, schema: 'llmdispatch' })  // production, plain SQL, bring your own pg.Pool
 ```
 
-`postgresStores` ships a versioned SQL migration (you run it — llmdispatch never touches your schema on its own) and uses single-statement atomic operations, safe under concurrency. The exact `ConfigStore`/`UsageStore` contracts — including the idempotent commit protocol and lease semantics — are spec §4 and §6, and a **conformance test suite** ships with the package: passing it verifies your custom adapter against every executed case, concurrency included — check its `skipped` list, because scenarios you don't supply are unverified, not passed.
+`postgresStores` ships a versioned SQL migration (you run it, llmdispatch never touches your schema on its own) and uses single-statement atomic operations, safe under concurrency. The exact `ConfigStore` and `UsageStore` contracts, including the idempotent commit protocol and lease semantics, are spec §4 and §6. A **conformance test suite** ships with the package: passing it verifies your custom adapter against every executed case, concurrency included. Check its `skipped` list, because scenarios you don't supply are unverified, not passed.
 
-The pool you hand it must run at `READ COMMITTED`, which is PostgreSQL's default: that is the level the single-statement reserve is built for, and under `REPEATABLE READ` or `SERIALIZABLE` two concurrent reserves abort with a serialization failure (surfaced as the usage store being unavailable) instead of one of them being cleanly denied.
+The pool you hand it must run at `READ COMMITTED`, which is PostgreSQL's default. That is the level the single-statement reserve is built for, and under `REPEATABLE READ` or `SERIALIZABLE` two concurrent reserves abort with a serialization failure (surfaced as the usage store being unavailable) instead of one of them being cleanly denied.
 
-Applying the schema is your job, not the library's: `migrationSql()` from `llmdispatch/postgres` returns the SQL and its sha256, and you run it with whatever tool you already use, in a schema dedicated to llmdispatch. Re-running the same file is safe — every statement is idempotent, so "apply twice" and "re-run after a failure" are the same operation — and a *different* version-1 template is refused by the version record at the end of the file. The file carries no transaction control of its own, though, because migration tools differ on whether they supply theirs: a tool that commits statement by statement leaves the earlier DDL in place when that final record is the thing that conflicts, and re-running the same file is what completes a partial apply.
+Applying the schema is your job, not the library's. `migrationSql()` from `llmdispatch/postgres` returns the SQL and its sha256, and you run it with whatever tool you already use, in a schema dedicated to llmdispatch. Re-running the same file is safe, because every statement is idempotent, so "apply twice" and "re-run after a failure" are the same operation. A *different* version-1 template is refused by the version record at the end of the file. The file carries no transaction control of its own, though, because migration tools differ on whether they supply theirs: a tool that commits statement by statement leaves the earlier DDL in place when that final record is the thing that conflicts, and re-running the same file is what completes a partial apply.
 
 Apply the whole rendered file in one transaction on one connection, which is also what makes an advisory lock cover the DDL rather than just the call that took it:
 
@@ -142,7 +142,7 @@ import { migrationSql } from 'llmdispatch/postgres'
 const { sql } = migrationSql({ schema: 'llmdispatch' })   // your migration tool runs this
 ```
 
-Whatever store you write it against, the strings llmdispatch hands a store — operation names, provider IDs, models, subject IDs, reservation IDs — are well-formed Unicode, free of U+0000, and at most 1 000 bytes of UTF-8, checked before every store call, so any relational backend can hold them verbatim (spec §6).
+Whatever store you write it against, the strings llmdispatch hands a store (operation names, provider IDs, models, subject IDs, reservation IDs) are well-formed Unicode, free of U+0000, and at most 1 000 bytes of UTF-8, checked before every store call, so any relational backend can hold them verbatim (spec §6).
 
 ## Providers
 
@@ -152,11 +152,13 @@ Whatever store you write it against, the strings llmdispatch hands a store — o
 | `openaiCompatible()` | OpenAI-shaped APIs (`baseUrl` for non-OpenAI hosts) | OpenAI, DeepSeek, OpenRouter; others best-effort |
 | `gemini()` | Google Gemini models | Gemini API (live check each release) |
 
-Built-in adapters are **zero-dependency**: plain `fetch` against pinned API versions (with redirects disabled — exactly one HTTP request per attempt), no vendor SDKs to install, ever. They're ordinary implementations of the same public `Provider` interface, including its optional `prepare()` readiness hook — nothing built-in has special powers, so the package stays provider-agnostic by construction.
+Built-in adapters are **zero-dependency**: plain `fetch` against pinned API versions (with redirects disabled, exactly one HTTP request per attempt), no vendor SDKs to install, ever. They're ordinary implementations of the same public `Provider` interface, including its optional `prepare()` readiness hook. Nothing built-in has special powers, so the package stays provider-agnostic by construction.
 
-Why two native adapters instead of routing everything through OpenAI-compatibility layers? Because we verified the compat layers break exactly what llmdispatch depends on: Anthropic's compat endpoint ignores `response_format` entirely (no JSON mode) and is documented by Anthropic as a testing tool, and Gemini's is beta with token totals that silently include unitemized "thinking" tokens — which would corrupt cost tracking. The exact wire contracts and error mappings for all three adapters are spec §5c, with sources — also published as a per-adapter reference in [providers.md](./providers.md).
+Why two native adapters instead of routing everything through OpenAI-compatibility layers? Because we verified the compat layers break exactly what llmdispatch depends on. Anthropic's compat endpoint ignores `response_format` entirely (no JSON mode) and is documented by Anthropic as a testing tool, and Gemini's is beta with token totals that silently include unitemized "thinking" tokens, which would corrupt cost tracking. The exact wire contracts and error mappings for all three adapters are spec §5c, with sources, and are also published as a per-adapter reference in [providers.md](./providers.md).
 
-Custom providers implement one required method (plus an optional `prepare()` readiness hook) and classify their failures with `ProviderError` — the classification is what drives the fallback matrix. Full contract and types: spec §5–6.
+Register every provider you might ever want, on day one. It costs nothing: API keys resolve lazily, so a registered provider with no key only fails if you actually route to it. A `fallback` on a route counts as routed, so its key is checked before anything runs. Adding a provider later is then one env var and one route change in your admin screen, with no code push. `openaiCompatible` pointed at a gateway such as OpenRouter reaches a large model catalogue through a single registration.
+
+Custom providers implement one required method (plus an optional `prepare()` readiness hook) and classify their failures with `ProviderError`. The classification is what drives the fallback matrix. Full contract and types: spec §5 and §6.
 
 ```ts
 import { ProviderError, type Provider } from 'llmdispatch'
@@ -174,7 +176,7 @@ const myProvider: Provider = {
 
 ## Cost
 
-Token usage is reported per attempt, normalized from provider-reported counts into `{ inputTokens, outputTokens }` (`null` when the provider didn't report — spec §7 defines each adapter's mapping). Dollar cost is computed **only from prices you supply**, keyed by provider ID + model — the same model can cost differently through different providers, and a bundled price table would go stale and lie:
+Token usage is reported per attempt, normalized from provider-reported counts into `{ inputTokens, outputTokens }`, and `null` when the provider didn't report (spec §7 defines each adapter's mapping). Dollar cost is computed **only from prices you supply**, keyed by provider ID plus model. The same model can cost differently through different providers, and a bundled price table would go stale and lie:
 
 ```ts
 createSwitch({
@@ -185,18 +187,18 @@ createSwitch({
 })
 ```
 
-`result.cost` is a **simple input/output-token estimate** (cached-token discounts and request fees are out of scope in v0.1 — spec §7), and it's `null` whenever any dispatched attempt is unpriced or has unknown usage — explicitly unknown, never a misleading zero.
+`result.cost` is a **simple input/output-token estimate** (cached-token discounts and request fees are out of scope in v0.1, spec §7), and it's `null` whenever any dispatched attempt is unpriced or has unknown usage. Explicitly unknown, never a misleading zero.
 
 ## TypeScript
 
-Inference-first: operation names are typed (`ai.run('summarize', …)` compiles, `ai.run('sumarize', …)` doesn't), `input` checks against the operation's input schema, and `result.data` is the output schema's inferred type. All public types — `Provider`, `ProviderError`, `ConfigStore`, `UsageStore`, `LLMDispatchError`, `OperationDefinition` — are exported and specified in spec §6.
+Inference-first: operation names are typed (`ai.run('summarize', …)` compiles, `ai.run('sumarize', …)` doesn't), `input` checks against the operation's input schema, and `result.data` is the output schema's inferred type. All public types (`Provider`, `ProviderError`, `ConfigStore`, `UsageStore`, `LLMDispatchError`, `OperationDefinition`) are exported and specified in spec §6.
 
 ## Compatibility
 
 - **Node.js ≥ 20**, server-side only. Browsers and edge runtimes are not supported in v0.1.
-- **No bundled runtime dependencies** — **Zod 4** is the one required peer you install alongside it.
+- **No bundled runtime dependencies.** **Zod 4** is the one required peer you install alongside it.
 - **ESM and CJS** both supported, with explicit `exports` and bundled type declarations.
-- Postgres adapter: PostgreSQL ≥ 14, bring your own pool (any object with a `query` method — `pg` works, but isn't required by llmdispatch).
+- Postgres adapter: PostgreSQL ≥ 14, bring your own pool (any object with a `query` method, so `pg` works but isn't required by llmdispatch).
 
 ## Using it in your framework
 
@@ -205,7 +207,7 @@ One instance, called from wherever your server handles requests. Runnable exampl
 ```ts
 // Next.js route handler
 export async function POST(req: Request) {
-  const userId = await requireUser(req)            // your auth — subjectId must be server-derived
+  const userId = await requireUser(req)            // your auth: subjectId must be server-derived
   const parsed = BodySchema.safeParse(await req.json())
   if (!parsed.success) return Response.json({ error: 'Bad request' }, { status: 400 })
   try {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "llmdispatch",
   "version": "0.1.0",
-  "description": "Route each AI operation to the right LLM — swap providers at runtime, fall back on failure, enforce per-user quotas in your own Postgres.",
+  "description": "Model-agnostic LLM routing. Pick the provider and model per operation, swap them at runtime, fall back on failure, and enforce per-user quotas in your own Postgres.",
   "keywords": [
     "llm",
+    "model-agnostic",
+    "provider-agnostic",
     "anthropic",
     "openai",
     "gemini",


### PR DESCRIPTION
Rewrites the readme so it can be read in a minute: one install command, one worked example that still compiles as a type fixture, then links out to the guide and spec. The duplicated feature list, the package-manager variants and the provider-planning aside are gone; the useful part of that aside (keys resolve lazily, so registering a provider early costs nothing) moved into the guide.

Opens on the library being model agnostic, and the package description now says the same.

The guide keeps all of its content and is reworded for plainer sentences.

Readme is 114 lines to 98. `npm run check` passes, including the 16 compile fixtures, one of which is the readme quickstart itself.