### PR TITLE
docs: rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - run: npm run typecheck
       - run: npm run depcruise
       - run: npm run build
-      # Every fixture — the README quickstart fence included — compiled against the build
+      # Every fixture, the README quickstart fence included, compiled against the build
       # rather than against the spec.
       - name: Compile the fixtures the build can satisfy against it
         run: node scripts/check-types-fixtures.mjs --target package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,7 +87,7 @@ jobs:
 
   # Stages the artifact the audit job produced. The environment approval happens
   # here: after the audit, immediately before the registry is changed. Staging never
-  # makes a version installable — promoting it is a separate, 2FA-protected act.
+  # makes a version installable; promoting it is a separate, 2FA-protected act.
   publish:
     needs: audit
     # An audit-only run never reaches this job, so no approval is left pending on it.
@@ -97,7 +97,7 @@ jobs:
     environment: release
     permissions:
       contents: read
-      # How this job proves to npm which repository, workflow and run it is — both the
+      # How this job proves to npm which repository, workflow and run it is: both the
       # OIDC credential it authenticates with and what the provenance is minted from.
       # This is the only job that holds the permission.
       id-token: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@
 
 ### Patch Changes
 
-- e5ef94e: Docs: the README quickstart is now self-contained and mechanically verified — its
+- e5ef94e: Docs: the README quickstart is now self-contained and mechanically verified: its
   TypeScript fence is compiled straight out of the README against both the spec and the
   built package, and executed in a clean directory against a packed tarball in CI. New
   generated per-adapter wire reference at `docs/providers.md` (built verbatim from spec §5c,
   drift-gated, shipped in the npm package). Every markdown link and anchor is now checked in
   CI. Error-sanitization wording in README and SECURITY scoped to package-owned fields, with
   the pre-dispatch `cause` pass-through disclosed.
-- 2f6e1d9: Docs: the README's Contributing section now points at the security policy — security
+- 2f6e1d9: Docs: the README's Contributing section now points at the security policy, since security
   problems go through GitHub's private vulnerability reporting, described in `SECURITY.md`,
   rather than an issue or a pull request.
-- ee1bcb9: Docs: the README now links two runnable examples — `examples/next` (TypeScript, App
-  Router) and `examples/express` (plain JavaScript) — each a self-contained project that
+- ee1bcb9: Docs: the README now links two runnable examples: `examples/next` (TypeScript, App
+  Router) and `examples/express` (plain JavaScript), each a self-contained project that
   installs the packed tarball and runs one operation end to end, and each verified that way
   in CI against a local fixture provider rather than a live key. The Quickstart also notes
   that any package manager works.
@@ -24,7 +24,7 @@ Notable changes to this package, in the style of
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are generated from
 changesets when a release is prepared, so nothing is written here by hand.
 
-While the package is on `0.x`, a breaking change bumps the **minor** version — see the
+While the package is on `0.x`, a breaking change bumps the **minor** version. See the
 semantic-versioning note in `docs/spec.md`.
 
 Nothing has been released yet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for looking. This package is pre-release: the design in [`docs/spec.md`](docs/spec.md)
 is settled and the implementation is being written against it. If you are thinking of a
-change, open an issue first — it is a short conversation, and it saves you from writing
+change, open an issue first. It is a short conversation, and it saves you from writing
 code against a contract that says something different.
 
 ## Getting set up
@@ -12,12 +12,12 @@ npm ci
 npm run check
 ```
 
-`npm run check` is the whole local pass: formatting, lint, types — the compile fixtures
-included — module boundaries, the build, then the subset of those fixtures whose imports
+`npm run check` is the whole local pass: formatting, lint, types (the compile fixtures
+included), module boundaries, the build, then the subset of those fixtures whose imports
 already exist in the build compiled against it (the rest join as the remaining exports land),
 the export inventory comparing `dist/` with the specification, package
 linting, package typing, the public type surface, the size budget, and the unit tests with
-coverage. If it is green, continuous integration will almost certainly agree — it runs the
+coverage. If it is green, continuous integration will almost certainly agree, since it runs the
 same thing plus a few checks that need a database, a second Node, or a network download.
 
 Node 24.19.0 is the development version (`.nvmrc`); the package supports Node 20 and up,
@@ -29,7 +29,7 @@ Nothing below is a matter of taste. Each one has a check behind it, so you will 
 from `npm run check` rather than from a comment on your pull request.
 
 **Types.** `strict` plus `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`. No
-`any` anywhere — the lint rule is an error, not a warning. No non-null assertions outside
+`any` anywhere: the lint rule is an error, not a warning. No non-null assertions outside
 tests. Type-only imports are written as such.
 
 **Module boundaries.** The folders in `src/` are a dependency order, not a filing system;
@@ -52,33 +52,33 @@ changeset (`npx changeset`).
 **The specification is the surface.** `test/types/spec-surface*.d.ts` are generated from the
 §6 and §6b code fences of [`docs/spec.md`](docs/spec.md): edit the spec, run `npm run
 surface:update`, never edit them by hand. `check-spec-surface.mjs` compares every name
-`dist/` exports — both module systems, type told from value — with what the spec declares. A
+`dist/` exports, both module systems and type told from value, with what the spec declares. A
 spec name the implementation has not reached yet is listed in `test/types/spec-pending.json`;
 a name on that list which has appeared in `dist/` fails as loudly as one that is missing.
 
-**Compile fixtures.** `test/types/positive/` must compile with no diagnostic at all — the
-README's examples among them — and `test/types/negative/` holds the shapes the README
+**Compile fixtures.** `test/types/positive/` must compile with no diagnostic at all, the
+README's examples among them, and `test/types/negative/` holds the shapes the README
 promises will not compile. `check-types-fixtures.mjs` compiles each in a program of its own:
 
 - line one is `// @targets spec[, package]`; every fixture targets `spec`, and gains
   `package` once every value it imports exists in `dist/`.
 - a negative fixture carries `// @expect TS####` on the line above the offending one and must
   produce exactly that: "something went wrong" is not evidence.
-- no suppression and no `any` — either would let a fixture compile proving nothing.
+- no suppression and no `any`, since either would let a fixture compile proving nothing.
 - `test/types/scaffold.d.ts` declares the values the README examples use without introducing
   them, so those examples compile as printed.
 
 **Errors.** Two public classes. `LLMDispatchError` has a closed set of codes and a `retryable`
 flag copied from the classification row in spec §5b rather than worked out on the spot. The
-flag belongs to the row and not to the code — `PROVIDER_FAILED` is retryable for a
-`transient` failure and not for a `refused` one — which is why `src/errors` has one factory
+flag belongs to the row and not to the code: `PROVIDER_FAILED` is retryable for a
+`transient` failure and not for a `refused` one, which is why `src/errors` has one factory
 per classification, and why nothing is ever constructed by hand. `ProviderError` is what a
-provider adapter throws, and it is recognised with `ProviderError.is()` — never bare
+provider adapter throws, and it is recognised with `ProviderError.is()`, never bare
 `instanceof`, which breaks the moment ESM and CommonJS copies meet. Messages never contain a
 prompt, a model's output, or a raw provider error.
 
 **Tests.** Vitest. Unit tests run everywhere; the ones that need PostgreSQL live in
-`test/integration` and read `DATABASE_URL`. They are skipped when it is unset — except in
+`test/integration` and read `DATABASE_URL`. They are skipped when it is unset, except in
 continuous integration, where a missing database is a failure rather than a quiet pass. The
 version they are written against is the one CI runs:
 
@@ -129,7 +129,7 @@ section.
 Everything that takes a tarball takes one you produced with `npm pack`; they never pack one
 themselves, so what you audit is what you test.
 
-`verify:release` needs `DATABASE_URL` pointing at a throwaway database on this machine — it
+`verify:release` needs `DATABASE_URL` pointing at a throwaway database on this machine. It
 creates a schema, writes to it and drops it, so it takes exactly one shape,
 `postgres://user:password@127.0.0.1:port/database`: an address in 127.0.0.0/8, a port written
 out, and no query string or fragment. The header of `scripts/verify-release.mjs` has a
@@ -139,12 +139,12 @@ container to run it against.
 `npm run check` and never runs in continuous integration. Each provider is called in a process
 of its own holding only that provider's key; use throwaway keys and revoke them afterwards. Run
 `npm run live:providers -- --release <tgz>` to check a packed tarball rather than your working
-tree — that form requires every adapter to run, so a missing key is a failure instead of a
+tree, since that form requires every adapter to run, so a missing key is a failure instead of a
 skip. (The `--` is what stops npm from eating the arguments.)
 
 ## How changes land
 
-**Commit messages follow Conventional Commits** — `feat:`, `fix:`, `docs:`, and the rest.
+**Commit messages follow Conventional Commits**: `feat:`, `fix:`, `docs:`, and the rest.
 That is the convention the history is written in; the changelog itself is generated from
 changesets, not from commit messages, so the prefix is for the reader of `git log`.
 
@@ -152,7 +152,7 @@ changesets, not from commit messages, so the prefix is for the reader of `git lo
 away before the final review. The history is linear and there are no merge commits, so
 `git log` reads as the order things actually happened.
 
-**Never a live API key** — not in a pull request, not in a fixture, not in continuous
+**Never a live API key**: not in a pull request, not in a fixture, not in continuous
 integration. Fixtures are synthetic, or recorded from a real response and then redacted; CI
 runs without provider keys by construction rather than by anyone remembering. `npm run scan`
 is part of reviewing a change, and secret hygiene is checked before anything is pushed, not
@@ -164,7 +164,7 @@ Getting a version out is a separate procedure with its own preconditions:
 ## Pull requests
 
 One coherent change per pull request, with the checks green. Explain what the change does
-and why in the description — the commit history is the project's memory. If the change is
+and why in the description, because the commit history is the project's memory. If the change is
 visible to users of the package, say so in a changeset.
 
 Security problems do not go in a pull request: see [`SECURITY.md`](SECURITY.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,12 @@
 # Releasing
 
-How a version of this package reaches npm. Written so that whoever does it next — including
-me, six months from now — does not have to work out the reasoning again.
+How a version of this package reaches npm. Written so that whoever does it next, including
+me, six months from now, does not have to work out the reasoning again.
 
 A release is staged before it is published. The workflow builds the bytes, audits them and
 hands them to the registry as a _staged_ version: reserved, downloadable by a maintainer,
 and installable by nobody. The same bytes are then downloaded, verified, and promoted by
-hand behind a 2FA challenge. That split is the point of this document — what gets verified
+hand behind a 2FA challenge. That split is the point of this document: what gets verified
 is what gets published, because there is only ever one tarball.
 
 ## Before any release
@@ -40,18 +40,18 @@ both pass:
 ( cd <checkout>; node scripts/live-check-providers.mjs --release ~/release-<version>/<tarball> )
 ```
 
-**Where they run from:** both are scripts in this repository, so they need a checkout of it —
+**Where they run from:** both are scripts in this repository, so they need a checkout of it,
 the directory the tarball sits in holds nothing but the tarball and its hashes. The
 subshells are what keep that a detour: the shell you are working in stays where it was, and
 the tarball is passed across by path.
 
-That checkout must be at the commit being released and clean — `git status --porcelain`
-prints nothing — because the scripts and the helpers they import come out of it: an edited
+That checkout must be at the commit being released and clean (`git status --porcelain`
+prints nothing), because the scripts and the helpers they import come out of it: an edited
 harness verifies something other than the release. What comes from the tarball is the package
 under test, which each script installs into a scratch project and exercises from there.
 
 The first installs that tarball into a scratch project, applies the packaged SQL to a real
-PostgreSQL and runs all three conformance suites from the installed package — not from the
+PostgreSQL and runs all three conformance suites from the installed package, not from the
 working tree, so what is verified is what adopters get. It needs `DATABASE_URL` pointing at
 a throwaway database on this machine; `CONTRIBUTING.md` has the shape it accepts and the
 script's own header has a container to run it against.
@@ -63,7 +63,7 @@ is a failure rather than a skip. Use throwaway keys and revoke them when you sto
 when you finish.
 
 **When they run:** on the staged tarball, after the workflow has staged the release and
-before you approve it — that is the only moment the bytes are both final and not yet
+before you approve it: that is the only moment the bytes are both final and not yet
 installable by anyone. The release candidate in the bootstrap below is verified the same
 way, on the audited artifact, before it is published from a laptop.
 
@@ -86,7 +86,7 @@ staging.
    hash record names, in the same step, so there is no window between verifying the bytes and
    sending them. It authenticates over OIDC and carries no token. A staged version is
    reserved and downloadable, and `npm install` cannot reach it. The stage also records the
-   dist-tag the version will take — `latest`, since the step passes no `--tag` — and that tag
+   dist-tag the version will take (`latest`, since the step passes no `--tag`) and that tag
    is applied when the stage is approved rather than now. That is what a stable release
    wants. A prerelease is a different matter: npm refuses to stage one under the default tag
    at all, so staging a prerelease through this workflow would mean adding `--tag` to the
@@ -102,7 +102,7 @@ staging.
 
    Work from this directory for the rest of the flow, and keep it outside any checkout of
    this repository: the scratch install in step 10 needs a directory that is nobody's
-   subdirectory. The two verification commands are the exception — they are scripts in this
+   subdirectory. The two verification commands are the exception: they are scripts in this
    repository, so they run from a checkout at the released commit with the tarball passed by
    path, as _Release verification_ shows.
 
@@ -113,8 +113,8 @@ staging.
    npm stage list llmdispatch
    ```
 
-   Exactly one stage for the version being released. If there is another — an abandoned
-   attempt, most likely — reject it before going on, so that "the stage" means one thing for
+   Exactly one stage for the version being released. If there is another, an abandoned
+   attempt, most likely, reject it before going on, so that "the stage" means one thing for
    the rest of these steps. Every `npm stage` subcommand needs authenticated maintainer
    access; OIDC can only stage.
 
@@ -122,7 +122,7 @@ staging.
    the listing above. npm scans staged bytes like any other upload, and a stage it has not
    finished with can be neither downloaded nor approved. At the time of writing the CLI
    reports that condition as `validating`; wait for it to report the stage as ready. A stage
-   that ends in a failed or rejected state is not something to retry into — reject it and
+   that ends in a failed or rejected state is not something to retry into. Reject it and
    find out why, as in the mismatch branch below. The exact state names, like the `shasum`
    field that branch reads, are worth confirming here on the first staged release, before
    anything depends on them.
@@ -144,17 +144,17 @@ staging.
    giving each the full path to the file you just downloaded; in the subshell form shown
    there, they leave you in this directory. If the hashes differ, this is not a retry and not a rebuild: the
    registry is holding bytes that were never audited. Do not approve. Reject the stage, and
-   treat it as a security incident — audit the account, its tokens and the workflow before
+   treat it as a security incident: audit the account, its tokens and the workflow before
    anything is dispatched again.
 
-9. Approve the stage you just downloaded and verified — the same identifier, not the newest
+9. Approve the stage you just downloaded and verified, the same identifier, not the newest
    one on the listing:
 
    ```bash
    npm stage approve <stage-id>
    ```
 
-   npm answers with a 2FA challenge. If none appears, **stop** — the credential in play is
+   npm answers with a 2FA challenge. If none appears, **stop**: the credential in play is
    not the one this process assumes. Approval promotes the same registry-held bytes; nothing
    is rebuilt and nothing is re-uploaded. Staged versions carry provenance exactly as direct
    publishes do. The version is installable from this moment, under the tag the stage
@@ -200,7 +200,7 @@ staging.
 
     Two statements print: the publish attestation, and the provenance one, whose
     `predicateType` names SLSA provenance. In the provenance statement,
-    `subject[0].digest.sha512` is the subject digest — it must equal `$expected` — and
+    `subject[0].digest.sha512` is the subject digest, and it must equal `$expected`;
     `subject[0].name` is the package and version it was signed for. The rest sits under
     `predicate`: `buildDefinition.externalParameters.workflow` carries the repository, the
     workflow file and the ref, `buildDefinition.resolvedDependencies[0].digest.gitCommit` the
@@ -216,13 +216,13 @@ staging.
 
     That prints `sha512-` and the registry's digest for the tarball in base64; decode it with
     `node -p "Buffer.from('<base64>', 'base64').toString('hex')"` and compare with
-    `$expected`. It is a different question from the attestation — what installers receive,
-    rather than what the registry attests about where it came from — and both must answer
+    `$expected`. It is a different question from the attestation (what installers receive,
+    rather than what the registry attests about where it came from) and both must answer
     the same digest.
 
     A missing attestation, a missing entry, or a digest that does not match is an incident on
-    a version that is already installable. Deprecate it while you investigate —
-    `npm deprecate llmdispatch@<version> "under investigation"` — rather than leaving it
+    a version that is already installable. Deprecate it while you investigate,
+    `npm deprecate llmdispatch@<version> "under investigation"`, rather than leaving it
     recommended to everyone, and do not go on to step 11.
 
 11. Settle the dist-tags. Approval already applied `latest`, so the only question left is
@@ -233,9 +233,9 @@ staging.
     ```
 
     In practice only the bootstrap leaves anything to do here, because the release candidate
-    is what puts `next` on the package. If `next` is present, either move it —
-    `npm dist-tag add llmdispatch@<version> next` — or remove it —
-    `npm dist-tag rm llmdispatch next` — and read the tags back. If it is absent, there is
+    is what puts `next` on the package. If `next` is present, either move it,
+    `npm dist-tag add llmdispatch@<version> next`, or remove it,
+    `npm dist-tag rm llmdispatch next`, and read the tags back. If it is absent, there is
     nothing to move and nothing to add. Then close the session.
 
 Consult `npm stage --help` for exact subcommand syntax at the time you run it: staged
@@ -245,7 +245,7 @@ The workflow also takes an `audit_only` input. With it set, the publish job neve
 eligible at all, so nothing is staged: the run produces the audited `release-tarball`
 artifact and stops. Use it whenever you want the exact audited bytes without leaving a run
 parked one approval away from the registry. However you dispatch it, look at the run
-afterwards and confirm the publish job shows as skipped — that check costs seconds and does
+afterwards and confirm the publish job shows as skipped. That check costs seconds and does
 not depend on how the input was delivered.
 
 ### Temporary authenticated sessions
@@ -267,12 +267,12 @@ rm -f "$NPM_CONFIG_USERCONFIG"
 
 Every npm command in that shell inherits both settings, which is the point: the commands in
 this document that belong to a session carry no `--userconfig` or `--registry` of their own,
-and a command that needs different settings — the scratch install in step 10 — overrides them
+and a command that needs different settings (the scratch install in step 10) overrides them
 on its own command line. The path is absolute so that changing directory mid-task cannot
 strand the credential in a file nobody deletes.
 
 The separate user config keeps the credential out of `~/.npmrc`, where it would outlive the
-task by default. `npm whoami` is an identity check, not a formality — it says which account
+task by default. `npm whoami` is an identity check, not a formality: it says which account
 the following commands will act as, and the registry is pinned for the same reason it is
 pinned everywhere else here: a configured mirror would otherwise answer instead.
 
@@ -286,7 +286,7 @@ any of this.
 
 - The workflow's successful **stage** proves the trusted-publisher binding works: npm accepted
   an OIDC credential naming this repository, this workflow and this environment. That the job
-  used no token is a separate claim, and a different mechanism proves it — the workflow file
+  used no token is a separate claim, and a different mechanism proves it: the workflow file
   passes no credential to the step, and the repository's secrets list holds none for it. Read
   both; a successful stage cannot tell you that.
 - The **approval** proves owner presence: it is interactive, it is answered with 2FA, and it
@@ -298,7 +298,7 @@ approval, and an approval says nothing about how the bytes got there.
 ### When something fails
 
 Everything here turns on one question: has the stage been approved yet. Before approval the
-version exists only as a stage — it reserves its number while being invisible to a plain
+version exists only as a stage: it reserves its number while being invisible to a plain
 `npm view`, so "nothing is on the registry" is not evidence of anything, and anything wrong
 with it is undone by rejecting it. After approval the version is live and cannot be rejected,
 withdrawn or replaced; the remedy there is to deprecate it while you investigate. Work out
@@ -307,25 +307,25 @@ which side of that line you are on before you type anything.
 **The workflow run failed and the stage state is unknown.** Inspect `npm stage list` and
 `npm stage view` from a temporary authenticated session, which is also what pins the registry
 for the commands below. What a stage listing shows of the bytes is a `shasum`, which is a
-SHA-1 — the legacy field, and the only digest on offer there — so compare it against
+SHA-1, the legacy field and the only digest on offer there, so compare it against
 `sha1sum` of the tarball in the run's artifact rather than against either recorded hash. The
 release candidate never stages, since it is published from a laptop, so the first chance to
 confirm this reading is steps 5 and 6 of the first staged release: read the fields there,
 before this branch depends on them.
 
-- No stage — fix the cause and dispatch again.
-- A stage whose `shasum` matches the artifact's `sha1sum` — the send succeeded and something
+- No stage: fix the cause and dispatch again.
+- A stage whose `shasum` matches the artifact's `sha1sum`: the send succeeded and something
   after it did not. Carry on with verification of that stage, whose full check is step 8.
-- A stage whose `shasum` does not match, or one left in a failed validation state — reject it
+- A stage whose `shasum` does not match, or one left in a failed validation state: reject it
   with `npm stage reject <stage-id>` and find out where those bytes came from before doing
   anything else.
 
 **You issued an approval and do not know whether it promoted.** Query the version on the
 pinned public registry.
 
-- Absent — re-check the stage and approve again.
-- Present, digest matches, provenance as expected — it worked; reconcile and carry on.
-- Present with a different digest, or with no provenance — treat it as a security incident.
+- Absent: re-check the stage and approve again.
+- Present, digest matches, provenance as expected: it worked; reconcile and carry on.
+- Present with a different digest, or with no provenance: treat it as a security incident.
   The version is live and cannot be taken back, so deprecate it with a message saying it is
   under investigation, then stop: audit the account, its tokens and the workflow, and do not
   retry.
@@ -333,11 +333,11 @@ pinned public registry.
 Three more, none of which is a retry:
 
 - **A verification command fails before approval.** The release is blocked and the gate did
-  what it is for. Do not approve the stage — reject it with `npm stage reject <stage-id>`,
+  what it is for. Do not approve the stage. Reject it with `npm stage reject <stage-id>`,
   because a stage left standing still holds that version number while being invisible to
   `npm view`, and the next dispatch would collide with your own abandoned attempt. Revoke the
   provider keys before you put it down.
-- **Something is wrong after approval** — a missing attestation, a digest that does not match,
+- **Something is wrong after approval**: a missing attestation, a digest that does not match,
   anything the step-10 checks turn up. There is no stage left to reject: deprecate the
   version with a message saying so while you investigate, and treat a digest or provenance
   discrepancy as a security incident rather than a bookkeeping error.
@@ -347,7 +347,7 @@ Three more, none of which is a retry:
   page is healthy.
 
 If you stop for any reason once a release candidate exists, say explicitly what happens to
-the `next` tag — kept, with a reason, or removed — rather than leaving it pointing at
+the `next` tag, kept with a reason or removed, rather than leaving it pointing at
 whatever it happened to point at.
 
 ## Every release after the first
@@ -359,7 +359,7 @@ configured trusted publisher, and no publish token exists in it at all.
 
 npm will only let a trusted publisher be configured on a package that already exists, so the
 very first version cannot go through the workflow. This section exists once. Follow it in
-order — several steps are ordered for a reason, noted where it matters.
+order: several steps are ordered for a reason, noted where it matters.
 
 1. **Recheck the name.** The name is already held by a `0.0.0` placeholder published from
    this project, so the check is ownership, not absence. Immediately before publishing:
@@ -370,14 +370,14 @@ order — several steps are ordered for a reason, noted where it matters.
 
    It must show exactly the placeholder `0.0.0` and the maintainer account this document's
    sessions sign in as. The registry is named explicitly because a mirror or a corporate
