### PR TITLE
Version 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.1
+
+### Patch Changes
+
+- Documentation only. The readme is shorter and leads on the package being model
+  agnostic, the full reference moved to `docs/guide.md`, and the prose across the
+  spec, runbook and code comments is plainer. No runtime code changed.
+
 ## 0.1.0
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llmdispatch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llmdispatch",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llmdispatch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Model-agnostic LLM routing. Pick the provider and model per operation, swap them at runtime, fall back on failure, and enforce per-user quotas in your own Postgres.",
   "keywords": [
     "llm",


### PR DESCRIPTION
Patch release. Documentation only: the readme rewrite and the plainer prose across the spec, runbook, module readmes, examples and code comments. No runtime code changed.

Publishing it is what puts the new readme and package description on the npm page.