-   proxy can answer differently from the public registry. Anything else — extra versions, an
-   unfamiliar maintainer — means the name is not in the expected state: **stop** and find out
-   why before publishing. Moving to a different name is not a rename — the import specifier
+   proxy can answer differently from the public registry. Anything else (extra versions, an
+   unfamiliar maintainer) means the name is not in the expected state: **stop** and find out
+   why before publishing. Moving to a different name is not a rename: the import specifier
    is the package's public contract, and it appears in the README, the type fixtures, the
    consumer tests, the examples and their lockfiles, and the verification harnesses. That is
    a migration with every release gate re-run, and it needs planning on its own.
 
-2. **Build a release candidate.** Set the version to `0.1.0-rc.0` — this one bump is an
+2. **Build a release candidate.** Set the version to `0.1.0-rc.0`. This one bump is an
    exception to the changesets rule above, because the RC is not a stable release: edit
    `version` in `package.json` and in `package-lock.json` (both the root entry and the
    self-referencing packages entry) by hand, and land it as its own reviewed commit. Run the
@@ -395,7 +395,7 @@ order — several steps are ordered for a reason, noted where it matters.
    ```
 
    You must be presented with a 2FA challenge. If none appears, **stop** and find out why
-   before republishing — an unchallenged publish means the credential in play is not the one
+   before republishing: an unchallenged publish means the credential in play is not the one
    this process assumes. The `next` tag keeps the version that bootstraps the registry entry
    out of what a plain `npm install` gets.
 
@@ -403,11 +403,11 @@ order — several steps are ordered for a reason, noted where it matters.
    included.
 
 5. **Wait.** npm scans a fresh publish before the package page and its settings are usable.
-   Allow minutes, not seconds — often around five, sometimes fifteen or more. Poll rather
+   Allow minutes, not seconds, often around five, sometimes fifteen or more. Poll rather
    than assume, and read what the page says: pending is not the same as rejected.
 
 6. **Configure the trusted publisher**, interactively, on the package's settings. The binding
-   is data — copy it character for character:
+   is data, so copy it character for character:
 
    | Field             | Value               |
    | ----------------- | ------------------- |
@@ -419,7 +419,7 @@ order — several steps are ordered for a reason, noted where it matters.
 
    The workflow field is a filename, not a path. The environment name is case-sensitive. A
    package gets one trusted publisher, so there is no second entry to fall back on. npm does
-   not validate any of these fields when you save them — a mismatch first shows up as a
+   not validate any of these fields when you save them, and a mismatch first shows up as a
    failed stage, which is why they are copied rather than typed from memory. The allowed
    action is the whole point of the arrangement: the workflow may stage a version and may
    not publish one, so the automated half of a release can never reach an installable
@@ -427,7 +427,7 @@ order — several steps are ordered for a reason, noted where it matters.
 
 7. **Restrict the package**: require 2FA, and disallow publishing with a token. Do this now,
    before the first stable release rather than after it. It is safe at this point precisely
-   because the flow is split — the workflow stages over OIDC, which the restriction does not
+   because the flow is split: the workflow stages over OIDC, which the restriction does not
    touch, and the promotion is the interactive, 2FA-answered step the restriction is meant to
    enforce. Leaving it until the end would mean the one release that matters most is the one
    published under the looser rules. Confirm on the settings page that turning the
@@ -437,13 +437,13 @@ order — several steps are ordered for a reason, noted where it matters.
    trusted-publisher list shows the single entry above and nothing else.
 
 9. **Restore the real version**, as its own reviewed commit. `npx changeset version` run
-   against `0.1.0-rc.0` consumes the pending patch changesets and lands on exactly `0.1.0` —
+   against `0.1.0-rc.0` consumes the pending patch changesets and lands on exactly `0.1.0`,
    a patch bump of a prerelease drops the prerelease rather than adding to it. Confirm that
    rather than trusting it; if the tool produces anything else, correct the version by hand
    in the same commit. The released version is `0.1.0`, not a `0.1.1` that a pending
    changeset produced by accident. Changesets edits `package.json` and the changelog but not
    the lockfile, so bring `package-lock.json` along by running
-   `npm install --package-lock-only --ignore-scripts` — continuous integration checks the
+   `npm install --package-lock-only --ignore-scripts`, since continuous integration checks the
    lockfile is canonical and will fail the commit otherwise.
 
    The same commit is where the pre-release prose goes, because changesets only ever inserts
@@ -459,20 +459,20 @@ order — several steps are ordered for a reason, noted where it matters.
     provenance naming the repository, the workflow and the run.
 
 11. **Clean up the `next` tag**, as step 11 of that flow. Approving the stage applied `latest`
-    to `0.1.0`; `next` is still on the RC until you move it —
-    `npm dist-tag add llmdispatch@0.1.0 next` — or remove it —
+    to `0.1.0`; `next` is still on the RC until you move it,
+    `npm dist-tag add llmdispatch@0.1.0 next`, or remove it,
     `npm dist-tag rm llmdispatch next`. Read the result back with
     `npm dist-tag ls llmdispatch` and check both tags say what you intended. These commands run
     in the same authenticated session as the approval, which is what pins the registry for
     them; a configured mirror would otherwise take them silently.
 
     This is the last thing that session is for. Close it as _Temporary authenticated
-    sessions_ describes — token audit, logout, delete the user config. The bootstrap is not
+    sessions_ describes: token audit, logout, delete the user config. The bootstrap is not
     finished while a credential is still sitting on disk.
 
 No granular access token with Bypass 2FA is used at any point. Besides being one more
 credential to protect, npm has said such tokens lose their direct-publish capability around
 January 2027, so a release process built on one would have to be rebuilt.
 
-Stable releases carry provenance. The bootstrap RC does not — a publish from a laptop has
+Stable releases carry provenance. The bootstrap RC does not: a publish from a laptop has
 nothing to attest with.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ These are properties of the design, described in full in
 **Credentials stay in your process.** Provider credentials are supplied in code, as
 functions that return them when a request is about to be made. They are never read from
 runtime configuration, never written to the database, and never part of what an
-administrator can edit at runtime. Changing a route changes a provider and a model — never
+administrator can edit at runtime. Changing a route changes a provider and a model, never
 a credential or an endpoint.
 
 **Prompts and outputs are never persisted.** What the stores hold is the operation name,
@@ -39,7 +39,7 @@ prompt, not the input, not the model's output, not a raw provider error.
 run carries a code, a retryable flag, and attempt records; those fields do not carry
 prompt text, model output, or the provider's raw error body from a dispatched attempt.
 One deliberate pass-through: a pre-dispatch error may chain the underlying store or
-`prepare()` failure as `cause`, verbatim — treat that `cause` as unsanitised.
+`prepare()` failure as `cause`, verbatim, so treat that `cause` as unsanitised.
 
 **Requests are not redirected.** Every built-in adapter sends its request with redirects
 disabled, so a credential or a prompt is never replayed to a host you did not configure. A

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -117,7 +117,7 @@ declare function defineOperation<In extends z.ZodType, Out extends z.ZodType>(de
  * Collects operations for `createSwitch`.
  *
  * An identity collector (spec §6): it returns exactly the object it was given and does not
- * itself restore inference — that is {@link defineOperation}'s job, per entry.
+ * itself restore inference; that is {@link defineOperation}'s job, per entry.
  *
  * @param operations The map of operations, each wrapped in `defineOperation`.
  * @returns The same object.
@@ -129,8 +129,8 @@ declare function defineOperations<Ops extends OperationsMap>(operations: Ops): O
  * Builds a configured switch: providers, operations and stores in; `run` plus the admin
  * surface out (spec §6).
  *
- * Construction is pure wiring — no store is called, no provider is prepared, no network is
- * touched — plus the §6 validation of every range and name, so a misconfiguration fails
+ * Construction is pure wiring: no store is called, no provider is prepared, no network is
+ * touched, plus the §6 validation of every range and name, so a misconfiguration fails
  * here, loudly, rather than on the first request.
  *
  * @param config Who can be called, what the app does, and where config and counters live.

--- a/api/postgres.d.ts
+++ b/api/postgres.d.ts
@@ -3,8 +3,8 @@
  * The packaged migrations (spec §6b).
  *
  * llmdispatch never runs DDL: it hands you the SQL and its hash, and you apply it with whatever
- * tool you already use. The hash a version records is the hash of its template — the schema
- * placeholder still in place — so two adopters using different schema names still agree on
+ * tool you already use. The hash a version records is the hash of its template, with the schema
+ * placeholder still in place, so two adopters using different schema names still agree on
  * which version 1 they applied.
  *
  * @module
@@ -47,7 +47,7 @@ declare function migrationSql(opts?: {
 /**
  * Every statement the PostgreSQL stores send, built once per schema.
  *
- * Each one is a single command, so the pool runs it in a transaction of its own — which is
+ * Each one is a single command, so the pool runs it in a transaction of its own, which is
  * what makes a reserve atomic without the store ever pinning a connection (spec §4). Values
  * are always bound; the only thing spliced into the text is the validated schema identifier.
  *

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ graph TD
 ```
 
 Every arrow points down the same slope, so the graph has no cycles, and the layer that
-changes most often — the adapters — sits where nothing depends on it.
+changes most often, the adapters, sits where nothing depends on it.
 
 ## What each folder is for
 
@@ -52,7 +52,7 @@ importing nothing but Zod.
 
 **`errors/`** is the bottom layer of behaviour. Two public classes: `LLMDispatchError`, with a
 closed set of codes, the typed factories that construct it, and the literal `retryable` of
-the spec §5b classification row — the row, not the code, since `PROVIDER_FAILED` is retryable
+the spec §5b classification row: the row, not the code, since `PROVIDER_FAILED` is retryable
 for a `transient` failure and not for a `refused` one; and `ProviderError`, which an adapter
 throws to classify a failed call and which is recognised by a brand rather than by
 `instanceof`. Everything may depend on it; it depends on nothing but the public types.
@@ -63,8 +63,8 @@ all. It reaches storage and providers only through the interfaces they implement
 is why it never needs editing when either gains a member.
 
 **`providers/`** holds one adapter per provider API. Each one translates a request into
-that API's wire format, sends it with global `fetch`, and translates what comes back —
-including failures — into the shared shapes. An adapter reports; it does not decide
+that API's wire format, sends it with global `fetch`, and translates what comes back,
+including failures, into the shared shapes. An adapter reports; it does not decide
 whether to fall back or whether a quota allows the call.
 
 **`stores/`** holds one adapter per storage backend, implementing the config store and the
@@ -91,20 +91,20 @@ These are the ones `.dependency-cruiser.cjs` enforces:
 - `providers/` may import `providers/`, `errors/`, and the public types. `stores/` may
   import `stores/`, `errors/`, and the public types. Neither may reach the other, and
   neither may reach `core/`.
-- `conformance/` may import `conformance/`, `errors/`, and the public types — never a
+- `conformance/` may import `conformance/`, `errors/`, and the public types, never a
   concrete provider or store.
 - `errors/` may import only itself and the public types, and no Node built-in either:
   constructing an error must not touch the outside world.
 - The public types module imports nothing but `zod`. It is shapes, not behaviour.
 - `index.ts` is the one module allowed to import `core/` together with `providers/` and
-  `stores/`. `postgres.ts` reaches the packaged migrations and nothing else at all — the
+  `stores/`. `postgres.ts` reaches the packaged migrations and nothing else at all: the
   PostgreSQL stores themselves are exported from the root, as the specification declares
   them, so an application that has already migrated never loads the DDL. `conformance.ts`
   reaches the harnesses and nothing else at all. Both re-export what those folders already
   expose, so neither needs the error surface directly.
 - The only package `src/` may import is `zod`, which is a peer dependency. The published
   package has no runtime dependencies of its own.
-- No cycles, and no module that nothing imports — except the three entry modules, which
+- No cycles, and no module that nothing imports, except the three entry modules, which
   the manifest points at rather than another module.
 
 The public types live in one module and are re-exported from the entry points, so a shape
@@ -120,5 +120,5 @@ Adding a provider or a store is additive. It is a new folder under `providers/` 
 `core/` is not allowed to know the folder exists.
 
 Any implementation that passes the conformance harnesses is substitutable for a built-in
-one. That holds only if the harnesses and the core both go through the same interfaces —
+one. That holds only if the harnesses and the core both go through the same interfaces,
 which is exactly what the `conformance/` rule guarantees.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,4 +1,4 @@
-<!-- Generated from docs/spec.md §5c by scripts/build-provider-reference.mjs — do not
+<!-- Generated from docs/spec.md §5c by scripts/build-provider-reference.mjs: do not
      edit this file. Edit the spec, then run `npm run docs:providers`. -->
 
 # Provider wire reference
@@ -17,17 +17,17 @@
 
 All built-ins: `fetch` with `redirect: 'error'`, JSON bodies, per-attempt signal.
 **Optional request fields (`maxOutputTokens`, `temperature`) are omitted from the wire body
-when unset — never defaulted** (single exception: Anthropic `max_tokens` below). Every
+when unset, never defaulted** (single exception: Anthropic `max_tokens` below). Every
 mapping is fixed by recorded synthetic fixtures.
 **Universal status-family default (all built-ins, total by construction):** any status not
-explicitly mapped classifies by family — 401/403 → `auth` (except documented moderation
+explicitly mapped classifies by family: 401/403 → `auth` (except documented moderation
 envelopes → `refused`); 402/429 → `rate_limit`; 404 → `model_not_found`; 408 → `transient`;
 any other 4xx (incl. 409/413/422) → `invalid_request`; any 5xx (incl. 504/529) →
 `transient`; network/DNS/TLS failures → `transient`. Implementers never invent a mapping.
 
 ## `openaiCompatible`
 
-**`openaiCompatible({ apiKey, baseUrl?, jsonMode?, tokenParam? })` — the universal transport.**
+**`openaiCompatible({ apiKey, baseUrl?, jsonMode?, tokenParam? })`, the universal transport.**
 Default `baseUrl` `https://api.openai.com/v1`; `POST {baseUrl}/chat/completions`;
 `Authorization: Bearer`. ([OpenAI API reference](https://platform.openai.com/docs/api-reference/chat))
 Request: `model`, `messages: [{role:'user', content: prompt}]`, `max_tokens`,
@@ -35,11 +35,11 @@ Request: `model`, `messages: [{role:'user', content: prompt}]`, `max_tokens`,
 AND the JSON capability applies. **JSON capability rule:** direct known-good hosts
 (api.openai.com, api.deepseek.com, api.groq.com, api.mistral.ai) get native `json_object`;
 **model-multiplexing gateways (openrouter.ai, api.together.xyz, api.fireworks.ai) and
-unknown hosts are prompt-only by default** — JSON-mode support there is per-MODEL, not
+unknown hosts are prompt-only by default**: JSON-mode support there is per-MODEL, not
 per-host, and an unsupported route would fail `invalid_request` without fallback; the
 factory's `jsonMode: 'native' | 'prompt-only'` overrides either way and is the documented
 knob when you know your models. (Ollama
-`http://localhost:11434/v1`: key accepted-but-unused; schema formats silently ignored —
+`http://localhost:11434/v1`: key accepted-but-unused; schema formats silently ignored,
 prompt-only. [Ollama compat](https://ollama.com/blog/openai-compatibility))
 Token parameter: `max_completion_tokens` for host api.openai.com (OpenAI deprecates
 `max_tokens` and rejects it on reasoning models), `max_tokens` for all other compat hosts;
@@ -53,7 +53,7 @@ missing/invalid base counters → `usage: null`** (never zero-defaulted).
 **Embedded HTTP-200 errors (OpenRouter):** before completion parsing, a body carrying
 `finish_reason: 'error'` or a top-level/choice-level `error` object classifies from its
 `error.metadata.error_type`/`code` vocabulary (moderation → `refused`; auth/credit/rate →
-`auth`/`rate_limit`; otherwise `transient`) — never treated as normal completion.
+`auth`/`rate_limit`; otherwise `transient`), never treated as normal completion.
 Errors ([OpenAI error codes](https://developers.openai.com/api/docs/guides/error-codes),
 [OpenRouter errors](https://openrouter.ai/docs/api_reference/errors-and-debugging)):
 401 → `auth`; **403: for OpenRouter envelopes carrying moderation metadata →
@@ -64,19 +64,19 @@ Errors ([OpenAI error codes](https://developers.openai.com/api/docs/guides/error
 
 ## `anthropic`
 
-**`anthropic({ apiKey })` — native Messages API.** `POST
+**`anthropic({ apiKey })`, native Messages API.** `POST
 https://api.anthropic.com/v1/messages`; **`x-api-key`** + required
 **`anthropic-version: 2023-06-01`**. ([Anthropic Messages](https://docs.anthropic.com/en/api/messages);
-the OpenAI-compat layer is not used — it ignores `response_format` and is documented as a
+the OpenAI-compat layer is not used: it ignores `response_format` and is documented as a
 testing tool: [Anthropic OpenAI SDK compat](https://docs.anthropic.com/en/api/openai-sdk))
-Request: `model`, `max_tokens` (**always sent** — required by Anthropic; default 4096 when
+Request: `model`, `max_tokens` (**always sent**, required by Anthropic; default 4096 when
 the route sets none), `messages: [{role:'user', content: prompt}]`, `temperature` (0–1;
 core-range values are clamped, documented). JSON is prompt-driven in v0.1.
 Response: first `text` block of `content[]`; `stop_reason` normalized to
 `ProviderResponse.kind`: `max_tokens` **and `model_context_window_exceeded`** →
 `'truncated'`; `refusal` → `'refused'`; `end_turn`/`stop_sequence` → `'complete'`; other →
 throw `ProviderError('malformed_response')`. Usage: base counters `input_tokens` and
-`output_tokens` are REQUIRED — missing/invalid → `usage: null`; the additive optional
+`output_tokens` are REQUIRED; missing/invalid → `usage: null`; the additive optional
 cache categories (`cache_creation_input_tokens`, `cache_read_input_tokens`) default 0 and
 are summed into `inputTokens`. ([Anthropic usage/caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching),
 [stop reasons](https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons))
@@ -86,14 +86,14 @@ Errors (envelope `{type:'error', error:{type,message}}`): `authentication_error`
 
 ## `gemini`
 
-**`gemini({ apiKey })` — native generateContent.** `POST
+**`gemini({ apiKey })`, native generateContent.** `POST
 https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`;
 `x-goog-api-key` header. Pinned to `v1beta` deliberately: it is the channel Google's
 Gemini API docs default to and where JSON-output fields live; verified by recorded
 fixtures and the release live-check gate ([Gemini API](https://ai.google.dev/api/generate-content),
 [API versions](https://ai.google.dev/gemini-api/docs/api-versions)). The OpenAI-compat
 endpoint is not used: it is officially beta, and only the native API documents explicit
-thought-token accounting (`thoughtsTokenCount`) and full termination metadata — both of
+thought-token accounting (`thoughtsTokenCount`) and full termination metadata, both of
 which this design depends on ([Gemini OpenAI compat](https://ai.google.dev/gemini-api/docs/openai),
 [native usage fields](https://ai.google.dev/api/generate-content); the compat-usage
 discrepancy observed in the research is recorded as an empirical fixture-verification item,
@@ -109,7 +109,7 @@ WITHOUT block metadata → throw `ProviderError('malformed_response')`; `finishR
 `'complete'`; other → throw `ProviderError('malformed_response')`. Usage: base counter
 `promptTokenCount` REQUIRED (missing/invalid → `usage: null`); `outputTokens =
 candidatesTokenCount + thoughtsTokenCount` where `candidatesTokenCount` is required and
-`thoughtsTokenCount` is additive-optional (default 0; thinking tokens are billed output —
+`thoughtsTokenCount` is additive-optional (default 0; thinking tokens are billed output,
 [thinking docs](https://ai.google.dev/gemini-api/docs/thinking)).
 Errors (`{error:{code,status,message}}`): 401/403 → `auth`; 404 → `model_not_found`;
 429/`RESOURCE_EXHAUSTED` → `rate_limit`; 500/503 → `transient`; 400/`INVALID_ARGUMENT` →

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,4 +1,4 @@
-# llmdispatch v0.1 — Normative Specification
+# llmdispatch v0.1 Normative Specification
 
 This document is the exact contract for llmdispatch v0.1. The [README](../README.md) is the
 introduction; when they disagree, this spec wins. §8 defines the adopter-facing conformance
@@ -6,7 +6,7 @@ suite; the core's own behavior (state machine, matrices, sanitization, type infe
 enforced by the package's internal test suite, including compile-time positive and negative
 type fixtures (which include the exact README quickstart shape).
 
-Status: **pre-release contract for v0.1** — the design is final; the implementation is under
+Status: **pre-release contract for v0.1**. The design is final; the implementation is under
 active development and not yet on npm. Semver: while on 0.x, breaking changes to anything
 here bump the minor version.
 
@@ -22,7 +22,7 @@ resolver (`input.parseAsync`, API-key resolvers, `prepare()`, `prompt`, `output.
 `quality`) is **raced against the signal** (`raceWithAbort`): on abort the core stops
 waiting, the losing promise's eventual rejection is suppressed, and the run ends `ABORTED`.
 The only exception: an in-flight `reserve`/`commit` call is awaited to its
-(deadline-bounded) result first — those have side effects — then the run ends `ABORTED`
+(deadline-bounded) result first (those have side effects), then the run ends `ABORTED`
 without dispatching. Quota effect of an abort: whatever state was reached stands (nothing /
 pending-expires / committed counts). An abort arriving **after** a successful attempt does
 not change the outcome: the run returns its result; settlement records `succeeded`.
@@ -33,30 +33,30 @@ not change the outcome: the run returns its result; settlement records `succeede
 | 1 | Operation lookup (JS callers can pass unknown names) | `INVALID_INPUT` | none |
 | 2 | Input parse: `input.parseAsync(args.input)`. `ZodError` = validation failure; a **non-Zod exception from user transform code passes through unwrapped** (pre-quota user bug) | `INVALID_INPUT` | none |
 | 3 | Subject check for a **declared** quota: an operation whose definition declares `quota` requires non-empty `subjectId` | `MISSING_SUBJECT` | none |
-| 4 | Config resolution (§2) — primary **and** fallback route — then, if the effective route enables a quota the definition does not declare, the same subject check | `INVALID_CONFIG` / `CONFIG_STORE_UNAVAILABLE` / `MISSING_SUBJECT` | none |
+| 4 | Config resolution (§2) for the primary **and** fallback route, then, if the effective route enables a quota the definition does not declare, the same subject check | `INVALID_CONFIG` / `CONFIG_STORE_UNAVAILABLE` / `MISSING_SUBJECT` | none |
 | 5 | Readiness for **both** routes (§5a): registration + `prepare()` per unique provider | `INVALID_CONFIG` (`detectedAt:'local'`; `retryable` per §5a) | none |
 | 6 | Prompt build: `prompt(parsedInput)` (raced with abort). A non-string return is a user bug: descriptive `TypeError` passes through unwrapped | user exception unwrapped | none |
 | 7 | Quota reserve (§4), performed iff the run has an **effective** quota (§2) | `QUOTA_EXCEEDED` / `USAGE_STORE_UNAVAILABLE` | pending reservation (envelope held) |
 | 8 | Quota commit (§4 recovery table; same condition as 7; signal checked before each recovery I/O) | `QUOTA_EXCEEDED` (denied re-reserve) / `USAGE_STORE_UNAVAILABLE` | committed on success; §4 table otherwise |
 | 9 | Primary attempt: final signal check → dispatch via prepared dispatcher → output pipeline (§3) | classified per §5 | committed |
-| 10 | Fallback decision (§5) and, if eligible and configured, the fallback attempt (same sub-stages, fresh provider timeout) | terminal code per §5 | same slot — never a second reservation |
+| 10 | Fallback decision (§5) and, if eligible and configured, the fallback attempt (same sub-stages, fresh provider timeout) | terminal code per §5 | same slot, never a second reservation |
 | 11 | **Finalization (try/finally, before every post-commit return or throw):** settle (§4), then return/throw | settlement never changes the outcome | accounting only |
 
 Fixed rules:
 
-- Quota work happens after config and readiness — local misconfiguration of either route
+- Quota work happens after config and readiness, so local misconfiguration of either route
   never consumes quota.
 - **Subject-check precedence.** Stage 3 covers only a *declared* quota, so that check stays
   ahead of all I/O. A quota that only the effective route enables is unknown until the route
   resolves, so its check runs immediately after stage 4: for such an operation a config
   failure or a malformed/unresolvable route (stage 4 reads the store, up to 5 s) is reported
-  **before** `MISSING_SUBJECT`. The stage numbering is unchanged — this is a sub-step of 4.
+  **before** `MISSING_SUBJECT`. The stage numbering is unchanged: this is a sub-step of 4.
 - `INVALID_CONFIG` also arises **post-dispatch** (provider rejects credentials/model;
   `detectedAt:'provider'`). The slot stays committed.
 - Unwrapped user exceptions (stages 2/6 pre-quota; `output_schema_error`/`quality_error`
-  post-dispatch) propagate as the user's raw error, carrying no `attempts` field —
+  post-dispatch) propagate as the user's raw error, carrying no `attempts` field;
   post-dispatch ones are settled first with their attempt records.
-- Crash between stages 8 and 9 leaves a committed slot with no provider call — the
+- Crash between stages 8 and 9 leaves a committed slot with no provider call, the
   deliberate conservative window.
 
 ## 2. Config resolution (stage 4)
@@ -65,14 +65,14 @@ Per-operation resolution matrix:
 
 | Cache state | Store read | Row | Result | Cached? |
 |---|---|---|---|---|
-| fresh (age < TTL; `configTtlMs: 0` disables reuse entirely) | not attempted | — | cached effective route | already |
+| fresh (age < TTL; `configTtlMs: 0` disables reuse entirely) | not attempted | n/a | cached effective route | already |
 | stale/absent | success | valid row | row is effective | yes |
-| stale/absent | success | malformed row | `INVALID_CONFIG` (isolated to this operation) | not cached — re-read next run |
+| stale/absent | success | malformed row | `INVALID_CONFIG` (isolated to this operation) | not cached, re-read next run |
 | stale/absent | success | no row | `defaultRoute` if declared (negative-cached as effective), else `INVALID_CONFIG` | yes |
-| stale/absent | failure/timeout | unknown | `CONFIG_STORE_UNAVAILABLE` — **`defaultRoute` is never an outage fallback** | no |
+| stale/absent | failure/timeout | unknown | `CONFIG_STORE_UNAVAILABLE`. **`defaultRoute` is never an outage fallback** | no |
 
 - The `getAll()` return itself is validated first: a non-record (null, array, primitive)
-  → `CONFIG_STORE_UNAVAILABLE` (fail-closed — a malformed container must never read as
+  → `CONFIG_STORE_UNAVAILABLE` (fail-closed: a malformed container must never read as
   "no rows" and activate defaults). Rows are then validated strictly (unknown fields →
   malformed). A shape-valid row referencing an unregistered provider is malformed for
   resolution (`INVALID_CONFIG`, isolated), as is a row whose `quota` fails its §6 validation
@@ -81,18 +81,18 @@ Per-operation resolution matrix:
 - **Effective quota.** The effective quota is the effective route's `quota` if the route
   carries one, else the operation's declared `quota` (§6); the effective route is the stored
   row when one resolves, else `defaultRoute`. Explicitly: a stored row **without** `quota`
-  does **not** inherit `defaultRoute.quota` — it falls back to the declared quota, and the
+  does **not** inherit `defaultRoute.quota`. It falls back to the declared quota, and the
   operation runs with no quota at all if the definition declares none. A stored `quota` on an
   operation that declares none *enables* a quota (the row is valid, and the subject
   requirement then applies, checked after stage 4 per §1). `resetConfig` deletes the row, so
   `defaultRoute` and its `quota` apply again. A run's effective quota is fixed at stage 4 (§4).
 - **Cache coherence:** generation counter; every mutation outcome (success, timeout,
-  rejection — any outcome whose non-application is not positively known) bumps the
+  rejection, meaning any outcome whose non-application is not positively known) bumps the
   generation and invalidates locally. A read begun under an older generation cannot
   overwrite a newer entry. **Mutation ordering:** the core serializes config mutations
   per operation within a process (one in flight, FIFO); the mutex is RELEASED at the
   caller deadline (ConfigStore has no cancellation contract), so a timed-out write may
-  still land late and overwrite a subsequent write — in-process as well as cross-process.
+  still land late and overwrite a subsequent write, in-process as well as cross-process.
   This is the documented last-write-wins/unknown-ack limitation; the deferred CAS/revision
   mechanism (v0.2, settled) is the full fix. Custom ConfigStores must give the writing client
   read-your-writes.
@@ -107,7 +107,7 @@ Per-operation resolution matrix:
 
 - `getConfig()` returns per operation `{ stored: OperationRoute | null | 'malformed',
   effective: OperationRoute | null }` (readiness not probed).
-- `setConfig` replace-only, validated (shape, registered provider IDs, §6 ranges — including
+- `setConfig` replace-only, validated (shape, registered provider IDs, §6 ranges, including
   `quota.perDay`). Cache TTL default 5000ms (`configTtlMs`, 0–300 000; `0` = read every run).
 - `getQuota` resolves the operation's config before reading usage, because the limit it
   reports is the **effective** limit and may live on the route. Full precedence: unknown
@@ -120,8 +120,8 @@ Per-operation resolution matrix:
 
 ## 3. Output pipeline (attempt sub-stages)
 
-1. Each operation declares `format`: **`'json'`** (default — top-level JSON **object**),
-   **`'json-any'`** (arbitrary JSON — native provider JSON modes never enabled), or
+1. Each operation declares `format`: **`'json'`** (the default: a top-level JSON **object**),
+   **`'json-any'`** (arbitrary JSON; native provider JSON modes never enabled), or
    **`'text'`**. No schema introspection: text-shaped output schemas MUST set `'text'`.
 2. The adapter receives `responseFormat: { type: 'text' } | { type: 'json'; topLevel:
    'object' | 'any' }` and enables native generic JSON mode only per its §5c capability
@@ -148,25 +148,25 @@ Per-operation resolution matrix:
 ## 4. Quota lifecycle and UsageStore contract
 
 One **run** = one slot, shared with its fallback attempt. The **store's clock owns the UTC
-day**. `reserve()` returns the store-created immutable **`ReservationEnvelope`** —
+day**. `reserve()` returns the store-created immutable **`ReservationEnvelope`**:
 `{ reservationId, key, day }` with `day` as `YYYY-MM-DD` (UTC, chosen by the store; years
-0001–9999 — year 0000 is invalid, because PostgreSQL has no year zero where JavaScript
-would accept it, and substitutability requires the shared bound) — which
+0001–9999; year 0000 is invalid, because PostgreSQL has no year zero where JavaScript
+would accept it, and substitutability requires the shared bound), which
 the core validates (`key` must equal the requested key; `day` must match the domain) and
 carries verbatim through commit recovery and settlement. A re-reservation **replaces** the
 active envelope.
 
-- **reserve** — the `limit` passed is the run's **effective limit** (§2). The store atomically
+- **reserve**: the `limit` passed is the run's **effective limit** (§2). The store atomically
   counts committed + unexpired pending slots for the store's current UTC day (`used`) and
   admits iff `used < limit`: insert pending reservation, lease
   `expiresAt = min(now + leaseMs, resetsAt)` (a lease never crosses the day boundary).
   A denial's `used` is authoritative for that `reserve`'s own snapshot-and-lock point: it is
   never lower than live usage, and it exceeds live usage only by rows that lapsed or appeared
   while that `reserve` waited for the counter.
-  **`limit === 0`:** the core **still calls `reserve`** and never short-circuits — `used` and
+  **`limit === 0`:** the core **still calls `reserve`** and never short-circuits, since `used` and
   `resetsAt` must be store-authoritative. An available store returns the complete denial
-  `{ ok: false, used, resetsAt }` — `used` being the day's authoritative count, which may be
-  non-zero — **without inserting a reservation**, and the run ends `QUOTA_EXCEEDED`; a
+  `{ ok: false, used, resetsAt }`, with `used` being the day's authoritative count, which may be
+  non-zero, **without inserting a reservation**, and the run ends `QUOTA_EXCEEDED`; a
   transport error or timeout still maps to `USAGE_STORE_UNAVAILABLE`, so a zero limit during
   a store outage refuses as an outage, not as a quota denial. `getQuota` at zero
   returns `limit: 0`, `remaining: 0`, and that same authoritative `used`. How quickly a
@@ -181,14 +181,14 @@ active envelope.
   | `'committed'` | dispatch |
   | `'expired'` | re-reserve **once** (new envelope): `{ok:true}` → commit the new id (`'expired'`/`'missing'` again → `USAGE_STORE_UNAVAILABLE`); `{ok:false}` → `QUOTA_EXCEEDED` with its `resetsAt` |
   | `'missing'` | `USAGE_STORE_UNAVAILABLE` |
-  | transport error/timeout | retry same id ×3 (250/500/1000ms) → `USAGE_STORE_UNAVAILABLE` ("possibly committed" — conservative) |
+  | transport error/timeout | retry same id ×3 (250/500/1000ms) → `USAGE_STORE_UNAVAILABLE` ("possibly committed", conservative) |
 
-- **settle(envelope, outcome, attempts)** — idempotent, atomic per reservation: exact
+- **settle(envelope, outcome, attempts)**: idempotent, atomic per reservation: exact
   duplicate → no-op; conflicting payload after settlement → ignored (first write wins);
   pending/expired/**unknown** reservation → record attempts against the envelope's
   key/day without changing slot accounting. Attempt order = dispatch order.
 - **Settlement execution (v0.1, non-durable):** initial `settle` awaited (10s deadline)
-  in finalization — settlement failure never changes an otherwise successful outcome,
+  in finalization, and settlement failure never changes an otherwise successful outcome,
   though delivery may be delayed by up to that deadline; then up to 3 detached retries
   (1s/5s/25s, same per-attempt deadline); remaining failure →
   `onSettlementError(error, { reservation, outcome, attempts })` invoked through an
@@ -206,14 +206,14 @@ active envelope.
 edited between one run and the next:
 
 1. A run captures its effective limit at config resolution (stage 4). A later change never
-   alters that run's pending envelope, its commit recovery, or an in-flight re-reservation —
+   alters that run's pending envelope, its commit recovery, or an in-flight re-reservation;
    those complete against the captured limit.
 2. A limit lowered to at or below the day's current `used` denies **new** reservations
    (`QUOTA_EXCEEDED` with the store's `resetsAt`); already-committed slots stand.
 3. `getQuota` may therefore report `used > limit` with `remaining: 0`, since `remaining` is
    `max(0, limit - used)`.
-4. Removing the only quota — clearing `quota` from a stored row for an operation whose
-   definition declares none — makes new runs non-quota and `getQuota` return `INVALID_INPUT`;
+4. Removing the only quota, that is clearing `quota` from a stored row for an operation whose
+   definition declares none, makes new runs non-quota and `getQuota` return `INVALID_INPUT`;
    reservations already pending or committed keep their normal lifecycle (expiry, commit,
    settle, pruning) and their rows are untouched.
 5. Any change, including to 0, applies to new runs once it is cache-visible per §2, and never
@@ -227,13 +227,13 @@ Postgres adapter: single-statement atomic reserve/commit (row-level concurrency,
 explicit table-wide locks), lease and day boundary enforced in SQL, schema-qualified
 identifiers, default `leaseMs` 120 000 (5 000–600 000). Every method sends one command, so
 each call runs in a transaction of its own; the pool must run at READ COMMITTED
-(PostgreSQL's default) — under REPEATABLE READ or SERIALIZABLE, concurrent reserves abort
+(PostgreSQL's default). Under REPEATABLE READ or SERIALIZABLE, concurrent reserves abort
 with a serialization failure instead of one being denied: fail-closed, never
 over-admitting. Migrations are packaged (§6b), schema-aware, and never auto-run.
 
 **Persisted data (privacy boundary):** operation, `subjectId` (verbatim), UTC day,
 reservation state, timestamps, and the complete `AttemptRecord` fields per attempt
-(provider, model, outcome, status, token counts, `costUsd`, `durationMs`) — so settle
+(provider, model, outcome, status, token counts, `costUsd`, `durationMs`), so settle
 round-trip/duplicate detection is defined over whole records.
 Never prompts, inputs, outputs, or raw errors. **Pruning:** prune **settled** rows ≥ 2 days
 past their day; committed-but-unsettled rows retained until 24h past their day, then
@@ -248,8 +248,8 @@ implementing exactly this.
   fetch-based and dependency-free by design.
 - **Stage 5 (per run, before quota):** both routes' providers must be registered. If a
   provider declares **`prepare()`** (§6), it is invoked (raced with abort) **once per
-  unique provider registration ID per run** — memoized, so a run whose primary and
-  fallback share a provider gets one snapshot — returning a run-scoped dispatcher used
+  unique provider registration ID per run**, memoized, so a run whose primary and
+  fallback share a provider gets one snapshot, returning a run-scoped dispatcher used
   for that run's attempts (nothing stored on the shared provider; concurrent runs are
   isolated). A malformed return (no `complete` function) → `INVALID_CONFIG` (local).
   Built-in factories implement `prepare()` to resolve their `apiKey` (empty/undefined →
@@ -260,7 +260,7 @@ implementing exactly this.
 - **Post-dispatch:** provider rejects credential/model → `auth`/`model_not_found` →
   `INVALID_CONFIG` (`detectedAt:'provider'`), slot committed. Neither classification is
   fallback-eligible unless `fallbackOnAuthOrModelNotFound` (§6) is on, and the flag governs
-  a **primary** attempt only — it never introduces a second fallback and does not touch the
+  a **primary** attempt only: it never introduces a second fallback and does not touch the
   local `INVALID_CONFIG` paths above. `detectedAt` is a property of the thrown
   `LLMDispatchError`, never of an `AttemptRecord` (§6), and `detectedAt:'provider'` is set only
   when the terminal code is `INVALID_CONFIG` from the final attempt: a primary rescued by its
@@ -273,12 +273,12 @@ implementing exactly this.
 | Classification | Fallback? | Terminal code if final | `retryable` |
 |---|---|---|---|
 | `transient` (network, 5xx, 408, overload) | ✅ | `PROVIDER_FAILED` | `true` |
-| `rate_limit` (429; billing-exhaustion via 429/402 included — cross-provider fallback is the remedy) | ✅ | `PROVIDER_FAILED` | `true` |
+| `rate_limit` (429; billing-exhaustion via 429/402 included; cross-provider fallback is the remedy) | ✅ | `PROVIDER_FAILED` | `true` |
 | `malformed_response` (unusable body/shape/unknown terminal state) | ✅ | `PROVIDER_FAILED` | `true` |
 | `timeout` (core-assigned) | ✅ | `PROVIDER_FAILED` | `true` |
-| `truncated` (`ProviderResponse.kind: 'truncated'` — max-token/length/context termination per §5c) | ✅ | `OUTPUT_REJECTED` | `true` |
+| `truncated` (`ProviderResponse.kind: 'truncated'`, max-token/length/context termination per §5c) | ✅ | `OUTPUT_REJECTED` | `true` |
 | `output_rejected` (JSON parse / object-shape / `ZodError` / quality `{ok:false}`) | ✅ | `OUTPUT_REJECTED` | `true` |
-| `refused` (`ProviderResponse.kind: 'refused'` — refusal/safety/policy block on a 200 per §5c) | ❌ | `PROVIDER_FAILED` | `false` |
+| `refused` (`ProviderResponse.kind: 'refused'`, refusal/safety/policy block on a 200 per §5c) | ❌ | `PROVIDER_FAILED` | `false` |
 | `auth` | ❌ default; with `fallbackOnAuthOrModelNotFound: true` → ✅ (primary attempt only) | `INVALID_CONFIG` (provider) | `false` |
 | `model_not_found` | ❌ default; with `fallbackOnAuthOrModelNotFound: true` → ✅ (primary attempt only) | `INVALID_CONFIG` (provider) | `false` |
 | `invalid_request` (content-dependent rejection, e.g. context overflow) | ❌ | `PROVIDER_FAILED` | `false` |
@@ -298,7 +298,7 @@ tables.
 - Built-in adapters make exactly one client-side HTTP request per attempt: `redirect:
   'error'` on every fetch (a 3xx → `transient`; no prompt/credential ever reaches a
   redirect target); no retries in llmdispatch's own HTTP layer. (Gateway hosts may retry
-  upstream internally — outside our boundary.)
+  upstream internally, outside our boundary.)
 - **ProviderError recognition is brand-based, never bare `instanceof`**: the class carries
   `Symbol.for('llmdispatch.ProviderError')` and exposes `ProviderError.is(value)`; the core
   classifies with `.is()` so a `ProviderError` crossing ESM/CJS entry points (dual-package
@@ -312,15 +312,15 @@ tables.
 
 All built-ins: `fetch` with `redirect: 'error'`, JSON bodies, per-attempt signal.
 **Optional request fields (`maxOutputTokens`, `temperature`) are omitted from the wire body
-when unset — never defaulted** (single exception: Anthropic `max_tokens` below). Every
+when unset, never defaulted** (single exception: Anthropic `max_tokens` below). Every
 mapping is fixed by recorded synthetic fixtures.
 **Universal status-family default (all built-ins, total by construction):** any status not
-explicitly mapped classifies by family — 401/403 → `auth` (except documented moderation
+explicitly mapped classifies by family: 401/403 → `auth` (except documented moderation
 envelopes → `refused`); 402/429 → `rate_limit`; 404 → `model_not_found`; 408 → `transient`;
 any other 4xx (incl. 409/413/422) → `invalid_request`; any 5xx (incl. 504/529) →
 `transient`; network/DNS/TLS failures → `transient`. Implementers never invent a mapping.
 
-**`openaiCompatible({ apiKey, baseUrl?, jsonMode?, tokenParam? })` — the universal transport.**
+**`openaiCompatible({ apiKey, baseUrl?, jsonMode?, tokenParam? })`, the universal transport.**
 Default `baseUrl` `https://api.openai.com/v1`; `POST {baseUrl}/chat/completions`;
 `Authorization: Bearer`. ([OpenAI API reference](https://platform.openai.com/docs/api-reference/chat))
 Request: `model`, `messages: [{role:'user', content: prompt}]`, `max_tokens`,
@@ -328,11 +328,11 @@ Request: `model`, `messages: [{role:'user', content: prompt}]`, `max_tokens`,
 AND the JSON capability applies. **JSON capability rule:** direct known-good hosts
 (api.openai.com, api.deepseek.com, api.groq.com, api.mistral.ai) get native `json_object`;
 **model-multiplexing gateways (openrouter.ai, api.together.xyz, api.fireworks.ai) and
-unknown hosts are prompt-only by default** — JSON-mode support there is per-MODEL, not
+unknown hosts are prompt-only by default**: JSON-mode support there is per-MODEL, not
 per-host, and an unsupported route would fail `invalid_request` without fallback; the
 factory's `jsonMode: 'native' | 'prompt-only'` overrides either way and is the documented
 knob when you know your models. (Ollama
-`http://localhost:11434/v1`: key accepted-but-unused; schema formats silently ignored —
+`http://localhost:11434/v1`: key accepted-but-unused; schema formats silently ignored,
 prompt-only. [Ollama compat](https://ollama.com/blog/openai-compatibility))
 Token parameter: `max_completion_tokens` for host api.openai.com (OpenAI deprecates
 `max_tokens` and rejects it on reasoning models), `max_tokens` for all other compat hosts;
@@ -346,7 +346,7 @@ missing/invalid base counters → `usage: null`** (never zero-defaulted).
 **Embedded HTTP-200 errors (OpenRouter):** before completion parsing, a body carrying
 `finish_reason: 'error'` or a top-level/choice-level `error` object classifies from its
 `error.metadata.error_type`/`code` vocabulary (moderation → `refused`; auth/credit/rate →
-`auth`/`rate_limit`; otherwise `transient`) — never treated as normal completion.
+`auth`/`rate_limit`; otherwise `transient`), never treated as normal completion.
 Errors ([OpenAI error codes](https://developers.openai.com/api/docs/guides/error-codes),
 [OpenRouter errors](https://openrouter.ai/docs/api_reference/errors-and-debugging)):
 401 → `auth`; **403: for OpenRouter envelopes carrying moderation metadata →
@@ -355,19 +355,19 @@ Errors ([OpenAI error codes](https://developers.openai.com/api/docs/guides/error
 400/413/422 → `invalid_request`; unparseable body → classify by status; unknown status →
 `transient` (a real HTTP outcome, unlike unclassified thrown values).
 
-**`anthropic({ apiKey })` — native Messages API.** `POST
+**`anthropic({ apiKey })`, native Messages API.** `POST
 https://api.anthropic.com/v1/messages`; **`x-api-key`** + required
 **`anthropic-version: 2023-06-01`**. ([Anthropic Messages](https://docs.anthropic.com/en/api/messages);
-the OpenAI-compat layer is not used — it ignores `response_format` and is documented as a
+the OpenAI-compat layer is not used: it ignores `response_format` and is documented as a
 testing tool: [Anthropic OpenAI SDK compat](https://docs.anthropic.com/en/api/openai-sdk))
-Request: `model`, `max_tokens` (**always sent** — required by Anthropic; default 4096 when
+Request: `model`, `max_tokens` (**always sent**, required by Anthropic; default 4096 when
 the route sets none), `messages: [{role:'user', content: prompt}]`, `temperature` (0–1;
 core-range values are clamped, documented). JSON is prompt-driven in v0.1.
 Response: first `text` block of `content[]`; `stop_reason` normalized to
 `ProviderResponse.kind`: `max_tokens` **and `model_context_window_exceeded`** →
 `'truncated'`; `refusal` → `'refused'`; `end_turn`/`stop_sequence` → `'complete'`; other →
 throw `ProviderError('malformed_response')`. Usage: base counters `input_tokens` and
-`output_tokens` are REQUIRED — missing/invalid → `usage: null`; the additive optional
+`output_tokens` are REQUIRED; missing/invalid → `usage: null`; the additive optional
 cache categories (`cache_creation_input_tokens`, `cache_read_input_tokens`) default 0 and
 are summed into `inputTokens`. ([Anthropic usage/caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching),
 [stop reasons](https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons))
@@ -375,14 +375,14 @@ Errors (envelope `{type:'error', error:{type,message}}`): `authentication_error`
 `auth`; `not_found_error` → `model_not_found`; `rate_limit_error`/429 → `rate_limit`;
 `overloaded_error`/529/5xx → `transient`; `invalid_request_error`/400 → `invalid_request`.
 
-**`gemini({ apiKey })` — native generateContent.** `POST
+**`gemini({ apiKey })`, native generateContent.** `POST
 https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`;
 `x-goog-api-key` header. Pinned to `v1beta` deliberately: it is the channel Google's
 Gemini API docs default to and where JSON-output fields live; verified by recorded
 fixtures and the release live-check gate ([Gemini API](https://ai.google.dev/api/generate-content),
 [API versions](https://ai.google.dev/gemini-api/docs/api-versions)). The OpenAI-compat
 endpoint is not used: it is officially beta, and only the native API documents explicit
-thought-token accounting (`thoughtsTokenCount`) and full termination metadata — both of
+thought-token accounting (`thoughtsTokenCount`) and full termination metadata, both of
 which this design depends on ([Gemini OpenAI compat](https://ai.google.dev/gemini-api/docs/openai),
 [native usage fields](https://ai.google.dev/api/generate-content); the compat-usage
 discrepancy observed in the research is recorded as an empirical fixture-verification item,
@@ -398,7 +398,7 @@ WITHOUT block metadata → throw `ProviderError('malformed_response')`; `finishR
 `'complete'`; other → throw `ProviderError('malformed_response')`. Usage: base counter
 `promptTokenCount` REQUIRED (missing/invalid → `usage: null`); `outputTokens =
 candidatesTokenCount + thoughtsTokenCount` where `candidatesTokenCount` is required and
-`thoughtsTokenCount` is additive-optional (default 0; thinking tokens are billed output —
+`thoughtsTokenCount` is additive-optional (default 0; thinking tokens are billed output,
 [thinking docs](https://ai.google.dev/gemini-api/docs/thinking)).
 Errors (`{error:{code,status,message}}`): 401/403 → `auth`; 404 → `model_not_found`;
 429/`RESOURCE_EXHAUSTED` → `rate_limit`; 500/503 → `transient`; 400/`INVALID_ARGUMENT` →
@@ -409,13 +409,13 @@ Errors (`{error:{code,status,message}}`): 401/403 → `auth`; 404 → `model_not
 ```ts
 import { z } from 'zod'
 
-// ——— entry point ———
+// --- entry point ---
 export declare function createSwitch<Ops extends OperationsMap>(
   config: CreateSwitchConfig<Ops>
 ): Switch<Ops>
 
 // Inference builders. defineOperation correlates each operation's schemas with its
-// callbacks; **every entry in defineOperations MUST be wrapped in defineOperation** —
+// callbacks; **every entry in defineOperations MUST be wrapped in defineOperation**;
 // defineOperations is an identity collector and does not itself restore inference.
 // The README quickstart uses exactly this shape; negative compile fixtures assert that
 // invalid `prompt` input and `quality.data` accesses FAIL to compile in that shape.
@@ -460,7 +460,7 @@ export interface Logger {                                // invoked through caug
   error(message: string, data?: unknown): void | Promise<void>
 }
 
-// ——— operations ———
+// --- operations ---
 export interface OperationDefinition<In extends z.ZodType, Out extends z.ZodType> {
   input: In
   output: Out
@@ -473,7 +473,7 @@ export interface OperationDefinition<In extends z.ZodType, Out extends z.ZodType
 }
 export type QualityVerdict = { ok: true } | { ok: false; reason?: string }
 
-// ——— routing / views ———
+// --- routing / views ---
 export interface OperationRoute {
   provider: string                                       // non-empty registered provider ID
   model: string                                          // non-empty
@@ -491,7 +491,7 @@ export interface OperationConfigView {
 }
 export interface QuotaView { limit: number; used: number; remaining: number; resetsAt: string } // limit = the effective limit (route override, else declared); remaining = max(0, limit - used); getQuota requires non-empty subjectId
 
-// ——— run results ———
+// --- run results ---
 export interface RunResult<Out> {
   data: Out
   route: { provider: string; model: string }
@@ -518,7 +518,7 @@ export interface AttemptRecord {
 export interface TokenUsage { inputTokens: number; outputTokens: number }  // non-negative SAFE integers
 export interface ModelPrice { inputPerM: number; outputPerM: number }      // finite, ≥ 0
 
-// ——— providers ———
+// --- providers ---
 export interface Provider {
   prepare?(): PreparedProvider | Promise<PreparedProvider>  // §5a; memoized per run per provider ID
   complete(req: ProviderRequest): Promise<ProviderResponse> // used directly when prepare absent
@@ -563,7 +563,7 @@ export declare function openaiCompatible(opts: {
 export declare function gemini(opts: { apiKey: ApiKeyResolver }): Provider
 export type ApiKeyResolver = () => string | undefined | Promise<string | undefined>
 
-// ——— stores ———
+// --- stores ---
 export interface ConfigStore {
   getAll(): Promise<Record<string, unknown>>
   set(operation: string, route: OperationRoute): Promise<void>
@@ -587,7 +587,7 @@ export declare function postgresStores(opts: {
   leaseMs?: number                                       // default 120_000; 5_000–600_000
 }): StorePair
 
-// ——— errors ———
+// --- errors ---
 export declare class LLMDispatchError extends Error {
   private constructor()                                  // instances come from the package; narrow on `code`
   readonly code: 'INVALID_INPUT' | 'MISSING_SUBJECT' | 'QUOTA_EXCEEDED'
@@ -600,7 +600,7 @@ export declare class LLMDispatchError extends Error {
   readonly attempts?: AttemptRecord[]
   // Sanitized, scoped to the package's own fields: they never carry prompts, model
   // output, or raw provider errors from a dispatched attempt. A pre-dispatch error may
-  // chain the underlying store or `prepare()` failure as `cause`, verbatim — the
+  // chain the underlying store or `prepare()` failure as `cause`, verbatim: the
   // adopter's own thrown error, or a provider adapter's readiness failure.
 }
 ```
@@ -613,9 +613,9 @@ non-string prompt returns → unwrapped
 `TypeError` (pre-quota); malformed quality verdicts → `quality_error`; malformed prepared
 dispatchers → `INVALID_CONFIG` (local).
 
-**String domain.** Every string that reaches a store — operation names, provider
+**String domain.** Every string that reaches a store (operation names, provider
 registration IDs, `OperationRoute`/`RouteTarget` `provider` and `model`, `subjectId`,
-`ReservationEnvelope.reservationId`, and `AttemptRecord.provider`/`model` — is well-formed
+`ReservationEnvelope.reservationId`, and `AttemptRecord.provider`/`model`) is well-formed
 Unicode (`String.prototype.isWellFormed()`), contains no U+0000, and is at most 1 000 bytes
 of UTF-8. The core checks this **before any store call**, at these boundaries: operation
 names, provider IDs and declared routes at `createSwitch` → `INVALID_CONFIG`; a route at
@@ -626,15 +626,15 @@ malformed store result → `USAGE_STORE_UNAVAILABLE`, checked before `commit`; t
 the attempt records are checked again before `settle`. A store additionally rejects
 out-of-domain values as defence in depth. The bound is part of the contract because a
 relational store cannot hold every JavaScript string: PostgreSQL `text` and `jsonb` reject
-U+0000, lone surrogates do not survive a round trip, and index entries are size-capped — so a
+U+0000, lone surrogates do not survive a round trip, and index entries are size-capped, so a
 store that had to narrow the domain itself would not be substitutable.
 
 ## 6a. Core-enforced store deadlines
 
 `ConfigStore.getAll` 5s; `set`/`delete` 10s (unknown-ack semantics per §2);
 `reserve`/`commit`/`snapshot` 10s; `settle` 10s per attempt including each detached retry.
-`getQuota` may spend both in sequence — a `getAll` that is not served from cache, then
-`snapshot` — so its worst case is 15s. Constants in v0.1.
+`getQuota` may spend both in sequence: a `getAll` that is not served from cache, then
+`snapshot`, so its worst case is 15s. Constants in v0.1.
 
 ## 6b. Packaged operational surfaces (exact declarations)
 
@@ -683,7 +683,7 @@ export declare function runProviderConformance(opts: {
   // 'success' is MANDATORY; each other scenario puts the adopter's backend into the named
   // condition and resolves when ready; the harness dispatches and asserts the resulting
   // ProviderResponse.kind or ProviderError classification. Absent optional scenarios are
-  // reported in `skipped` — a skipped scenario means that classification is UNVERIFIED.
+  // reported in `skipped`: a skipped scenario means that classification is UNVERIFIED.
   scenarios: { success: () => Promise<void> } & Partial<Record<
     'auth' | 'rate_limit' | 'model_not_found' | 'invalid_request' | 'transient'
     | 'malformed_response' | 'truncated' | 'refused', () => Promise<void>>>
@@ -718,9 +718,9 @@ discounts, tiered pricing, and request fees are out of scope in v0.1.
 
 ## 8. Conformance suite (adopter-facing)
 
-Runners per §6b. Three of the cases below are new to this contract — two `UsageStore` cases
+Runners per §6b. Three of the cases below are new to this contract: two `UsageStore` cases
 (a `reserve` at limit 0, and a limit lowered below existing usage) and one `ConfigStore` case
-(a route carrying `quota`) — so a custom store can fail the suite without any change on its
+(a route carrying `quota`), so a custom store can fail the suite without any change on its
 side: a `UsageStore` that treats a non-positive `limit` as unlimited, or a `ConfigStore` that
 persists only a whitelist of route fields, needs updating. Coverage:
 
@@ -733,10 +733,10 @@ persists only a whitelist of route fields, needs updating. Coverage:
   denying without inserting a reservation (observed as: a following `reserve` at `limit: 1`
   on the same key is admitted with `used` 0), and a limit lowered below existing
   pending/committed usage denying new reservations while leaving those rows intact.
-  (Settle-FAILURE isolation — a rejecting store not affecting run outcomes — is core
+  (Settle-FAILURE isolation, a rejecting store not affecting run outcomes, is core
   behavior, tested internally.)
 - **ConfigStore:** set/get/delete round-trip fidelity, raw-value persistence via
-  `seedRaw` (the store must return exactly what was written — validation is the CORE's
+  `seedRaw` (the store must return exactly what was written; validation is the CORE's
   job and is tested internally), delete-removes-row, read-your-writes, and a route carrying
   `quota` returned verbatim like any other field.
 - **Provider:** mandatory success dispatch (correct `kind`/text/usage shape); honors

--- a/examples/express/README.md
+++ b/examples/express/README.md
@@ -2,12 +2,12 @@
 
 A minimal Express server with one llmdispatch operation behind it.
 
-- `switch.js` — the switch: one provider, one `summarize` operation, in-memory stores.
-- `server.js` — `POST /summarize`, with `LLMDispatchError` codes mapped to HTTP statuses,
+- `switch.js`: the switch, one provider, one `summarize` operation, in-memory stores.
+- `server.js`: `POST /summarize`, with `LLMDispatchError` codes mapped to HTTP statuses,
   and `GET /healthz`.
 
 Plain ESM JavaScript. The route is `openaiCompatible`, so it works against OpenAI or any
-OpenAI-compatible endpoint — a gateway, or a local model server — by setting
+OpenAI-compatible endpoint (a gateway, or a local model server) by setting
 `OPENAI_BASE_URL`.
 
 ## In your own project

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -35,7 +35,7 @@ app.post('/summarize', async (request, response) => {
   // the server from the session and never read out of the request body.
   const subjectId = 'demo-user'
 
-  // If the caller goes away, the work goes with it — an abandoned request should not carry
+  // If the caller goes away, the work goes with it, since an abandoned request should not carry
   // on spending provider budget. `run` then ends in `ABORTED`. It is the RESPONSE that says
   // whether the client is still there: `request`'s own `close` fires as soon as its body has
   // been read, which is every request, not an abandoned one.

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -2,13 +2,13 @@
 
 A Next.js App Router project with one llmdispatch operation behind a route handler.
 
-- `lib/switch.ts` — the switch: one provider, one `summarize` operation, in-memory stores.
-- `app/api/summarize/route.ts` — `POST`, with `LLMDispatchError` codes mapped to HTTP
+- `lib/switch.ts`: the switch, one provider, one `summarize` operation, in-memory stores.
+- `app/api/summarize/route.ts`: `POST`, with `LLMDispatchError` codes mapped to HTTP
   statuses.
-- `app/api/healthz/route.ts` — `GET`.
+- `app/api/healthz/route.ts`: `GET`.
 
 TypeScript, Node.js runtime. The route is `openaiCompatible`, so it works against OpenAI
-or any OpenAI-compatible endpoint — a gateway, or a local model server — by setting
+or any OpenAI-compatible endpoint (a gateway, or a local model server) by setting
 `OPENAI_BASE_URL`.
 
 ## In your own project

--- a/examples/next/app/api/summarize/route.ts
+++ b/examples/next/app/api/summarize/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: Request): Promise<Response> {
   const subjectId = 'demo-user'
 
   try {
-    // If the caller goes away, the work goes with it — an abandoned request should not
+    // If the caller goes away, the work goes with it, since an abandoned request should not
     // carry on spending provider budget. `run` then ends in `ABORTED`.
     const result = await ai.run(
       'summarize',

--- a/scripts/build-provider-reference.mjs
+++ b/scripts/build-provider-reference.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 /**
- * Builds `docs/providers.md` from spec §5c — the research-verified adapter wire contracts.
+ * Builds `docs/providers.md` from spec §5c: the research-verified adapter wire contracts.
  *
  * The reference is a verbatim slice, not a rewrite: the section between the `### 5c.`
  * heading and the next heading of equal or higher rank is copied as it stands, split into
  * one page section per adapter factory at the bold `**`factory(...)`**` paragraph leads the
- * spec already uses. The generator authors no provider fact of its own — the banner and the
+ * spec already uses. The generator authors no provider fact of its own: the banner and the
  * one structural label are fixed strings, every name and every sentence comes from the
- * spec — so the page cannot drift from the contract it documents. Anything it cannot parse
+ * spec, so the page cannot drift from the contract it documents. Anything it cannot parse
  * exactly (missing heading, missing boundary, an unexpected number of factory leads) is a
  * loud failure, never a guess.
  *
@@ -44,7 +44,7 @@ function sliceSection(lines, problems) {
   let end = null
   for (let index = start + 1; index < lines.length; index += 1) {
     // Equal or higher rank than the `###` opener: `#`, `##` or `###`. §5c is the last
-    // subsection of its parent today, so the boundary is `## 6.` — assuming a later `###`
+    // subsection of its parent today, so the boundary is `## 6.`: assuming a later `###`
     // would swallow the sections that follow.
     if (/^#{1,3} /.test(lines[index])) {
       end = index
@@ -97,7 +97,7 @@ function build(problems) {
 
   const chunks = []
   chunks.push(
-    '<!-- Generated from docs/spec.md §5c by scripts/build-provider-reference.mjs — do not',
+    '<!-- Generated from docs/spec.md §5c by scripts/build-provider-reference.mjs: do not',
     '     edit this file. Edit the spec, then run `npm run docs:providers`. -->',
     '',
     '# Provider wire reference',
@@ -147,12 +147,12 @@ function main() {
     try {
       existing = readFileSync(OUT, 'utf8')
     } catch {
-      process.stderr.write(`${out} is missing — run 'npm run docs:providers'\n`)
+      process.stderr.write(`${out} is missing, run 'npm run docs:providers'\n`)
       return 1
     }
     if (existing !== page) {
       process.stderr.write(
-        `${out} does not match docs/spec.md §5c — run 'npm run docs:providers' and commit the result\n`,
+        `${out} does not match docs/spec.md §5c, run 'npm run docs:providers' and commit the result\n`,
       )
       return 1
     }

--- a/scripts/check-docs-links.mjs
+++ b/scripts/check-docs-links.mjs
@@ -2,11 +2,11 @@
 /**
  * Checks every markdown link in the repository the way GitHub will resolve it: relative
  * targets must exist, and `#fragment` anchors must match a heading slug in the target
- * document. External URLs are counted but never fetched — their health is a different
+ * document. External URLs are counted but never fetched: their health is a different
  * question, and this gate stays network-free and deterministic.
  *
  * The embedded slugger mirrors GitHub's, and is validated against fixed fixtures taken
- * from known GitHub outputs before anything is checked — never against expectations this
+ * from known GitHub outputs before anything is checked, never against expectations this
  * script generated for itself, so the checker cannot quietly agree with its own mistakes.
  * A heading character or a link form the fixtures do not cover fails the gate loudly
  * instead of being skipped.
@@ -23,7 +23,7 @@ import { dirname, join, normalize, sep } from 'node:path'
 const ROOT = join(import.meta.dirname, '..')
 const USAGE = 'usage: check-docs-links.mjs\n'
 
-// ——— slugger ———
+// --- slugger ---
 
 /**
  * GitHub's slug algorithm for the character classes this repository actually uses:
@@ -41,13 +41,13 @@ function slugOf(headingText) {
 
 /**
  * Exactly the character classes the fixtures below prove `slugOf` handles the way GitHub
- * does. A heading using anything else fails the gate loudly — the maintainer then adds a
+ * does. A heading using anything else fails the gate loudly: the maintainer then adds a
  * fixture with the known GitHub output and widens this set, never the other way around.
  */
 const COVERED_HEADING = /^[\p{L}\p{N} `*\-.():;+,/'—]*$/u
 
 /**
- * Known GitHub outputs, not outputs of `slugOf` — the point is that the two agree.
+ * Known GitHub outputs, not outputs of `slugOf`: the point is that the two agree.
  * Sourced from GitHub's rendering of these exact heading texts. Together they cover every
  * character `COVERED_HEADING` admits.
  */
@@ -92,11 +92,11 @@ function sluggerSelfTest(problems) {
   }
 }
 
-// ——— markdown reading ———
+// --- markdown reading ---
 
 /**
  * Two views of the file with line numbers preserved. Fenced code blocks are blanked in
- * both — nothing inside a fence is markup. Inline code spans are blanked only in the
+ * both: nothing inside a fence is markup. Inline code spans are blanked only in the
  * link-scanning view: a bracket inside backticks is not a link, but a heading's inline
  * code DOES contribute its text to GitHub's slug, so the heading view keeps it.
  */
@@ -176,7 +176,7 @@ function linksOf(lines, file, problems) {
   return links
 }
 
-// ——— resolution ———
+// --- resolution ---
 
 function main() {
   if (process.argv.length > 2) {

--- a/scripts/check-spec-surface.mjs
+++ b/scripts/check-spec-surface.mjs
@@ -2,7 +2,7 @@
 /**
  * Regenerates `test/types/spec-surface*.d.ts` from the §6 and §6b code fences of
  * docs/spec.md, compiles them with the fixtures' own options, and compares every name
- * `dist/` exports — ESM and CommonJS, type told apart from value — with what the spec says.
+ * `dist/` exports: ESM and CommonJS, type told apart from value, with what the spec says.
  *
  * A spec name the implementation has not reached yet belongs in `spec-pending.json`; any
  * other difference is a failure. Signatures are not compared: printed text does not
@@ -199,7 +199,7 @@ function reconcileSurfaces(surfaces, update, problems) {
     const recorded = existsSync(path) ? readFileSync(path, 'utf8') : null
     if (recorded !== expected) {
       problems.push(
-        `test/types/${surface} no longer matches docs/spec.md — run \`npm run surface:update\``,
+        `test/types/${surface} no longer matches docs/spec.md, run \`npm run surface:update\``,
       )
     }
   }
@@ -502,7 +502,7 @@ function comparePublished(entry, found, pending, problems) {
       problems.push(`${entry}: ${name} is listed as pending but the spec does not declare it`)
     if (esm.has(name)) {
       problems.push(
-        `${entry}: ${name} is published but still listed in spec-pending.json — remove it there`,
+        `${entry}: ${name} is published but still listed in spec-pending.json, so remove it there`,
       )
     }
     if (spec.get(name) !== kind) {
@@ -580,7 +580,7 @@ function main() {
   if (missing.length > 0) {
     if (!update) {
       problems.push(
-        `${relative(ROOT, missing[0] ?? '')} is missing — run \`npm run build\` first`,
+        `${relative(ROOT, missing[0] ?? '')} is missing, run \`npm run build\` first`,
       )
       return report(problems)
     }

--- a/scripts/check-types-fixtures.mjs
+++ b/scripts/check-types-fixtures.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Compiles every fixture under `test/types/` in a program of its own — one at a time, since
- * the negative ones are meant to fail — and checks that each behaves as it says it will.
+ * Compiles every fixture under `test/types/` in a program of its own, one at a time, since
+ * the negative ones are meant to fail, and checks that each behaves as it says it will.
  *
  * Line one is `// @targets spec[, package]`: `spec` is what docs/spec.md declares, `package`
  * what the build ships, and every fixture must target `spec`, the only run that happens
@@ -11,7 +11,7 @@
  *
  * One fixture does not live on disk: the README quickstart's TypeScript fence is extracted
  * verbatim at check time and compiled in memory against both targets. The printed example
- * is therefore the compiled example — there is no second copy to drift, and the fence never
+ * is therefore the compiled example: there is no second copy to drift, and the fence never
  * carries a `@targets` header the reader shouldn't see.
  *
  * Usage: node scripts/check-types-fixtures.mjs [--target spec|package]
@@ -240,8 +240,8 @@ function readableSource(fixture, problems) {
 
 /**
  * `{ line, code }` for every diagnostic, split into the fixture's own and everything else.
- * `lineOffset` shifts the fixture's own lines — for the README fence, whose line 1 is not
- * the README's line 1 — so every reported number is one the reader can jump to.
+ * `lineOffset` shifts the fixture's own lines, for the README fence, whose line 1 is not
+ * the README's line 1, so every reported number is one the reader can jump to.
  */
 function collectDiagnostics(program, fixturePath, lineOffset) {
   const own = []
@@ -273,8 +273,8 @@ function asPairs(entries) {
 }
 
 /**
- * A compiler host that serves one file from memory — the README fence, which exists at
- * check time only — and everything else from disk as usual.
+ * A compiler host that serves one file from memory: the README fence, which exists at
+ * check time only, and everything else from disk as usual.
  */
 function virtualHost(options, fixture) {
   const host = ts.createCompilerHost(options)

--- a/scripts/fixtures/README.md
+++ b/scripts/fixtures/README.md
@@ -12,5 +12,5 @@ from any real call is stored. The harness fills `model` and `choices[0].message.
 per run, deriving the content from that run's nonce, so a response can only have come from
 this fixture during this run.
 
-Refresh it from the provider's published response schema — never by pasting a captured
+Refresh it from the provider's published response schema, never by pasting a captured
 transcript.

--- a/scripts/gitleaks-scan.sh
+++ b/scripts/gitleaks-scan.sh
@@ -3,7 +3,7 @@
 #
 # Continuous integration runs it over the tree and over the history; the tree scanner's
 # self-test runs it over a directory of deliberately matching strings. Sharing this file
-# is what stops the two from drifting apart — a self-test that proved a different command
+# is what stops the two from drifting apart: a self-test that proved a different command
 # would prove nothing about the one that actually runs.
 #
 # Usage: sh scripts/gitleaks-scan.sh dir|git <path>

--- a/scripts/lib/consumer-project.mjs
+++ b/scripts/lib/consumer-project.mjs
@@ -64,7 +64,7 @@ export function pinnedDevelopmentVersion(name) {
   const found = resolveFromLock(readLockfile(), '', name)
   if (found === null || typeof found.entry.version !== 'string') {
     throw new Error(
-      `package-lock.json records no installed version of ${name} — run \`npm install\``,
+      `package-lock.json records no installed version of ${name}, run \`npm install\``,
     )
   }
   return `${name}@${found.entry.version}`
@@ -78,8 +78,8 @@ function readLockfile() {
 /**
  * Exact versions for the transitive closure of the named packages, as npm `overrides`.
  *
- * Pinning the roots alone leaves their own dependencies — `pg-pool`, `pg-protocol` and the
- * rest — resolving from the registry at install time, so the check would be unreproducible in
+ * Pinning the roots alone leaves their own dependencies: `pg-pool`, `pg-protocol` and the
+ * rest: resolving from the registry at install time, so the check would be unreproducible in
  * the part of it nobody looks at. Overrides pin every nested resolution without adding
  * anything to the dependency list: an optional dependency stays optional, so a platform that
  * cannot install `pg-cloudflare` is not made to.
@@ -87,7 +87,7 @@ function readLockfile() {
  * @param names The packages whose closure to pin, each of which the repository must declare.
  * @returns A map of package name to exact version, for the project's `overrides` field.
  * @throws `Error` when a package is not declared or recorded, when a required dependency
- * cannot be resolved, or when two nodes reach the same name at different versions — that has
+ * cannot be resolved, or when two nodes reach the same name at different versions: that has
  * no single answer, so it is refused rather than decided quietly.
  */
 export function pinnedDevelopmentOverrides(names) {
@@ -128,7 +128,7 @@ export function pinnedDevelopmentOverrides(names) {
         if (found === null || typeof found.entry.version !== 'string') {
           if (optional) continue
           throw new Error(
-            `package-lock.json does not resolve ${wanted}, required by ${name} — ` +
+            `package-lock.json does not resolve ${wanted}, required by ${name}: ` +
               'run `npm install`',
           )
         }
@@ -189,7 +189,7 @@ export function createConsumerProject(opts) {
     },
   )
   if (install.status !== 0 || install.error !== undefined) {
-    // `error` is set when npm never started, overran the output limit or hit the deadline —
+    // `error` is set when npm never started, overran the output limit or hit the deadline,
     // cases that often produce no output at all.
     const reason = install.error === undefined ? '' : `\n${install.error.message}`
     throw new Error(
@@ -303,7 +303,7 @@ let stopping = false
  * Kills every running child and waits for it to go.
  *
  * A signal sent to this process is not delivered to a child it spawned, so without this a
- * handler would tidy up and exit while a keyed runner carried on orphaned — still holding a
+ * handler would tidy up and exit while a keyed runner carried on orphaned: still holding a
  * credential, still writing to a schema that had just been dropped. Every signal handler must
  * await this before cleaning up anything else.
  *

--- a/scripts/lib/database-target.mjs
+++ b/scripts/lib/database-target.mjs
@@ -26,7 +26,7 @@ function ipv4Octets(host) {
  * Whether a host is a literal address in `127.0.0.0/8`.
  *
  * Names are never accepted, `localhost` included: this check does not control what a name
- * resolves to. `::1` is not accepted either — the parser returns it bracketed as `[::1]`, and
+ * resolves to. `::1` is not accepted either: the parser returns it bracketed as `[::1]`, and
  * the driver passes that to `net.connect` as a name to resolve, which fails with ENOTFOUND.
  *
  * @param {string} host The host as the connection string gives it.

--- a/scripts/lib/quickstart-section.mjs
+++ b/scripts/lib/quickstart-section.mjs
@@ -3,18 +3,18 @@
  * and the walk-through so the two gates can never disagree about what the printed
  * quickstart is.
  *
- * The section runs from the `## Quickstart` heading — which must occur exactly once in the
- * whole document — to the next `## ` heading. Inside it there must be exactly one `bash`
+ * The section runs from the `## Quickstart` heading, which must occur exactly once in the
+ * whole document, to the next `## ` heading. Inside it there must be exactly one `bash`
  * fence followed by one `ts` fence. Fences follow CommonMark: any ``` line with an info
- * string opens one, and only a bare ``` line closes one — a ```-prefixed line WITH an info
+ * string opens one, and only a bare ``` line closes one: a ```-prefixed line WITH an info
  * string inside an open fence is content, not a closer. Anything else is reported, never
  * guessed at, so a README restructure fails the gates loudly instead of silently checking
  * the wrong code.
  */
 
 /**
- * `{ install, code, codeOpenerIndex }` — the install command, the ts fence body (verbatim,
- * trailing newline), and the 0-based line index of the ts fence's opener — or `null` after
+ * `{ install, code, codeOpenerIndex }`: the install command, the ts fence body (verbatim,
+ * trailing newline), and the 0-based line index of the ts fence's opener, or `null` after
  * pushing the reason into `problems`.
  */
 export function readQuickstart(readmeText, problems) {

--- a/scripts/lib/subpath-resolution.mjs
+++ b/scripts/lib/subpath-resolution.mjs
@@ -68,7 +68,7 @@ export function assertInstalledPackageResolves() {
     throw new Error(`the package is not installed at ${installed}`)
   }
   const manifest = JSON.parse(readFileSync(join(installed, 'package.json'), 'utf8'))
-  // Resolved paths come back with symlinks followed — a package manager that links its store
+  // Resolved paths come back with symlinks followed: a package manager that links its store
   // would otherwise compare a link against its target and reject an honest install.
   const root = realpathSync(installed)
   const resolved = []

--- a/scripts/live-check-providers.mjs
+++ b/scripts/live-check-providers.mjs
@@ -45,7 +45,7 @@ const USAGE = 'usage: live-check-providers.mjs [--release <path-to-tgz>]\n'
  *
  * The models are the smallest each provider offers, and the runner asks for a handful of
  * tokens: a full run should cost a fraction of a cent. Change them here when a provider
- * retires one — nowhere else names a model.
+ * retires one: nowhere else names a model.
  */
 const PROVIDERS = [
   { name: 'anthropic', key: 'ANTHROPIC_API_KEY', model: 'claude-haiku-4-5' },

--- a/scripts/runners/json-tolerance.mjs
+++ b/scripts/runners/json-tolerance.mjs
@@ -2,7 +2,7 @@
  * Reads a JSON object out of what a model returned for the live check's JSON call.
  *
  * On adapters with no native JSON mode the call is a prompt, so the object may arrive in a
- * code fence or wrapped in prose; both are tolerated. An empty object is not — it parses and
+ * code fence or wrapped in prose; both are tolerated. An empty object is not: it parses and
  * proves nothing.
  *
  * Copied into the scratch project alongside `live-check.mjs`, and kept separate from it so it

--- a/scripts/runners/live-check.mjs
+++ b/scripts/runners/live-check.mjs
@@ -3,7 +3,7 @@
  * One provider's live check, in a process that holds one provider's credential.
  *
  * Two calls: a plain one and one asking for a JSON object. Both have to come back complete,
- * with text, and with usage the package was able to normalize — a provider whose wire shape
+ * with text, and with usage the package was able to normalize: a provider whose wire shape
  * has moved under the adapter shows up here as a null usage or a missing field, which is the
  * whole reason this check exists.
  *

--- a/scripts/runners/release-conformance.mjs
+++ b/scripts/runners/release-conformance.mjs
@@ -9,7 +9,7 @@
  * installed PostgreSQL stores, and run the provider suite against a fixture backend served
  * from this process.
  *
- * The schema is named by the caller, which also drops it — this process can be killed and so
+ * The schema is named by the caller, which also drops it: this process can be killed and so
  * cannot be relied on to clean up after itself.
  *
  * Usage: node release-conformance.mjs <schema>
@@ -56,7 +56,7 @@ async function importInstalledPackage() {
  *
  * The provider suite puts the backend into a named condition and then dispatches; this server
  * is that backend. Every classification row the built-in adapter documents is covered here, so
- * the suite reports nothing as unverified — a release must not ship on a partial answer.
+ * the suite reports nothing as unverified: a release must not ship on a partial answer.
  */
 function renderScenario(template, scenario) {
   const body = structuredClone(template)
@@ -148,7 +148,7 @@ ON CONFLICT (operation) DO UPDATE SET route = EXCLUDED.route`,
 
 /**
  * Runs both store suites against the installed stores, reached only through the public
- * factory and a pool of this check's own — the shape an adopter has.
+ * factory and a pool of this check's own: the shape an adopter has.
  */
 async function runStoreSuites(pool, schema) {
   const controls = controlStatements(schema)

--- a/scripts/scan-allowlist.txt
+++ b/scripts/scan-allowlist.txt
@@ -1,5 +1,5 @@
 # Hosts this repository is allowed to link to. One host per line; `#` starts a comment.
-# A link to anything else is a finding — add the host here, in a reviewed change, first.
+# A link to anything else is a finding: add the host here, in a reviewed change, first.
 
 # This project and the tooling around it
 github.com

--- a/scripts/scan-denylist.mjs
+++ b/scripts/scan-denylist.mjs
@@ -23,7 +23,7 @@
  * The self-test writes one deliberately matching input per rule, plus the near-misses
  * that must stay silent, into a temporary directory it deletes afterwards. Those inputs
  * are assembled at run time from harmless pieces and are never committed in any
- * encoding — a committed one would fail every ordinary run of this script and of the
+ * encoding: a committed one would fail every ordinary run of this script and of the
  * secret scanner that runs beside it.
  */
 
@@ -249,8 +249,8 @@ function collectResolved(node, found) {
  * being scanned, which the examples use so they always install the packed tarball.
  *
  * The answer comes from resolving the path, not from reading it. A test that looks for
- * `..` misses every other spelling of the same escape — `..%2f`, `%2e%2e`, a backslash
- * separator, a drive letter, a `~` home reference — so each is decoded or rejected before
+ * `..` misses every other spelling of the same escape: `..%2f`, `%2e%2e`, a backslash
+ * separator, a drive letter, a `~` home reference, so each is decoded or rejected before
  * the containment check, which is the only thing that actually decides.
  */
 function isLocalFileSpec(resolved, root, lockfileDirectory) {
@@ -401,7 +401,7 @@ function buildCanaries(root) {
   )
   write('ip-literal.md', 'see ' + 'ht' + 'tps://' + '203.0.113.7' + '/x\n', 'unreviewed-host')
   // The bracketed form ends at the closing bracket, so the token does not parse as a
-  // link at all — which the host rule treats as unreviewed, exactly as it should.
+  // link at all, which the host rule treats as unreviewed, exactly as it should.
   write(
     'ipv6-literal.md',
     'see ' + 'ht' + 'tps://' + '[2001:db8::1]' + '/x\n',
@@ -450,7 +450,7 @@ function buildCanaries(root) {
     'foreign-registry',
   )
   // A `file:` spec is only ever the repository's own, so one reaching outside the tree is
-  // as much a finding as a mirror — in every spelling, since a reader who only knows `..`
+  // as much a finding as a mirror, in every spelling, since a reader who only knows `..`
   // would wave most of these through.
   const escapes = {
     relative: '../../elsewhere/t.tgz',

--- a/scripts/test-consumers.mjs
+++ b/scripts/test-consumers.mjs
@@ -188,7 +188,7 @@ function main() {
           'across the ESM and CommonJS builds in both directions, rejected the values that only ' +
           'look like one, narrowed LLMDispatchError by code, and round-tripped a reservation ' +
           'through the in-memory stores, and rendered the same packaged migration from both ' +
-          `builds — from sha256 ${before}\n`
+          `builds, from sha256 ${before}\n`
       : `${String(problems.length)} problem(s)\n`,
   )
   return problems.length === 0 ? 0 : 1

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -9,21 +9,21 @@
  * committed template with content derived from that same nonce. So a passing run means the
  * example parsed the input, routed it through the installed package, reached the provider
  * with the right model and credentials, validated the answer against its own schema, and
- * reported the route it took — a chain no cached build or stale server can fake. The
+ * reported the route it took: a chain no cached build or stale server can fake. The
  * fixture's address reaches the example only when its server starts: the build stage is
  * given an address nothing answers on, so a value captured at build time cannot pass for a
  * value read at runtime.
  *
  * The temporary project is assembled outside the repository from an explicit list of the
- * example's tracked files, so nothing untracked — a local `.env`, an `.npmrc`, a stray
- * `node_modules` — can travel into it. The child environment is the shared allowlist, which
+ * example's tracked files, so nothing untracked: a local `.env`, an `.npmrc`, a stray
+ * `node_modules`: can travel into it. The child environment is the shared allowlist, which
  * carries a synthetic key and the fixture's base URL and nothing else: no run of this can
  * become live billed traffic.
  *
  * Needs the network for `npm ci`.
  *
  * Usage: node scripts/verify-examples.mjs [path-to-tarball]
- *   With no argument, packs the working tree — including whatever `dist/` currently holds,
+ *   With no argument, packs the working tree, including whatever `dist/` currently holds,
  *   so a stale local build is verified as it is. CI passes the audited tarball.
  * Exit codes: 0 every example ran as documented, 1 one did not, 2 bad arguments.
  */
@@ -77,7 +77,7 @@ const DEADLINES = {
 }
 /**
  * The whole run, comfortably inside the workflow job's own timeout so this trips first and
- * says which stage was running — a bare job kill says nothing.
+ * says which stage was running: a bare job kill says nothing.
  */
 const BUDGET = 30 * 60_000
 /** How long a server gets to leave on its own after TERM before it is killed. */
@@ -386,8 +386,8 @@ let shuttingDown = null
 
 /**
  * The signal, budget and uncaught paths: whatever any session still holds, wherever it is.
- * Processes are stopped across every session — newest first, so an example's server dies
- * before the workspace it lives in — and only then is anything removed from disk.
+ * Processes are stopped across every session: newest first, so an example's server dies
+ * before the workspace it lives in, and only then is anything removed from disk.
  */
 function releaseAll() {
   shuttingDown ??= (async () => {
@@ -510,7 +510,7 @@ async function runToCompletion(session, command, args, cwd, environment, timeout
   session.timers.add(deadline)
 
   // `close`, not `exit`: the streams are drained by then, so what the command printed on
-  // its way out — a packed filename, an EADDRINUSE — is all here rather than partly here.
+  // its way out: a packed filename, an EADDRINUSE: is all here rather than partly here.
   const result = await new Promise((done) => {
     started.child.once('error', (error) => done({ status: null, error }))
     started.child.once('close', (status) => done({ status, error: null }))
@@ -568,7 +568,7 @@ function trackedFiles(name) {
 
 /**
  * The one shape the tarball waiver below is safe for: the package is installed once, at the
- * root of the tree, from the local file — no workspace, no override, no second copy.
+ * root of the tree, from the local file, no workspace, no override, no second copy.
  */
 function checkLockfileShape(lockfile, name, problems) {
   const packages = lockfile.packages
@@ -602,10 +602,10 @@ function checkLockfileShape(lockfile, name, problems) {
   // The local tarball is packed fresh for every run, so no committed checksum can describe
   // it and `npm ci` refuses one that does not match. The lockfile is there for the
   // transitive tree; what was actually installed is proved a step later, against the
-  // tarball itself — which only holds while nothing else can supply the package.
+  // tarball itself, which only holds while nothing else can supply the package.
   if (local.integrity !== undefined) {
     problems.push(
-      `${name}: package-lock.json records a checksum for llmdispatch-local.tgz — ` +
+      `${name}: package-lock.json records a checksum for llmdispatch-local.tgz: ` +
         'regenerate it and drop that field, or no packed tarball but that one will install',
     )
     return false
@@ -635,7 +635,7 @@ function assembleProject(descriptor, workspace, tarball, problems) {
   const expected = [...descriptor.files].sort()
   if (tracked.join('\n') !== expected.join('\n')) {
     problems.push(
-      `${descriptor.name}: the tracked files are not the ones this harness copies — ` +
+      `${descriptor.name}: the tracked files are not the ones this harness copies: ` +
         `tracked ${tracked.join(', ')}; expected ${expected.join(', ')}`,
     )
     return null
@@ -854,7 +854,7 @@ async function verifyExample(descriptor, workspace, tarball, reference, template
       session,
     )
     if (server.problem !== null) {
-      problems.push(`${stage} failed — ${server.problem}`)
+      problems.push(`${stage} failed: ${server.problem}`)
       return
     }
 
@@ -881,7 +881,7 @@ async function verifyExample(descriptor, workspace, tarball, reference, template
           `${String(state.accepted)}; exactly one of each was expected`,
       )
     }
-    // After the drain, nothing may still be in flight — otherwise the counts above are a
+    // After the drain, nothing may still be in flight: otherwise the counts above are a
     // snapshot of a conversation that had not finished.
     if (state.active !== 0) {
       found.push(
@@ -894,7 +894,7 @@ async function verifyExample(descriptor, workspace, tarball, reference, template
     for (const problem of found) problems.push(`${descriptor.name}: ${problem}`)
   } catch (error) {
     problems.push(
-      `${stage} failed — ${error instanceof Error ? error.message : 'unknown error'}`,
+      `${stage} failed: ${error instanceof Error ? error.message : 'unknown error'}`,
     )
   } finally {
     stage = `${descriptor.name}: tearing down`
@@ -938,7 +938,7 @@ async function main() {
       template = JSON.parse(readFileSync(TEMPLATE, 'utf8'))
     } catch (error) {
       process.stderr.write(
-        `${stage} failed — ${error instanceof Error ? error.message : 'unknown error'}\n`,
+        `${stage} failed: ${error instanceof Error ? error.message : 'unknown error'}\n`,
       )
       return 1
     }
@@ -948,7 +948,7 @@ async function main() {
     const named = EXAMPLES.map((descriptor) => descriptor.name).sort()
     if (directories.join(', ') !== named.join(', ')) {
       process.stderr.write(
-        `${stage} failed — the repository tracks examples/${directories.join(', examples/')}, ` +
+        `${stage} failed: the repository tracks examples/${directories.join(', examples/')}, ` +
           `but this harness verifies ${named.join(', ')}\n`,
       )
       return 1

--- a/scripts/verify-quickstart.mjs
+++ b/scripts/verify-quickstart.mjs
@@ -6,12 +6,12 @@
  * section must contain exactly one `bash` install fence followed by one `ts` code fence.
  * The install is the documented command with only the unpublished registry argument
  * `llmdispatch` replaced by the tarball path; the code fence is written byte-for-byte to its
- * own file — never edited, wrapped or rewritten — and executed by a two-line harness that
+ * own file, never edited, wrapped or rewritten, and executed by a two-line harness that
  * imports it. The child environment is the shared allowlist, which carries no provider key
  * and no `NODE_OPTIONS`, so the run cannot become live billed traffic and nothing preloaded
  * can put a key back: without a key, the documented outcome is an `LLMDispatchError`
  * with code `INVALID_CONFIG` from the unresolvable key, and that exact rejection is the
- * pass condition. Anything else — a ReferenceError, a different code, a run that resolves —
+ * pass condition. Anything else: a ReferenceError, a different code, a run that resolves,
  * means the printed quickstart is wrong.
  *
  * Needs Node >= 23.6 (native type stripping executes the `ts` fence as printed) and network
@@ -35,14 +35,14 @@ const README = join(ROOT, 'README.md')
 const USAGE = 'usage: verify-quickstart.mjs [path-to-tarball]\n'
 
 /**
- * The harness: import the printed file, require the documented rejection — a real
+ * The harness: import the printed file, require the documented rejection: a real
  * `LLMDispatchError` from the installed package, `INVALID_CONFIG`, detected locally (the
  * unresolvable key), never a dispatched provider rejection.
  */
 const HARNESS = `import { LLMDispatchError } from 'llmdispatch'
 try {
   await import('./quickstart.ts')
-  console.error('the quickstart ran to completion without an API key — expected INVALID_CONFIG')
+  console.error('the quickstart ran to completion without an API key: expected INVALID_CONFIG')
   process.exit(1)
 } catch (error) {
   if (
@@ -140,7 +140,7 @@ function main() {
     })
     return 0
   } catch {
-    process.stderr.write(`the quickstart walk-through failed while ${step} — output above\n`)
+    process.stderr.write(`the quickstart walk-through failed while ${step}: output above\n`)
     return 1
   } finally {
     rmSync(directory, { recursive: true, force: true })

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -5,7 +5,7 @@
  * The tarball is installed into a throwaway project, the installed bytes are checked against
  * it, and the check runs from inside that project: it applies the packaged migration to a real
  * PostgreSQL in a schema of its own and runs all three conformance suites. A skipped case
- * fails the run as a failing one does — a release must not ship on an unverified
+ * fails the run as a failing one does: a release must not ship on an unverified
  * classification. The suites `import` the package, so they exercise its ESM build; the
  * CommonJS build is covered by the consumer fixtures.
  *
@@ -14,7 +14,7 @@
  * is reported and makes the run non-zero.
  *
  * Usage: node scripts/verify-release.mjs <path-to-tgz>
- * Needs `DATABASE_URL` in exactly one shape: postgres://user:password@127.0.0.1:port/database —
+ * Needs `DATABASE_URL` in exactly one shape: postgres://user:password@127.0.0.1:port/database,
  * an address in 127.0.0.0/8, an explicit port, and no query string or fragment.
  *
  * A database for the run, thrown away with the container:
@@ -103,7 +103,7 @@ async function release() {
       owned.leftover = true
       process.stderr.write(
         `the schema ${owned.schema} could not be dropped. If the run reached the database, ` +
-          `it is still there — remove it with: DROP SCHEMA IF EXISTS "${owned.schema}" CASCADE\n`,
+          `it is still there: remove it with: DROP SCHEMA IF EXISTS "${owned.schema}" CASCADE\n`,
       )
     } finally {
       await pool.end().catch(() => undefined)
@@ -139,7 +139,7 @@ function cleanUpOnSignal() {
 
 /**
  * Drops every `PG*` name from this process's environment, so its pools connect on the
- * connection string alone — as the children already do under their allowlist. The driver reads
+ * connection string alone, as the children already do under their allowlist. The driver reads
  * these as defaults, so an ambient `PGSSLMODE` or `PGPORT` could otherwise make the clean-up
  * connect differently from the run it is cleaning up after.
  */
@@ -229,7 +229,7 @@ async function main() {
   }
   process.stdout.write(
     'the installed tarball applied its packaged migration to PostgreSQL and passed all ' +
-      `three conformance suites with nothing skipped — from sha256 ${before}\n`,
+      `three conformance suites with nothing skipped, from sha256 ${before}\n`,
   )
   return 0
 }

--- a/src/conformance.ts
+++ b/src/conformance.ts
@@ -1,9 +1,9 @@
 /**
- * Conformance entry point — `import { … } from 'llmdispatch/conformance'`.
+ * Conformance entry point. `import { … } from 'llmdispatch/conformance'`.
  *
  * For anyone writing their own usage store, config store or provider adapter: the harnesses
  * check an implementation against the behaviour the rest of the package relies on, so a store
- * or adapter that passes is substitutable for a built-in one. They need no test framework —
+ * or adapter that passes is substitutable for a built-in one. They need no test framework;
  * each one resolves with a plain result you can assert on however you like.
  *
  * The exact surface is specified in `docs/spec.md` §6b and §8.

--- a/src/conformance/README.md
+++ b/src/conformance/README.md
@@ -5,5 +5,5 @@ store or config store purely through its public interface and report which behav
 hold, so anyone can prove a custom implementation is substitutable for a built-in one.
 
 May import: `src/conformance`, `src/errors`, the public types, `zod`, and `node:*`
-built-ins. Must not import a concrete provider or store — a harness that reached for a
+built-ins. Must not import a concrete provider or store: a harness that reached for a
 built-in would test the built-in instead of the implementation under test.

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,10 +1,10 @@
 # `src/core`
 
 The decision layer: the run state machine, config resolution and caching, failure
-classification, and the quota lifecycle. Everything here is pure — it decides _what_
+classification, and the quota lifecycle. Everything here is pure: it decides _what_
 should happen and hands the work to an interface it never implements itself. No HTTP,
 no SQL, no clock reads that are not passed in, no Node built-ins at all.
 
 May import: `src/core`, `src/errors`, the public types, and `zod`. Must not import
-`src/providers`, `src/stores`, `src/conformance`, or an entry module — adding a
+`src/providers`, `src/stores`, `src/conformance`, or an entry module, since adding a
 provider or a store never edits this folder.

--- a/src/core/abort.ts
+++ b/src/core/abort.ts
@@ -1,5 +1,5 @@
 /**
- * The abort race and the deadline race — the two ways the core stops waiting.
+ * The abort race and the deadline race: the two ways the core stops waiting.
  *
  * Both are built on `Promise.race`, which keeps a reaction attached to the losing side, so a
  * user callback or store call that fails after the run has moved on never surfaces as an
@@ -103,7 +103,7 @@ export function callWithDeadline<T>(
  * Waits out a backoff delay unless the signal fires first.
  *
  * Used between commit retries: the §1 rule checks the signal before every quota-recovery
- * I/O, and ending the wait early just reports the abort sooner — the check still guards the
+ * I/O, and ending the wait early just reports the abort sooner, and the check still guards the
  * I/O itself. The timer is referenced (an in-flight run may not let the process exit) and is
  * cancelled if the abort wins; the listener is removed if the delay elapses.
  */

--- a/src/core/classify.ts
+++ b/src/core/classify.ts
@@ -38,7 +38,7 @@ const PROVIDER_ERROR_KINDS: ReadonlySet<string> = new Set<ProviderErrorKind>([
  * Classifies a value thrown by `complete()` (spec §5b).
  *
  * A branded `ProviderError` classifies by its captured `kind`; a captured kind outside the
- * closed set — or a second read that throws — follows the `provider_unclassified` row. An
+ * closed set, or a second read that throws, follows the `provider_unclassified` row. An
  * adapter-reported `'aborted'` is the caller's abort only if the caller's signal actually
  * fired; otherwise it re-classifies `timeout` (the adapter saw the core's own timeout).
  * Anything else thrown is `provider_unclassified`, or `transient` under

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -2,12 +2,12 @@
  * Config resolution (spec §2): the per-operation cache, the generation counter, the
  * per-operation mutation mutex, and the admin reads.
  *
- * Coherence rules, all from §2: every mutation outcome — success, rejection, timeout, and a
- * late ack after a timeout — bumps the operation's generation and invalidates its cache
+ * Coherence rules, all from §2: every mutation outcome (success, rejection, timeout, and a
+ * late ack after a timeout) bumps the operation's generation and invalidates its cache
  * entry; a read begun under an older generation installs nothing; cache age is stamped when
  * the read completes, not when it starts. Mutations are serialized per operation (FIFO, one
  * in flight), and the mutex is released at the store call's deadline even though the store
- * promise is still pending — the 10 s budget binds the store call itself, so a queued
+ * promise is still pending: the 10 s budget binds the store call itself, so a queued
  * mutation's own call still gets its full 10 s from the moment it starts.
  *
  * @module
@@ -85,7 +85,7 @@ export interface ConfigService {
 /**
  * Builds the config service for one switch.
  *
- * @param operations Every declared operation, keyed by name — the source of `defaultRoute`.
+ * @param operations Every declared operation, keyed by name, the source of `defaultRoute`.
  * @param registered The registered provider IDs, for validation-on-read of stored rows.
  */
 export function createConfigService(opts: {
@@ -225,7 +225,7 @@ export function createConfigService(opts: {
 
   /**
    * One serialized mutation. The mutex is released when the store call settles or times
-   * out — at the deadline the store promise is still pending, and its late outcome bumps
+   * out: at the deadline the store promise is still pending, and its late outcome bumps
    * the generation again when it finally lands (§2).
    */
   async function mutate(
@@ -263,7 +263,7 @@ export function createConfigService(opts: {
       } catch (error) {
         bumpAndInvalidate(operation)
         if (error instanceof DeadlineExceeded) {
-          // Unknown ack: the write may still land. When it does — either way — it bumps
+          // Unknown ack: the write may still land. When it does, either way, it bumps
           // again, so a stale entry cached in between is invalidated (§2).
           suppress(
             storePromise.then(

--- a/src/core/create-switch.ts
+++ b/src/core/create-switch.ts
@@ -71,7 +71,7 @@ export function defineOperation<In extends z.ZodType, Out extends z.ZodType>(
  * Collects operations for `createSwitch`.
  *
  * An identity collector (spec §6): it returns exactly the object it was given and does not
- * itself restore inference — that is {@link defineOperation}'s job, per entry.
+ * itself restore inference; that is {@link defineOperation}'s job, per entry.
  *
  * @param operations The map of operations, each wrapped in `defineOperation`.
  * @returns The same object.
@@ -207,7 +207,7 @@ function validateOperation(
  * Builds a configured switch (spec §6).
  *
  * Pure wiring plus §6 validation; no store is called and no provider is prepared here.
- * Internal — the public `createSwitch` in the root entry supplies the real runtime.
+ * Internal: the public `createSwitch` in the root entry supplies the real runtime.
  *
  * @throws `LLMDispatchError` with code `INVALID_CONFIG` naming the field that failed.
  */

--- a/src/core/output.ts
+++ b/src/core/output.ts
@@ -1,7 +1,7 @@
 /**
  * The output pipeline (spec §3): from a completed response's text to validated data.
  *
- * Termination is checked before content by the caller — this module only ever sees a
+ * Termination is checked before content by the caller, so this module only ever sees a
  * `kind: 'complete'` text. Parse and shape failures are output rejections (fallback-eligible);
  * a non-Zod exception from user transform code and anything wrong in the quality gate are the
  * user's own bugs, reported for settlement and then re-thrown raw.

--- a/src/core/quota.ts
+++ b/src/core/quota.ts
@@ -1,8 +1,8 @@
 /**
  * The quota lifecycle (spec §4): reserve, commit with recovery, and settlement.
  *
- * Every store return is validated fail-closed — the core never dispatches without a
- * validated `'committed'` — and the caller's signal is checked before every recovery I/O.
+ * Every store return is validated fail-closed: the core never dispatches without a
+ * validated `'committed'`, and the caller's signal is checked before every recovery I/O.
  * Settlement never changes a run's outcome: the initial `settle` is awaited to its deadline,
  * the retries are detached on unreferenced timers, and the failure hook and logger are
  * reached only through caught chains.
@@ -132,7 +132,7 @@ function storeFields<K extends string>(
 /**
  * Reserves the run's slot (spec §4, stage 7).
  *
- * Never raced with the signal — a reserve in flight is awaited to its deadline-bounded
+ * Never raced with the signal: a reserve in flight is awaited to its deadline-bounded
  * result (§1); the caller checks the signal afterwards. `limit === 0` still reserves: the
  * denial's `used` and `resetsAt` must be store-authoritative.
  *
@@ -169,7 +169,7 @@ async function reserveOnce(
     checkRecoverySignal(ctx)
     throw usageStoreUnavailable(ctx.operation, error)
   }
-  // §1: an in-flight reserve is awaited to its result first — then, before that result is
+  // §1: an in-flight reserve is awaited to its result first, then, before that result is
   // interpreted, an abort ends the run. Whatever state was reached stands: a granted
   // envelope simply expires on its own; a denial changed nothing.
   checkRecoverySignal(ctx)
@@ -229,7 +229,7 @@ function checkRecoverySignal(ctx: QuotaContext): void {
 
 /**
  * Commits the reservation, running the §4 recovery table, and answers the envelope the run
- * settles against — the original, or the replacement after a single re-reserve.
+ * settles against: the original, or the replacement after a single re-reserve.
  *
  * The signal is checked before every recovery I/O; an in-flight call is always awaited to
  * its deadline-bounded result first (§1).
@@ -299,7 +299,7 @@ async function commitWithTransportRetries(
       continue
     }
     // A validated 'committed' counts (§1): the run proceeds into the post-commit region,
-    // whose first boundary check reports the abort — with settlement. Every other answer
+    // whose first boundary check reports the abort, with settlement. Every other answer
     // yields to the abort before it is interpreted.
     if (answer === 'committed') return answer
     checkRecoverySignal(ctx)
@@ -399,7 +399,7 @@ function settlementDomainProblem(
  *
  * The returned promise is the awaited part: the initial `settle`, bounded by its 10 s
  * deadline, resolving whether or not that call succeeded. On failure, up to three retries
- * run on detached unreferenced timers — the process may exit before them (§4) — and if all
+ * run on detached unreferenced timers (the process may exit before them, §4), and if all
  * fail, `onSettlementError` and `logger.error` each run once through a caught chain.
  *
  * `attempts` must already be the run's own snapshot: the caller's arrays are reachable from

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -168,13 +168,13 @@ export async function executeRun(
   }
   throwIfAborted()
 
-  // Stage 3: subject check for a declared quota only — it must precede all I/O.
+  // Stage 3: subject check for a declared quota only: it must precede all I/O.
   const subjectId = args.subjectId
   if (op.quota !== undefined && !isNonEmptyString(subjectId)) throw missingSubject(operation)
   throwIfAborted()
 
   // Stage 4: config resolution for both routes in one read, then the route-enabled subject
-  // check — after config errors, per the §1 precedence rule.
+  // check, after config errors, per the §1 precedence rule.
   const route = await ctx.configService.resolve(operation)
   const effectiveQuota = route.quota ?? op.quota
   if (effectiveQuota !== undefined && !isNonEmptyString(subjectId))
@@ -205,7 +205,7 @@ export async function executeRun(
   throwIfAborted()
 
   // Stages 7 and 8: reserve and commit, only for an effective quota. Neither is raced with
-  // the signal — an in-flight call is awaited to its deadline-bounded result first (§1).
+  // the signal: an in-flight call is awaited to its deadline-bounded result first (§1).
   let envelope: ReservationEnvelope | null = null
   if (effectiveQuota !== undefined) {
     // Re-narrowing only: the stage 3/4 checks above already threw for a missing subject.

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -5,7 +5,7 @@
  * handed this object, the root entry wires the real one from `globalThis`, and tests inject a
  * fake. The referenced/unreferenced distinction is the process-liveness contract: a referenced
  * timer may keep the process alive (store deadlines, provider timeouts, the awaited settle),
- * an unreferenced one must not (the detached settlement retries — spec §4 lets the process
+ * an unreferenced one must not (the detached settlement retries: spec §4 lets the process
  * exit before them, losing attempt records but never slot accounting).
  *
  * @module

--- a/src/core/usage.ts
+++ b/src/core/usage.ts
@@ -1,7 +1,7 @@
 /**
  * Usage normalization and the §7 aggregates.
  *
- * The universal rule: invalid usage never fails a run — it normalizes to `null` — and a
+ * The universal rule: invalid usage never fails a run (it normalizes to `null`), and a
  * fabricated zero is never invented for a missing count. Aggregation sums only what was
  * reported, and says so through `usageComplete`.
  *
@@ -17,8 +17,8 @@ export type PricingTable = ReadonlyMap<string, ReadonlyMap<string, ModelPrice>>
 /**
  * Reads a provider-reported usage value once and answers a validated copy, or `null`.
  *
- * Both counters must be non-negative safe integers; anything else — wrong shape, wrong
- * type, negative, unsafe — normalizes to `null` (spec §5b, §7).
+ * Both counters must be non-negative safe integers; anything else (wrong shape, wrong
+ * type, negative, unsafe) normalizes to `null` (spec §5b, §7).
  */
 export function normalizeUsage(value: unknown): TokenUsage | null {
   try {
@@ -59,7 +59,7 @@ export interface UsageAggregate {
 /**
  * Aggregates a run's dispatched attempts (spec §7).
  *
- * `usage` is the field-wise sum over attempts with non-null usage — `{0,0}` when none —
+ * `usage` is the field-wise sum over attempts with non-null usage, `{0,0}` when none,
  * clamped field-wise to `Number.MAX_SAFE_INTEGER`. `usageComplete` is true iff every
  * dispatched attempt has usage and no clamp fired. `cost` is the summed per-attempt cost,
  * `null` if any dispatched attempt lacks usage or a price.

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -96,7 +96,7 @@ export function temperatureProblem(value: unknown): string | null {
   return numberProblem(value, { integer: false, min: 0, max: 2 })
 }
 
-/** A price per million tokens: finite and non-negative — a count bound does not apply. */
+/** A price per million tokens: finite and non-negative; a count bound does not apply. */
 export function priceProblem(value: unknown): string | null {
   return numberProblem(value, { integer: false, min: 0 })
 }
@@ -133,7 +133,7 @@ export type Validated<T> = { ok: true; value: T } | { ok: false; problem: string
 /**
  * Copies a validated route so nothing outside the switch can mutate the original.
  *
- * Used wherever a route the switch holds — a declared `defaultRoute`, a cached row — is
+ * Used wherever a route the switch holds (a declared `defaultRoute`, a cached row) is
  * handed to the adopter.
  */
 export function cloneRoute(route: OperationRoute): OperationRoute {
@@ -172,7 +172,7 @@ function unknownField(
 /**
  * Validates a `RouteTarget` strictly and answers a plain copy.
  *
- * Every property is read exactly once, and the copy holds those readings — the value a later
+ * Every property is read exactly once, and the copy holds those readings: the value a later
  * consumer sees is the value that was checked.
  */
 export function validateRouteTarget(
@@ -210,8 +210,8 @@ export function validateRouteTarget(
 /**
  * Validates an `OperationRoute` strictly and answers a plain copy.
  *
- * The same validator serves all three seats — declared routes at `createSwitch`, the route
- * handed to `setConfig`, and rows read back from the config store — so a row a store returns
+ * The same validator serves all three seats: declared routes at `createSwitch`, the route
+ * handed to `setConfig`, and rows read back from the config store, so a row a store returns
  * is held to exactly the shape an admin could have written (spec §2, §6).
  */
 export function validateRoute(

--- a/src/errors/README.md
+++ b/src/errors/README.md
@@ -2,7 +2,7 @@
 
 The two error classes adopters see. `LLMDispatchError` is what a classified failure raises: a
 closed `code` union, a private constructor, and a `retryable` flag that is the literal of the
-spec §5b classification row rather than of the code — `PROVIDER_FAILED` is retryable for a
+spec §5b classification row rather than of the code: `PROVIDER_FAILED` is retryable for a
 `transient` failure and not for a `refused` one, which is why there is one typed factory per
 classification. `ProviderError` is what an adapter throws to say how a call failed; it is
 recognised by a brand on its prototype, never by `instanceof`, so it still classifies
@@ -12,5 +12,5 @@ The factories stay internal. Messages are stable and carry no prompt, model outp
 provider error.
 
 May import: the public types in `src/types.ts`, `src/errors` itself, and `zod`. This is the
-bottom layer of behaviour — nothing else in `src` may be imported from here, so every other
+bottom layer of behaviour, and nothing else in `src` may be imported from here, so every other
 folder can depend on it without creating a cycle.

--- a/src/errors/factories.ts
+++ b/src/errors/factories.ts
@@ -4,7 +4,7 @@
  * One factory per classification, not per code: spec §5b makes `retryable` a function of the
  * classification, so `PROVIDER_FAILED` is retryable for a `transient` failure and not for a
  * `refused` one. Taking the classification and looking the literal up is what stops a throw
- * site disagreeing with the table. Messages carry an operation, a field or a classification —
+ * site disagreeing with the table. Messages carry an operation, a field or a classification;
  * never a prompt, a model's output, or a raw provider error (spec §4).
  *
  * @module

--- a/src/errors/provider-error.ts
+++ b/src/errors/provider-error.ts
@@ -2,7 +2,7 @@
  * The error a provider adapter throws to say how a call failed.
  *
  * Its `kind` drives the fallback matrix (spec §5b), so recognising one must work even when
- * the thrower and the reader loaded different copies of this module — the dual-package
+ * the thrower and the reader loaded different copies of this module: the dual-package
  * hazard. Recognition is therefore brand-based, and `ProviderError.is()` is the only
  * supported check; bare `instanceof` is never used.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Root entry point — `import { … } from 'llmdispatch'`.
+ * Root entry point. `import { … } from 'llmdispatch'`.
  *
  * The only module that assembles the pieces: the factory that turns providers, operations
  * and stores into a working switch, the built-in adapters, the in-memory stores, the errors,
@@ -56,8 +56,8 @@ export { defineOperation, defineOperations } from './core/create-switch'
  * Builds a configured switch: providers, operations and stores in; `run` plus the admin
  * surface out (spec §6).
  *
- * Construction is pure wiring — no store is called, no provider is prepared, no network is
- * touched — plus the §6 validation of every range and name, so a misconfiguration fails
+ * Construction is pure wiring: no store is called, no provider is prepared, no network is
+ * touched, plus the §6 validation of every range and name, so a misconfiguration fails
  * here, loudly, rather than on the first request.
  *
  * @param config Who can be called, what the app does, and where config and counters live.

--- a/src/postgres.ts
+++ b/src/postgres.ts
@@ -1,5 +1,5 @@
 /**
- * PostgreSQL entry point — `import { … } from 'llmdispatch/postgres'`.
+ * PostgreSQL entry point. `import { … } from 'llmdispatch/postgres'`.
  *
  * The packaged migrations: `MIGRATIONS` is every published version with its template hash, and
  * `migrationSql()` renders them for your schema. The stores themselves are exported from the

--- a/src/providers/README.md
+++ b/src/providers/README.md
@@ -1,7 +1,7 @@
 # `src/providers`
 
 One adapter per provider API. Each translates a request into that provider's wire
-format, sends it with global `fetch`, and translates the response — or the failure —
+format, sends it with global `fetch`, and translates the response, or the failure,
 back into the shared shapes. An adapter decides nothing about routing, fallback, or
 quotas; it reports what happened and lets the core decide.
 

--- a/src/providers/transport.ts
+++ b/src/providers/transport.ts
@@ -16,7 +16,7 @@ export interface HttpResult {
 
 /**
  * One request. Always uses `redirect: 'error'`. Rejects with `ProviderError('aborted')`
- * when the signal fired; other fetch failures — including a body that never arrives — are
+ * when the signal fired; other fetch failures, including a body that never arrives, are
  * `transient`. JSON parse failures stay a null body, not a network error.
  */
 export async function fetchJson(
@@ -39,7 +39,7 @@ export async function fetchJson(
       redirect: 'error',
     })
     // Body settlement is still network I/O. A reset here must classify like the fetch
-    // rejection above — otherwise a raw TypeError escapes and the core treats it as
+    // rejection above; otherwise a raw TypeError escapes and the core treats it as
     // `provider_unclassified` (no fallback). JSON.parse stays outside this catch.
     text = await response.text()
   } catch {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2,8 +2,8 @@
  * The real runtime behind the core's clock-and-timer seam, built from `globalThis`.
  *
  * The globals are read at call time, not import time, and `.unref()` is called only where the
- * returned handle actually has one — Node handles do, browser and edge runtimes hand back
- * numbers — so the same build runs anywhere `setTimeout` exists.
+ * returned handle actually has one: Node handles do, browser and edge runtimes hand back
+ * numbers, so the same build runs anywhere `setTimeout` exists.
  *
  * @module
  */

--- a/src/stores/memory/config-store.ts
+++ b/src/stores/memory/config-store.ts
@@ -34,8 +34,8 @@ export function createMemoryConfigStore(): MemoryConfigStore {
       set: (operation, route) =>
         asPromise(() => {
           assertStoreString(operation, 'operation')
-          // The checked copy is what is kept, so editing the caller's object afterwards — or
-          // answering differently on a second read — cannot change what the store holds.
+          // The checked copy is what is kept, so editing the caller's object afterwards, or
+          // answering differently on a second read, cannot change what the store holds.
           rows.set(operation, validatedRoute(route))
         }),
       delete: (operation) =>

--- a/src/stores/memory/index.ts
+++ b/src/stores/memory/index.ts
@@ -1,7 +1,7 @@
 /**
  * The in-memory store pair: everything a switch needs to run without a database.
  *
- * State lives in the process, so it is for development, tests and single-process tools —
+ * State lives in the process, so it is for development, tests and single-process tools,
  * two processes do not share a quota, and nothing survives a restart.
  *
  * @module

--- a/src/stores/postgres/index.ts
+++ b/src/stores/postgres/index.ts
@@ -1,7 +1,7 @@
 /**
  * The PostgreSQL store pair: routes and quota counters in a schema you own.
  *
- * Bring your own pool — the package has no driver dependency and never opens a connection of
+ * Bring your own pool: the package has no driver dependency and never opens a connection of
  * its own. Nothing here runs DDL either: apply `migrationSql()` from `llmdispatch/postgres`
  * first, and this pair will find its tables where the migration put them.
  *

--- a/src/stores/postgres/migrations/index.ts
+++ b/src/stores/postgres/migrations/index.ts
@@ -2,8 +2,8 @@
  * The packaged migrations (spec §6b).
  *
  * llmdispatch never runs DDL: it hands you the SQL and its hash, and you apply it with whatever
- * tool you already use. The hash a version records is the hash of its template — the schema
- * placeholder still in place — so two adopters using different schema names still agree on
+ * tool you already use. The hash a version records is the hash of its template, with the schema
+ * placeholder still in place, so two adopters using different schema names still agree on
  * which version 1 they applied.
  *
  * @module

--- a/src/stores/postgres/sql.ts
+++ b/src/stores/postgres/sql.ts
@@ -1,7 +1,7 @@
 /**
  * Every statement the PostgreSQL stores send, built once per schema.
  *
- * Each one is a single command, so the pool runs it in a transaction of its own — which is
+ * Each one is a single command, so the pool runs it in a transaction of its own, which is
  * what makes a reserve atomic without the store ever pinning a connection (spec §4). Values
  * are always bound; the only thing spliced into the text is the validated schema identifier.
  *

--- a/src/stores/postgres/usage-store.ts
+++ b/src/stores/postgres/usage-store.ts
@@ -63,7 +63,7 @@ function isOutcome(value: string): value is (typeof OUTCOMES)[number] {
  * Builds a PostgreSQL usage store.
  *
  * @param options `pool` runs the statements, `schema` is quoted, `leaseMs` is the lease, and
- * `now` overrides the store's clock — `null` leaves the instant to the database.
+ * `now` overrides the store's clock; `null` leaves the instant to the database.
  */
 export function createPostgresUsageStore(options: {
   pool: QueryablePool

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
  *
  * Shapes only: the file imports nothing but Zod, so every other folder can depend on it
  * without inheriting anything, and a public shape is never declared twice. Ranges and
- * defaults stay in the comments the spec gives them — they are enforced at runtime, since a
+ * defaults stay in the comments the spec gives them, and they are enforced at runtime, since a
  * `number` cannot say "safe integer, 0 to 1 000 000".
  *
  * @module
@@ -11,7 +11,7 @@
 
 import type { z } from 'zod'
 
-// ——— entry point ———
+// --- entry point ---
 
 /** The operations a switch is built from; every entry MUST be wrapped in `defineOperation`. */
 export type OperationsMap = Record<string, OperationDefinition<z.ZodType, z.ZodType>>
@@ -69,7 +69,7 @@ export interface Logger {
   error(message: string, data?: unknown): void | Promise<void>
 }
 
-// ——— operations ———
+// --- operations ---
 
 /** One operation: its schemas, its prompt, and the optional gates around them. */
 export interface OperationDefinition<In extends z.ZodType, Out extends z.ZodType> {
@@ -89,7 +89,7 @@ export interface OperationDefinition<In extends z.ZodType, Out extends z.ZodType
 /** What a `quality` gate answers: accepted, or rejected with an optional reason. */
 export type QualityVerdict = { ok: true } | { ok: false; reason?: string }
 
-// ——— routing / views ———
+// --- routing / views ---
 
 /** One operation's stored route: who answers, with what, under which limit. */
 export interface OperationRoute {
@@ -123,7 +123,7 @@ export interface QuotaView {
   resetsAt: string
 }
 
-// ——— run results ———
+// --- run results ---
 
 /** What a successful `run` resolves with. */
 export interface RunResult<Out> {
@@ -171,7 +171,7 @@ export interface ModelPrice {
   outputPerM: number
 }
 
-// ——— providers ———
+// --- providers ---
 
 /** What a provider adapter implements: one call out, optionally with a readiness step. */
 export interface Provider {
@@ -189,8 +189,8 @@ export interface ProviderRequest {
   prompt: string
   model: string
   responseFormat: { type: 'text' } | { type: 'json'; topLevel: 'object' | 'any' }
-  maxOutputTokens?: number // omitted from the wire body when unset — never defaulted (§5c)
-  temperature?: number // omitted from the wire body when unset — never defaulted (§5c)
+  maxOutputTokens?: number // omitted from the wire body when unset, never defaulted (§5c)
+  temperature?: number // omitted from the wire body when unset, never defaulted (§5c)
   signal: AbortSignal
 }
 
@@ -219,7 +219,7 @@ export type ProviderErrorKind =
 /** How a built-in adapter reaches its API key, resolved lazily on every run. */
 export type ApiKeyResolver = () => string | undefined | Promise<string | undefined>
 
-// ——— stores ———
+// --- stores ---
 
 /** Where routes live. Rows come back verbatim; validating them is the core's job. */
 export interface ConfigStore {
@@ -259,7 +259,7 @@ export interface UsageStore {
   snapshot(key: QuotaKey): Promise<{ used: number; resetsAt: string }>
 }
 
-// ——— packaged operational surfaces (spec §6b) ———
+// --- packaged operational surfaces (spec §6b) ---
 //
 // The shapes `llmdispatch/postgres` and `llmdispatch/conformance` publish are declared below this
 // line and re-exported by those entry points alone, so the root surface stays exactly §6.

--- a/test/consumers/esm/index.mjs
+++ b/test/consumers/esm/index.mjs
@@ -101,7 +101,7 @@ console.log('esm consumer round-tripped a reservation through the in-memory stor
 
 // The core pipeline end to end, from the installed package: an in-fixture provider, a
 // declared operation, and a run that parses, validates and counts against a quota. The
-// other build's createSwitch is checked too — both module systems reach the same factory.
+// other build's createSwitch is checked too, both module systems reach the same factory.
 const { z } = await import('zod')
 check(
   'the CommonJS build does not export createSwitch',

--- a/test/consumers/ts/a.mts
+++ b/test/consumers/ts/a.mts
@@ -17,7 +17,7 @@ export const reached = [root, postgres, conformance].length
 
 // The codes are a closed set, and this is what says so from outside the package: every one
 // of them is handled, and the `never` in the default arm refuses anything that is not on
-// the list. A code added to — or removed from — the union stops this file compiling.
+// the list. A code added to, or removed from: the union stops this file compiling.
 export function httpStatus(error: LLMDispatchError): number {
   switch (error.code) {
     case 'INVALID_INPUT':
@@ -43,8 +43,8 @@ export function httpStatus(error: LLMDispatchError): number {
   }
 }
 
-// `resetsAt` is optional on the class as a whole rather than tied to a code — the error is
-// not a discriminated union — so it is still `string | undefined` after this narrowing, and
+// `resetsAt` is optional on the class as a whole rather than tied to a code: the error is
+// not a discriminated union, so it is still `string | undefined` after this narrowing, and
 // the caller has to say what to do when it is absent.
 export function retryAfter(error: unknown): string | null {
   if (error instanceof LLMDispatchError && error.code === 'QUOTA_EXCEEDED') {

--- a/test/consumers/ts/b.cts
+++ b/test/consumers/ts/b.cts
@@ -33,8 +33,8 @@ export function httpStatus(error: root.LLMDispatchError): number {
   }
 }
 
-// `resetsAt` is optional on the class as a whole rather than tied to a code — the error is
-// not a discriminated union — so it is still `string | undefined` after this narrowing.
+// `resetsAt` is optional on the class as a whole rather than tied to a code: the error is
+// not a discriminated union, so it is still `string | undefined` after this narrowing.
 export function retryAfter(error: unknown): string | null {
   if (error instanceof root.LLMDispatchError && error.code === 'QUOTA_EXCEEDED') {
     return error.resetsAt ?? null

--- a/test/fixtures/scan/near-misses.md
+++ b/test/fixtures/scan/near-misses.md
@@ -2,7 +2,7 @@
 
 These sit in the repository on purpose: they are scanned like every other tracked file, so
 if a rule ever became too eager, an ordinary run would say so. Deliberately matching
-inputs are never committed — the scanner's self-test builds those in a temporary directory
+inputs are never committed: the scanner's self-test builds those in a temporary directory
 and deletes them.
 
 An address in the documentation domain: reader@example.com

--- a/test/integration/postgres/conformance.test.ts
+++ b/test/integration/postgres/conformance.test.ts
@@ -65,8 +65,8 @@ describeDatabase('the store conformance suites on PostgreSQL', () => {
 
   it('passes both suites through the public factory and a pool that supplies the clock', async () => {
     // The public factory has no clock option, so a harness drives its clock from the pool it
-    // supplies: it knows the store's convention — a usage statement starts with the marker and
-    // ends with the clock parameter — and substitutes that last parameter. The wrapper is
+    // supplies: it knows the store's convention: a usage statement starts with the marker and
+    // ends with the clock parameter, and substitutes that last parameter. The wrapper is
     // strict on purpose: if the convention ever drifted, this fails rather than quietly
     // testing the database's own clock.
     let pinned: Date | null = null

--- a/test/integration/postgres/setup.ts
+++ b/test/integration/postgres/setup.ts
@@ -1,8 +1,8 @@
 /**
  * What every PostgreSQL suite needs: a pool, a schema of its own, and the migration applied.
  *
- * Each file works in a schema named after itself plus a random suffix, so two files — or two
- * runs — never share a table. `DATABASE_URL` is what decides whether these suites run at all:
+ * Each file works in a schema named after itself plus a random suffix, so two files, or two
+ * runs, never share a table. `DATABASE_URL` is what decides whether these suites run at all:
  * absent locally they are skipped with the reason in the suite's name, and absent in CI they
  * fail, because a workflow that lost its database must not report a green skipped suite.
  */

--- a/test/types/positive/results.ts
+++ b/test/types/positive/results.ts
@@ -1,7 +1,7 @@
 // @targets spec, package
 // What a caller can do with the shapes a run hands back: read a typed result, walk the
 // attempt records, read a quota view, and switch over a provider response without a
-// default arm. The last one is the check that matters — an added `ProviderResponse` member
+// default arm. The last one is the check that matters: an added `ProviderResponse` member
 // has to break this file rather than fall through it silently.
 import type { AttemptRecord, ProviderResponse, QuotaView, RunResult } from 'llmdispatch'
 

--- a/test/types/positive/spec-identity.ts
+++ b/test/types/positive/spec-identity.ts
@@ -18,7 +18,7 @@ import type * as SpecPostgres from '../spec-surface-postgres'
 import type * as Spec from '../spec-surface'
 
 // Two types are identical when the compiler resolves these two conditional types to the same
-// one, which it does only for types it considers the same declaration — not merely assignable.
+// one, which it does only for types it considers the same declaration, not merely assignable.
 type Identical<Left, Right> =
   (<T>(value: T) => T extends Left ? 1 : 2) extends <T>(value: T) => T extends Right ? 1 : 2
     ? true

--- a/test/types/spec-surface-conformance.d.ts
+++ b/test/types/spec-surface-conformance.d.ts
@@ -33,7 +33,7 @@ export declare function runProviderConformance(opts: {
   // 'success' is MANDATORY; each other scenario puts the adopter's backend into the named
   // condition and resolves when ready; the harness dispatches and asserts the resulting
   // ProviderResponse.kind or ProviderError classification. Absent optional scenarios are
-  // reported in `skipped` — a skipped scenario means that classification is UNVERIFIED.
+  // reported in `skipped`: a skipped scenario means that classification is UNVERIFIED.
   scenarios: { success: () => Promise<void> } & Partial<Record<
     'auth' | 'rate_limit' | 'model_not_found' | 'invalid_request' | 'transient'
     | 'malformed_response' | 'truncated' | 'refused', () => Promise<void>>>

--- a/test/types/spec-surface.d.ts
+++ b/test/types/spec-surface.d.ts
@@ -3,13 +3,13 @@
 
 import { z } from 'zod'
 
-// ——— entry point ———
+// --- entry point ---
 export declare function createSwitch<Ops extends OperationsMap>(
   config: CreateSwitchConfig<Ops>
 ): Switch<Ops>
 
 // Inference builders. defineOperation correlates each operation's schemas with its
-// callbacks; **every entry in defineOperations MUST be wrapped in defineOperation** —
+// callbacks; **every entry in defineOperations MUST be wrapped in defineOperation**;
 // defineOperations is an identity collector and does not itself restore inference.
 // The README quickstart uses exactly this shape; negative compile fixtures assert that
 // invalid `prompt` input and `quality.data` accesses FAIL to compile in that shape.
@@ -54,7 +54,7 @@ export interface Logger {                                // invoked through caug
   error(message: string, data?: unknown): void | Promise<void>
 }
 
-// ——— operations ———
+// --- operations ---
 export interface OperationDefinition<In extends z.ZodType, Out extends z.ZodType> {
   input: In
   output: Out
@@ -67,7 +67,7 @@ export interface OperationDefinition<In extends z.ZodType, Out extends z.ZodType
 }
 export type QualityVerdict = { ok: true } | { ok: false; reason?: string }
 
-// ——— routing / views ———
+// --- routing / views ---
 export interface OperationRoute {
   provider: string                                       // non-empty registered provider ID
   model: string                                          // non-empty
@@ -85,7 +85,7 @@ export interface OperationConfigView {
 }
 export interface QuotaView { limit: number; used: number; remaining: number; resetsAt: string } // limit = the effective limit (route override, else declared); remaining = max(0, limit - used); getQuota requires non-empty subjectId
 
-// ——— run results ———
+// --- run results ---
 export interface RunResult<Out> {
   data: Out
   route: { provider: string; model: string }
@@ -112,7 +112,7 @@ export interface AttemptRecord {
 export interface TokenUsage { inputTokens: number; outputTokens: number }  // non-negative SAFE integers
 export interface ModelPrice { inputPerM: number; outputPerM: number }      // finite, ≥ 0
 
-// ——— providers ———
+// --- providers ---
 export interface Provider {
   prepare?(): PreparedProvider | Promise<PreparedProvider>  // §5a; memoized per run per provider ID
   complete(req: ProviderRequest): Promise<ProviderResponse> // used directly when prepare absent
@@ -157,7 +157,7 @@ export declare function openaiCompatible(opts: {
 export declare function gemini(opts: { apiKey: ApiKeyResolver }): Provider
 export type ApiKeyResolver = () => string | undefined | Promise<string | undefined>
 
-// ——— stores ———
+// --- stores ---
 export interface ConfigStore {
   getAll(): Promise<Record<string, unknown>>
   set(operation: string, route: OperationRoute): Promise<void>
@@ -181,7 +181,7 @@ export declare function postgresStores(opts: {
   leaseMs?: number                                       // default 120_000; 5_000–600_000
 }): StorePair
 
-// ——— errors ———
+// --- errors ---
 export declare class LLMDispatchError extends Error {
   private constructor()                                  // instances come from the package; narrow on `code`
   readonly code: 'INVALID_INPUT' | 'MISSING_SUBJECT' | 'QUOTA_EXCEEDED'
@@ -194,6 +194,6 @@ export declare class LLMDispatchError extends Error {
   readonly attempts?: AttemptRecord[]
   // Sanitized, scoped to the package's own fields: they never carry prompts, model
   // output, or raw provider errors from a dispatched attempt. A pre-dispatch error may
-  // chain the underlying store or `prepare()` failure as `cause`, verbatim — the
+  // chain the underlying store or `prepare()` failure as `cause`, verbatim: the
   // adopter's own thrown error, or a provider adapter's readiness failure.
 }

--- a/test/unit/composition/concurrency.test.ts
+++ b/test/unit/composition/concurrency.test.ts
@@ -1,7 +1,7 @@
 /**
  * Prepared-dispatcher concurrency under load (spec §5a): N overlapping runs over one
  * shared provider registered as both primary and fallback, each run resolving its own
- * credential — proof that nothing prepared leaks across runs — plus store reconciliation
+ * credential: proof that nothing prepared leaks across runs, plus store reconciliation
  * at quiescence, admin writes interleaved with in-flight runs, and a seeded stochastic
  * smoke over shuffled settlement orders. The scripted interleavings are the gate; the
  * seeded shuffle is evidence.
@@ -66,7 +66,7 @@ describe('the alternating-credentials race', () => {
         return currentKey
       },
     })
-    // Pinned clock: no UTC-midnight straddle, and time moves only when the test says so —
+    // Pinned clock: no UTC-midnight straddle, and time moves only when the test says so,
     // the zero-pending proof at the end depends on that.
     let nowMs = Date.parse('2026-08-26T12:00:00.000Z')
     const internal = createMemoryStores({ now: () => new Date(nowMs), leaseMs: 60_000 })
@@ -114,7 +114,7 @@ describe('the alternating-credentials race', () => {
     // the fallback wave would have moved this counter after the first assertion above.
     expect(resolverCalls).toBe(N)
 
-    // The named oracle: every dispatched request — primary and fallback alike — carries
+    // The named oracle: every dispatched request: primary and fallback alike: carries
     // exactly the key its run resolved.
     for (const call of wire.calls) {
       expect(call.headers.authorization).toBe(`Bearer key-${String(runIndexOf(call))}`)
@@ -137,7 +137,7 @@ describe('the alternating-credentials race', () => {
     })
 
     // Quiescence reconciliation. What each line pins: N grants observed, N commit acks
-    // observed (committed == runs that dispatched — the fallback shares its run's slot,
+    // observed (committed == runs that dispatched: the fallback shares its run's slot,
     // so attempts != slots), every granted slot settled with its run's attempt count,
     // and the public snapshot agreeing with the committed count.
     expect(recorded.envelopes).toHaveLength(N)
@@ -168,7 +168,7 @@ describe('the alternating-credentials race', () => {
 })
 
 describe('admin writes interleaved with in-flight runs', () => {
-  // What this proves is invalidation-on-write while earlier runs are still in flight —
+  // What this proves is invalidation-on-write while earlier runs are still in flight,
   // every run resolves exactly the write before it, never a stale cache entry. The
   // generation guard against a *read* racing a write is owned by the config suite
   // (test/unit/core/config.test.ts), whose scripted store can hold a read open.

--- a/test/unit/composition/helpers.ts
+++ b/test/unit/composition/helpers.ts
@@ -28,7 +28,7 @@ export interface Wire {
  * Stubs global `fetch` so every call parks in `calls` until the test resolves it.
  *
  * An already-aborted signal rejects immediately, as the real fetch does. A signal firing
- * *after* dispatch is deliberately ignored — no composition test aborts a parked call, and
+ * *after* dispatch is deliberately ignored, no composition test aborts a parked call, and
  * a future one would need an abort listener here first. Restore with
  * `vi.unstubAllGlobals()` in `afterEach`.
  */

--- a/test/unit/composition/matrix.test.ts
+++ b/test/unit/composition/matrix.test.ts
@@ -2,7 +2,7 @@
  * The §5b classification table composed end to end (spec 271–308): every attempt-outcome
  * row driven through `run` over its applicable fallback compositions, the flag axis on
  * exactly its two rows, per-outcome-shape assertions including the quota-effect call log,
- * and two-part completeness enforcement — an exhaustive `switch` over the
+ * and two-part completeness enforcement: an exhaustive `switch` over the
  * `ProviderErrorKind` and `AttemptOutcome` unions builds the case list (a union member
  * added later fails to compile), and the case count is pinned to a review-time inventory
  * literal a reader diffs against the spec table.
@@ -33,11 +33,11 @@ const QUOTA = { perDay: 5 }
 const TIMEOUT_MS = 1_000
 const TABLE = { quota: QUOTA, timeoutMs: TIMEOUT_MS }
 
-// ——— completeness enforcement ———
+// --- completeness enforcement ---
 
 /**
  * Review-time inventory: the §5b row counts a reader diffs against the spec table. An aid
- * for the human pass — the compile-time checks below are what fail when a union moves.
+ * for the human pass: the compile-time checks below are what fail when a union moves.
  */
 const INVENTORY = { attemptOutcomes: 15, providerErrorKinds: 7 }
 
@@ -115,7 +115,7 @@ function classify(outcome: AttemptOutcome): RowClass {
   }
 }
 
-// ——— the dispatched-failure rows ———
+// --- the dispatched-failure rows ---
 
 interface FailureRow {
   outcome: AttemptOutcome
@@ -245,7 +245,7 @@ const FAILURE_ROWS: FailureRow[] = [
   },
 ]
 
-// ——— instruments ———
+// --- instruments ---
 
 /** The quota-effect call log, reduced to its shape: reserve / commit / settle <outcome>. */
 function quotaLog(f: Fixture): string[] {
@@ -270,11 +270,11 @@ function asSwitchError(error: unknown, code: LLMDispatchError['code']): LLMDispa
   return typed
 }
 
-// ——— the matrix ———
+// --- the matrix ---
 
 describe('completeness: the switch-built case list against the review-time inventory', () => {
   it('enumerates both unions in full and routes every row to exactly one block', () => {
-    // These two cannot fail at runtime — their type annotations are the actual gate, and
+    // These two cannot fail at runtime: their type annotations are the actual gate, and
     // a union change fails `tsc`, not vitest. Kept as documentation of that mechanism.
     expect(outcomesExhaustive).toBe(true)
     expect(kindsExhaustive).toBe(true)
@@ -444,7 +444,7 @@ describe('the aborted row: caller-signal timing at the composition level', () =>
 
   it("an adapter-reported 'aborted' with no caller signal re-classifies timeout, still fallback-eligible", async () => {
     // The row's other half (spec §5b): the adapter saw the core's own timeout, not the
-    // caller's abort, so the timeout row's columns govern — including its eligibility.
+    // caller's abort, so the timeout row's columns govern, including its eligibility.
     const f = fixture(TABLE)
     f.p1.nextReject(new ProviderError('aborted'))
     const result = await f.ai.run('echo', ARGS)

--- a/test/unit/composition/vertical-slice.test.ts
+++ b/test/unit/composition/vertical-slice.test.ts
@@ -1,6 +1,6 @@
 /**
- * The vertical slice: one operation end to end through the public surface — `createSwitch`,
- * the `openaiCompatible` factory over a scripted wire, `memoryStores` — with the fallback
+ * The vertical slice: one operation end to end through the public surface: `createSwitch`,
+ * the `openaiCompatible` factory over a scripted wire, `memoryStores`, with the fallback
  * exercised, the output parsed by the operation's schema, and the daily quota enforced.
  * One green spec demonstrating the assembled whole is fit.
  */
@@ -67,7 +67,7 @@ describe('vertical slice: one operation through the assembled package', () => {
     expect(second.usedFallback).toBe(false)
     expect(second.route).toEqual({ provider: 'openai', model: 'gpt-primary' })
 
-    // Run 3: both daily slots are spent — denied before any dispatch. The fallback shared
+    // Run 3: both daily slots are spent; denied before any dispatch. The fallback shared
     // its run's slot, so two runs consumed two slots, not three attempts' worth.
     expect(dispatched).toBe(3)
     const denied = await expectCode(

--- a/test/unit/conformance/provider-runner.test.ts
+++ b/test/unit/conformance/provider-runner.test.ts
@@ -46,7 +46,7 @@ function okResponse(): ProviderResponse {
 /**
  * A `Provider` whose one behaviour is swapped out per scenario, like `okResponse` above.
  *
- * Honors an already-aborted signal on its own, the way a conforming adapter must — so every
+ * Honors an already-aborted signal on its own, the way a conforming adapter must, so every
  * test here exercises exactly the dimension it names, not the mandatory signal-honour check
  * too. `nonAbortingProvider` below is the one deliberate exception.
  */
@@ -155,7 +155,7 @@ describe('runner behavior', () => {
       controls: { observeRequest: (req) => seen.push(req) },
     })
     expect(result.passed).toBe(true)
-    // Mandatory success plus the already-aborted signal check — both go through dispatch.
+    // Mandatory success plus the already-aborted signal check, both go through dispatch.
     expect(seen.length).toBe(2)
     expect(seen.every((req) => req.model === 'observed')).toBe(true)
     expect(seen[1]!.signal.aborted).toBe(true)
@@ -165,7 +165,7 @@ describe('runner behavior', () => {
 describe('nonconforming fakes', () => {
   it('fails when the success scenario answers with the wrong ProviderResponse shape', async () => {
     const { provider, set } = scriptedProvider()
-    // Every dispatch resolves 'truncated' — never the 'complete' the success case requires.
+    // Every dispatch resolves 'truncated', never the 'complete' the success case requires.
     set(() => ({ kind: 'truncated', text: 'partial', usage: null }))
     const result = await runProviderConformance({
       provider,

--- a/test/unit/core/abort.test.ts
+++ b/test/unit/core/abort.test.ts
@@ -142,7 +142,7 @@ describe('abort at stage boundaries', () => {
     expect(s.log).toEqual(['getAll', 'reserve u 5'])
   })
 
-  it('awaits an in-flight commit, then ends ABORTED undispatched — and still settles', async () => {
+  it('awaits an in-flight commit, then ends ABORTED undispatched, and still settles', async () => {
     const f = fixture({ quota: { perDay: 5 } })
     const controller = new AbortController()
     const gate = f.s.commit.nextHang()
@@ -237,7 +237,7 @@ describe('abort precedence at the finalization boundary over user-error paths', 
         output: {
           parseAsync: () => {
             // The signal fires with the user bug already decided: the boundary check must
-            // report the abort, not hand back the raw error (§1 — only an abort after a
+            // report the abort, not hand back the raw error (§1, only an abort after a
             // SUCCESSFUL attempt is outcome-immune).
             controller.abort()
             throw bug
@@ -277,7 +277,7 @@ describe('abort precedence at the finalization boundary over user-error paths', 
   })
 })
 
-describe('suppression companions — what must NOT be suppressed', () => {
+describe('suppression companions: what must NOT be suppressed', () => {
   it('propagates a seam rejection raw when no abort happened', async () => {
     const bug = new Error('prompt exploded')
     const operations = {
@@ -302,7 +302,7 @@ describe('suppression companions — what must NOT be suppressed', () => {
     expect(error.retryable).toBe(true)
   })
 
-  it('never suppresses a settlement rejection — it drives the retry tail', async () => {
+  it('never suppresses a settlement rejection: it drives the retry tail', async () => {
     const { ai, s, runtime } = fixture({ quota: { perDay: 5 } })
     s.settle.nextReject(new Error('settle down'))
     await ai.run('echo', { ...INPUT, subjectId: 'u' })
@@ -355,7 +355,7 @@ describe('adapter-reported aborts and the composed signal', () => {
     expect(error.code).toBe('ABORTED')
     expect(error.attempts?.map((a) => a.outcome)).toEqual(['aborted'])
     expect(f.runtime.pending('referenced')).toBe(0) // the timeout timer was cancelled
-    void hang // never settled — deliberately
+    void hang // never settled, deliberately
   })
 
   it('aborts the provider-observed signal on timeoutMs alone, with the caller quiescent', async () => {

--- a/test/unit/core/classification.test.ts
+++ b/test/unit/core/classification.test.ts
@@ -1,7 +1,7 @@
 /**
  * Classification and whose-bug (spec §5b): every row at the classification level with
  * the kind↔outcome agreement invariant, fallback eligibility per row, the read-once TOCTOU
- * defence for `kind` and `status`, and the crossed-origin fixtures — origin decides, never
+ * defence for `kind` and `status`, and the crossed-origin fixtures: origin decides, never
  * the thrown class.
  */
 
@@ -297,7 +297,7 @@ describe('read-once TOCTOU defence', () => {
   })
 })
 
-describe('crossed origins — the origin decides, never the thrown class', () => {
+describe('crossed origins: the origin decides, never the thrown class', () => {
   it('propagates a branded ProviderError from the stage-2 input transform, unwrapped', async () => {
     const branded = new ProviderError('rate_limit', { status: 429 })
     const operations = {
@@ -370,7 +370,7 @@ describe('crossed origins — the origin decides, never the thrown class', () =>
     expect(error.attempts?.map((a) => a.outcome)).toEqual(['provider_unclassified'])
   })
 
-  it('wraps a ZodError thrown by complete() the same way — origin, not class', async () => {
+  it('wraps a ZodError thrown by complete() the same way: origin, not class', async () => {
     let zodError: unknown
     try {
       z.string().parse(42)

--- a/test/unit/core/config.test.ts
+++ b/test/unit/core/config.test.ts
@@ -116,7 +116,7 @@ describe('the §2 resolution matrix and the cache', () => {
       rows = 0
     }
     // A Map or a class instance has no enumerable own rows: reading it as empty would
-    // activate defaults during an outage-shaped answer — the exact §2 hazard.
+    // activate defaults during an outage-shaped answer: the exact §2 hazard.
     for (const container of [null, [], 42, 'rows', new Map(), new Date(0), new RowsLike()]) {
       const { ai } = fixture()
       const f = fixture()
@@ -146,7 +146,7 @@ describe('the §2 resolution matrix and the cache', () => {
     gate.resolve({})
     await flushMicrotasks()
     expect(run.state).toBe('resolved')
-    await runtime.advance(4000) // now 4 s after completion — stale only if stamped at start
+    await runtime.advance(4000) // now 4 s after completion: stale only if stamped at start
     await ai.run('echo', INPUT)
     expect(getAllCount(s)).toBe(1)
     await runtime.advance(1500) // 5.5 s after completion: genuinely stale
@@ -240,7 +240,7 @@ describe('generation coherence', () => {
     f.s.getAll.always(() => ({ echo: { provider: 'p1', model: 'm-new' } }))
     await f.ai.run('echo', INPUT)
     const reads = getAllCount(f.s)
-    gate.resolve({}) // the old read finds no row — it must not install the default
+    gate.resolve({}) // the old read finds no row: it must not install the default
     await flushMicrotasks()
     expect(oldRun.state).toBe('resolved')
     await f.ai.run('echo', INPUT)

--- a/test/unit/core/helpers.ts
+++ b/test/unit/core/helpers.ts
@@ -27,7 +27,7 @@ import type {
   UsageStore,
 } from '../../../src/types'
 
-// ——— promises ———
+// --- promises ---
 
 export interface Deferred<T> {
   promise: Promise<T>
@@ -47,13 +47,13 @@ export function deferred<T>(): Deferred<T> {
 
 /**
  * Drains the microtask queue completely: one real macrotask turn, before which the event
- * loop runs every queued microtask — however deep the promise chain — to exhaustion.
+ * loop runs every queued microtask: however deep the promise chain, to exhaustion.
  */
 export async function flushMicrotasks(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0))
 }
 
-/** One real macrotask turn — what Node needs before reporting an unhandled rejection. */
+/** One real macrotask turn: what Node needs before reporting an unhandled rejection. */
 export function macrotask(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
@@ -84,7 +84,7 @@ export function observe<T>(promise: Promise<T>): Observed<T> {
   return observed
 }
 
-// ——— unhandled rejections ———
+// --- unhandled rejections ---
 
 /** Collects unhandled rejections while installed; `stop()` removes the listener. */
 export function watchUnhandled(): { seen: unknown[]; stop: () => void } {
@@ -101,7 +101,7 @@ export function watchUnhandled(): { seen: unknown[]; stop: () => void } {
   }
 }
 
-// ——— fake runtime ———
+// --- fake runtime ---
 
 interface FakeTimer {
   id: number
@@ -162,7 +162,7 @@ export function fakeRuntime(start = 1_000_000): FakeRuntime {
   return runtime
 }
 
-// ——— scripted methods ———
+// --- scripted methods ---
 
 type Handler<A extends unknown[], T> = (...args: A) => T | Promise<T>
 
@@ -213,7 +213,7 @@ export function scripted<A extends unknown[], T>(
   return fn
 }
 
-// ——— scripted stores ———
+// --- scripted stores ---
 
 export const FIXED_DAY = '2026-08-26'
 export const RESETS_AT = '2026-08-27T00:00:00.000Z'
@@ -305,7 +305,7 @@ export function scriptedStores(): ScriptedStores {
   return { stores, log, getAll, set, del, reserve, commit, settle, snapshot }
 }
 
-// ——— scripted providers ———
+// --- scripted providers ---
 
 export interface ScriptedProvider {
   provider: Provider
@@ -368,7 +368,7 @@ export function scriptedProvider(): ScriptedProvider {
   }
 }
 
-// ——— the standard fixture ———
+// --- the standard fixture ---
 
 export const ECHO_INPUT = z.object({ text: z.string() })
 export const ECHO_OUTPUT = z.object({ answer: z.string() })

--- a/test/unit/core/output-pipeline.test.ts
+++ b/test/unit/core/output-pipeline.test.ts
@@ -34,7 +34,7 @@ describe('parsing and the format matrix', () => {
     expect(result.data).toEqual({ answer: 'fenced' })
   })
 
-  it('leaves an interior fence alone — only a whole-response fence is wrapping', async () => {
+  it('leaves an interior fence alone, only a whole-response fence is wrapping', async () => {
     const operations = {
       echo: {
         input: ECHO_INPUT,
@@ -155,7 +155,7 @@ describe('termination before content', () => {
   }
 
   // §6: `text: string` belongs to every variant of the union, so a terminated response whose
-  // body fails the shape is malformed_response — retryable and fallback-eligible.
+  // body fails the shape is malformed_response: retryable and fallback-eligible.
   const badBodies: { name: string; make: (kind: string) => unknown }[] = [
     { name: 'no text at all', make: (kind) => ({ kind, usage: null }) },
     { name: 'a non-string text', make: (kind) => ({ kind, text: 42, usage: null }) },

--- a/test/unit/core/quota.test.ts
+++ b/test/unit/core/quota.test.ts
@@ -343,7 +343,7 @@ describe('settlement detachment and retries', () => {
     const run = observe(f.ai.run('echo', ARGS))
     await flushMicrotasks()
     // Ordering oracle: the run is settled and settle was called exactly once, and only the
-    // detached 1 s retry timer is pending — in unreferenced mode, on the runtime seam.
+    // detached 1 s retry timer is pending, in unreferenced mode, on the runtime seam.
     expect(run.state).toBe('resolved')
     expect(f.s.settle.calls.length).toBe(1)
     expect(f.runtime.pendingDelays('unreferenced')).toEqual([1000])
@@ -376,7 +376,7 @@ describe('settlement detachment and retries', () => {
     f.s.settle.nextReject(new Error('settle 1')) // only the initial attempt fails
     await f.ai.run('echo', ARGS)
     await f.runtime.advance(1000)
-    expect(f.s.settle.calls.length).toBe(2) // the 1 s retry ran — and succeeded
+    expect(f.s.settle.calls.length).toBe(2) // the 1 s retry ran, and succeeded
     await f.runtime.advance(5000)
     await f.runtime.advance(25_000)
     expect(f.s.settle.calls.length).toBe(2) // a chain that keeps going fails here
@@ -400,7 +400,7 @@ describe('settlement detachment and retries', () => {
     void gate
   })
 
-  it('invokes the hook exactly once, after all four attempts failed, with the exact record — and logs once', async () => {
+  it('invokes the hook exactly once, after all four attempts failed, with the exact record, and logs once', async () => {
     const hookCalls: { error: unknown; record: SettlementFailure }[] = []
     const loggerCalls: { message: string; data: unknown }[] = []
     const finalError = new Error('settle 4')
@@ -603,7 +603,7 @@ describe('changing a limit while runs are in flight (§4 rules 1–5)', () => {
     expect(f.s.reserve.calls.map((call) => call[1])).toEqual([5, 5])
   })
 
-  it('rule 4 (in flight): removing the ONLY quota mid-run — the pending envelope finishes, new runs are quota-less', async () => {
+  it('rule 4 (in flight): removing the ONLY quota mid-run: the pending envelope finishes, new runs are quota-less', async () => {
     // The definition declares no quota: the only quota is the stored route's, so removing
     // it removes quota governance entirely (§4 rule 4).
     const f = fixture() // no declared quota
@@ -651,7 +651,7 @@ describe('changing a limit while runs are in flight (§4 rules 1–5)', () => {
     )
     await ai.run('echo', ARGS)
     await ai.run('echo', ARGS) // two committed slots
-    // Rule 2: lowered to at or below used — here to 0 — denies new reservations …
+    // Rule 2: lowered to at or below used: here to 0: denies new reservations …
     await ai.setConfig('echo', { provider: 'p1', model: 'm1', quota: { perDay: 0 } })
     const denied = await expectCode(ai.run('echo', ARGS), 'QUOTA_EXCEEDED')
     expect(denied.resetsAt).toBeDefined()

--- a/test/unit/core/run-stages.test.ts
+++ b/test/unit/core/run-stages.test.ts
@@ -26,7 +26,7 @@ import type { CreateSwitchConfig, OperationsMap } from '../../../src/types'
 
 const INPUT = { input: { text: 'hi' } }
 
-describe('stage 0 — pre-aborted signal', () => {
+describe('stage 0: pre-aborted signal', () => {
   it('ends ABORTED before anything else, with no store call and no attempts', async () => {
     const { ai, s } = fixture()
     const controller = new AbortController()
@@ -41,7 +41,7 @@ describe('stage 0 — pre-aborted signal', () => {
   })
 })
 
-describe('stage 1 — operation lookup', () => {
+describe('stage 1: operation lookup', () => {
   it('rejects an unknown operation with INVALID_INPUT and touches nothing', async () => {
     const { ai, s } = fixture()
     const error = await expectCode(ai.run('nope', INPUT), 'INVALID_INPUT')
@@ -51,7 +51,7 @@ describe('stage 1 — operation lookup', () => {
   })
 })
 
-describe('stage 2 — input parse', () => {
+describe('stage 2: input parse', () => {
   it('maps a ZodError to INVALID_INPUT with no store call', async () => {
     const { ai, s } = fixture()
     const error = await expectCode(ai.run('echo', { input: { text: 42 } }), 'INVALID_INPUT')
@@ -77,7 +77,7 @@ describe('stage 2 — input parse', () => {
   })
 })
 
-describe('stage 3 — declared-quota subject check', () => {
+describe('stage 3: declared-quota subject check', () => {
   it('requires a subject before any I/O when the definition declares a quota', async () => {
     const { ai, s } = fixture({ quota: { perDay: 5 } })
     const error = await expectCode(ai.run('echo', INPUT), 'MISSING_SUBJECT')
@@ -92,7 +92,7 @@ describe('stage 3 — declared-quota subject check', () => {
   })
 })
 
-describe('stage 4 — config resolution', () => {
+describe('stage 4: config resolution', () => {
   it('maps a store outage to CONFIG_STORE_UNAVAILABLE, retryable, quota untouched', async () => {
     const { ai, s } = fixture()
     s.getAll.nextReject(new Error('down'))
@@ -134,7 +134,7 @@ describe('stage 4 — config resolution', () => {
   })
 })
 
-describe('stage 5 — readiness', () => {
+describe('stage 5: readiness', () => {
   function preparingProvider(): {
     provider: Provider
     prepareCalls: number[]
@@ -349,7 +349,7 @@ describe('stage 5 — readiness', () => {
   })
 })
 
-describe('stage 6 — prompt build', () => {
+describe('stage 6: prompt build', () => {
   it('passes a thrown prompt exception through unwrapped, quota untouched', async () => {
     const bug = new Error('prompt bug')
     const operations = {
@@ -391,7 +391,7 @@ describe('stage 6 — prompt build', () => {
   })
 })
 
-describe('stages 7 and 8 — quota reserve and commit', () => {
+describe('stages 7 and 8: quota reserve and commit', () => {
   it('ends QUOTA_EXCEEDED on a denial, carrying the store resetsAt, no commit', async () => {
     const { ai, s } = fixture({ quota: { perDay: 5 } })
     s.reserve.nextResolve({ ok: false, used: 5, resetsAt: '2026-08-27T00:00:00.000Z' })
@@ -405,7 +405,7 @@ describe('stages 7 and 8 — quota reserve and commit', () => {
     expect(s.log).toEqual(['getAll', 'reserve u 5'])
   })
 
-  it('still calls reserve at limit 0 — denial must be store-authoritative', async () => {
+  it('still calls reserve at limit 0: denial must be store-authoritative', async () => {
     const { ai, s } = fixture({ quota: { perDay: 0 } })
     s.reserve.nextResolve({ ok: false, used: 3, resetsAt: '2026-08-27T00:00:00.000Z' })
     await expectCode(ai.run('echo', { ...INPUT, subjectId: 'u' }), 'QUOTA_EXCEEDED')
@@ -461,7 +461,7 @@ describe('stages 7 and 8 — quota reserve and commit', () => {
   })
 })
 
-describe('stages 9–11 — attempts, fallback and finalization', () => {
+describe('stages 9–11: attempts, fallback and finalization', () => {
   it('returns the primary result with route, usedFallback false and one attempt', async () => {
     const { ai, s, p1, p2 } = fixture({ quota: { perDay: 5 } })
     const result = await ai.run('echo', { ...INPUT, subjectId: 'u' })

--- a/test/unit/core/sanitization.test.ts
+++ b/test/unit/core/sanitization.test.ts
@@ -1,8 +1,8 @@
 /**
  * Sanitization: sentinel strings seeded into prompt text, input,
  * provider error messages and model output must never appear in any core-constructed field
- * of any `LLMDispatchError` — message, own enumerable properties, attempts, or the cause
- * chain — while an adopter's own thrown value passes into `cause` verbatim, which is the
+ * of any `LLMDispatchError`: message, own enumerable properties, attempts, or the cause
+ * chain, while an adopter's own thrown value passes into `cause` verbatim, which is the
  * documented scope boundary, not a leak. Logger payloads are swept too.
  */
 
@@ -44,7 +44,7 @@ function reachableStrings(value: unknown, seen = new Set<object>()): string[] {
   return found
 }
 
-/** The same walk, excluding everything below `cause` — the core-constructed fields only. */
+/** The same walk, excluding everything below `cause`: the core-constructed fields only. */
 function coreConstructedStrings(error: LLMDispatchError): string[] {
   const found: string[] = [error.message]
   for (const [key, entry] of Object.entries(error)) {
@@ -192,7 +192,7 @@ describe('the sentinel sweep over the whole error matrix', () => {
       const error = caught as LLMDispatchError
       // Core-constructed fields: no dispatch content, ever.
       expectNoSentinels(coreConstructedStrings(error), DISPATCH_SENTINELS)
-      // The full chain, cause included: still no dispatch content with core-safe doubles —
+      // The full chain, cause included: still no dispatch content with core-safe doubles,
       // the provider sentinel is permitted only inside a PRE-dispatch cause chain.
       expectNoSentinels(reachableStrings(error), DISPATCH_SENTINELS)
       if (postDispatch) {
@@ -243,7 +243,7 @@ describe('the sentinel sweep over the whole error matrix', () => {
     const error = caught as LLMDispatchError
     expect(error.code).toBe('INVALID_CONFIG')
     expect(error.retryable).toBe(true)
-    expect(error.cause).toBe(prepareFailure) // verbatim — prepare ran before the prompt
+    expect(error.cause).toBe(prepareFailure) // verbatim: prepare ran before the prompt
     expectNoSentinels(coreConstructedStrings(error), [...DISPATCH_SENTINELS, PROVIDER_SENTINEL])
   })
 
@@ -285,6 +285,6 @@ describe('the sentinel sweep over the whole error matrix', () => {
     } catch (error) {
       caught = error
     }
-    expect(caught).toBe(bug) // raw, by design (spec §1) — the user's bug in full
+    expect(caught).toBe(bug) // raw, by design (spec §1): the user's bug in full
   })
 })

--- a/test/unit/core/state-machine-property.test.ts
+++ b/test/unit/core/state-machine-property.test.ts
@@ -1,6 +1,6 @@
 /**
  * The state-machine property test: over arbitrary sequences of
- * provider outcomes, store outcomes and signal timings — never two reservations per run
+ * provider outcomes, store outcomes and signal timings, never two reservations per run
  * beyond the single §4 re-reserve, never a lost settle on a post-commit path, `retryable`
  * always the literal, cleanup invariants as postconditions, and the terminal-code
  * invariant conditioned on attempt-determined termination.
@@ -170,7 +170,7 @@ async function runScenario(scenario: Scenario): Promise<void> {
   // Never more than two reservations: the original plus §4's single re-reserve.
   expect(f.s.reserve.calls.length).toBeLessThanOrEqual(2)
 
-  // Never a lost settle on a post-commit path — and never a settle without a commit.
+  // Never a lost settle on a post-commit path, and never a settle without a commit.
   const committed = f.s.commit.calls.length > 0 && sawValidatedCommit(scenario)
   const initialSettles = f.s.settle.calls.length > 0
   if (committed) {
@@ -233,7 +233,7 @@ function sawValidatedCommit(scenario: Scenario): boolean {
       const answer = step(index)
       index += 1
       if (answer === 'reject') {
-        // A transport failure retries — unless the abort fired inside the commit handler,
+        // A transport failure retries, unless the abort fired inside the commit handler,
         // in which case the pre-retry signal check ends the run first.
         if (scenario.abortAt === 'commit') return 'aborted'
         continue
@@ -264,7 +264,7 @@ describe('the run state machine, property-tested', () => {
     const f = fixture({ quota: { perDay: 5 } })
     const controller = new AbortController()
     f.p1.next(() => {
-      // The abort lands a few microtasks after the classified rejection — exactly at the
+      // The abort lands a few microtasks after the classified rejection: exactly at the
       // stage-10 boundary, after the transient attempt was recorded and before the
       // fallback decision. (One tick earlier it would race the dispatch itself.)
       void Promise.resolve()

--- a/test/unit/core/string-domain.test.ts
+++ b/test/unit/core/string-domain.test.ts
@@ -65,7 +65,7 @@ function expectInvalidConfigThrow(make: () => unknown): void {
   expect((caught as LLMDispatchError).code).toBe('INVALID_CONFIG')
 }
 
-describe('violations at the createSwitch boundary — no store method called at all', () => {
+describe('violations at the createSwitch boundary: no store method called at all', () => {
   for (const { name, value } of VIOLATIONS) {
     it(`rejects an operation name carrying ${name}`, () => {
       const { s, make } = buildSwitch({
@@ -120,7 +120,7 @@ describe('violations at the createSwitch boundary — no store method called at 
   }
 })
 
-describe('violations at the setConfig boundary — no store method called', () => {
+describe('violations at the setConfig boundary: no store method called', () => {
   for (const { name, value } of VIOLATIONS) {
     it(`rejects a route model carrying ${name}`, async () => {
       const f = fixture()
@@ -154,7 +154,7 @@ describe('violations in a subjectId', () => {
   }
 })
 
-describe('violations in store-originated values — no dependent call', () => {
+describe('violations in store-originated values: no dependent call', () => {
   for (const { name, value } of VIOLATIONS) {
     it(`treats a stored row model carrying ${name} as a malformed row`, async () => {
       const f = fixture()
@@ -191,8 +191,8 @@ describe('violations in store-originated values — no dependent call', () => {
   }
 
   it('never calls settle for a violating envelope or attempt at finalization', async () => {
-    // Unreachable through the public API — reserve validates the envelope and the routes
-    // validate every attempt string — so the §6 re-check is exercised at the seam itself.
+    // Unreachable through the public API: reserve validates the envelope and the routes
+    // validate every attempt string, so the §6 re-check is exercised at the seam itself.
     const runtime = fakeRuntime()
     const s = scriptedStores()
     const hookCalls: unknown[] = []
@@ -221,7 +221,7 @@ describe('violations in store-originated values — no dependent call', () => {
   })
 
   it('never calls settle for a violating attempt record behind a valid envelope', async () => {
-    // The envelope passes; the attempt strings do not — the re-check must still refuse the
+    // The envelope passes; the attempt strings do not: the re-check must still refuse the
     // store call, and the failure still travels the retry-then-hook path.
     const runtime = fakeRuntime()
     const s = scriptedStores()
@@ -309,7 +309,7 @@ describe('valid-hostile keys', () => {
         stored: null,
         effective: { provider: 'p1', model: 'm1' },
       })
-      // An unknown name still resolves as unknown — the registry is not the prototype chain.
+      // An unknown name still resolves as unknown: the registry is not the prototype chain.
       await expectCode(ai.run('valueOf', INPUT), 'INVALID_INPUT')
     })
   }

--- a/test/unit/identity.test.ts
+++ b/test/unit/identity.test.ts
@@ -4,8 +4,8 @@ import { z } from 'zod'
 import { defineOperation, defineOperations } from '../../src/index'
 
 describe('the inference builders', () => {
-  // Spec §6: defineOperations is an identity collector — it returns exactly the object it
-  // was given — and defineOperation is the per-entry identity that carries the inference.
+  // Spec §6: defineOperations is an identity collector: it returns exactly the object it
+  // was given, and defineOperation is the per-entry identity that carries the inference.
   it('defineOperations returns the very object it was handed', () => {
     const operations = {
       summarize: defineOperation({

--- a/test/unit/providers/gemini.test.ts
+++ b/test/unit/providers/gemini.test.ts
@@ -37,7 +37,7 @@ describe('request shape', () => {
   })
 
   // A model containing URL-meaningful characters proves encodeURIComponent runs, not a bare
-  // string interpolation — an unencoded value would change the request path (D11).
+  // string interpolation: an unencoded value would change the request path (D11).
   it.each([
     ['slash', 'org/model', 'org%2Fmodel'],
     ['question mark', 'model?x', 'model%3Fx'],

--- a/test/unit/providers/helpers.ts
+++ b/test/unit/providers/helpers.ts
@@ -36,7 +36,7 @@ function parseBody(init: RequestInit): unknown {
   }
 }
 
-/** Builds a `Response` whose body is JSON — or `null` for an empty body. */
+/** Builds a `Response` whose body is JSON, or `null` for an empty body. */
 export function jsonResponse(status: number, body: unknown): Response {
   const text = body === null ? '' : JSON.stringify(body)
   return new Response(text, { status, headers: { 'content-type': 'application/json' } })

--- a/test/unit/providers/openai-compatible.test.ts
+++ b/test/unit/providers/openai-compatible.test.ts
@@ -75,7 +75,7 @@ describe('request shape', () => {
     expect(body.temperature).toBe(0.4)
   })
 
-  // The host-specific token parameter, not a hardcoded name — kills a fixed 'max_tokens'.
+  // The host-specific token parameter, not a hardcoded name: kills a fixed 'max_tokens'.
   it.each([
     [
       'api.openai.com default -> max_completion_tokens',
@@ -112,7 +112,7 @@ describe('request shape', () => {
     expect(other in body).toBe(false)
   })
 
-  // The capability table (native/gateway/unknown) x both override knobs — kills a rule that
+  // The capability table (native/gateway/unknown) x both override knobs: kills a rule that
   // always sends response_format, or never does.
   const TEXT = { type: 'text' } as const
   const JSON_OBJECT = { type: 'json', topLevel: 'object' } as const

--- a/test/unit/providers/redirect.test.ts
+++ b/test/unit/providers/redirect.test.ts
@@ -1,7 +1,7 @@
 /**
  * The redirect-exfiltration fixture (spec §5c/§8, plan §2 box 1): a real `fetch` against a
  * local two-endpoint `node:http` pair, source answering 302 to target. Proves what
- * `redirect: 'error'` does under the real runtime — no scripted fetch can show this.
+ * `redirect: 'error'` does under the real runtime, no scripted fetch can show this.
  */
 
 import { createServer } from 'node:http'

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -12,7 +12,7 @@
     "skipLibCheck": true,
     // The runners import the package by its published name. Left to the manifest that
     // resolves into `dist/`, which makes this typecheck depend on a build having happened
-    // first — it has not in CI, where typecheck runs before build. Pointed at the sources
+    // first, and it has not in CI, where typecheck runs before build. Pointed at the sources
     // instead, which are what `dist/` is generated from.
     "paths": {
       "llmdispatch": ["./src/index.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
       reporter: ['text', 'text-summary', 'lcov'],
       // Held to a threshold: what decides, and what is thrown. The stores, the harnesses,
       // and the built-in adapters are measured and reported so their number is visible, and
-      // gated later rather than at 90 % on the day they land — a ratchet only ever goes up.
+      // gated later rather than at 90 % on the day they land: a ratchet only ever goes up.
       thresholds: {
         'src/core/**/*.ts': { lines: 90, branches: 90 },
         'src/errors/**/*.ts': { lines: 90, branches: 90 },


### PR DESCRIPTION
Carries the readme pass through the rest of the repository: docs/spec.md, RELEASING.md, CONTRIBUTING.md, SECURITY.md, docs/architecture.md, the module readmes, the examples, and the comments in src, test and scripts.

Prose only. No rule, claim or contract wording changes: the spec diff was checked word by word and the only differences are added connectives and capitalisation after a new sentence break. Comments in src matter here because they compile into dist/*.d.ts and show up in editor tooltips.

Generated files follow their sources rather than being edited: docs/providers.md, api/*.d.ts and test/types/spec-surface.d.ts are regenerated, and the two generators that print those strings were fixed at the source.

Three places keep their punctuation on purpose, since it is data rather than prose: the heading character class and the slug case in scripts/check-docs-links.mjs, and the fake model response in test/unit/scripts/live-check-json.test.ts.

`npm run check` passes: 16 of 16 compile fixtures against both surfaces, 44 declared names against dist, providers.md matching spec §5c.