### PR TITLE
feat: multimodal wire mappings for the built-in adapters

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -30,9 +30,20 @@ any other 4xx (incl. 409/413/422) → `invalid_request`; any 5xx (incl. 504/529)
 **`openaiCompatible({ apiKey, baseUrl?, jsonMode?, tokenParam? })`, the universal transport.**
 Default `baseUrl` `https://api.openai.com/v1`; `POST {baseUrl}/chat/completions`;
 `Authorization: Bearer`. ([OpenAI API reference](https://platform.openai.com/docs/api-reference/chat))
-Request: `model`, `messages: [{role:'user', content: prompt}]`, `max_tokens`,
+Request: `model`, `messages: [{role:'user', content}]`, `max_tokens`,
 `temperature`, and `response_format: { type: 'json_object' }` only when JSON-object format
-AND the JSON capability applies. **JSON capability rule:** direct known-good hosts
+AND the JSON capability applies. **Content mapping:** a request whose parts are exactly one
+text part sends `content` as that plain string; every other parts list sends a content-part
+array, one entry per part in order — text → `{type:'text', text}`; image → `{type:
+'image_url', image_url:{ url: 'data:<mediaType>;base64,<data>' }}`; PDF → `{type:'file',
+file:{ filename, file_data: 'data:application/pdf;base64,<data>' }}`, `filename` falling
+back to `document.pdf` when the part carries none
+([images](https://platform.openai.com/docs/guides/images-vision),
+[PDF files](https://platform.openai.com/docs/guides/pdf-files)). **Both media forms are
+best-effort across compatible servers:** they are pinned to OpenAI's published Chat
+Completions shapes, no named compatible host is claimed to accept either, and a server
+lacking one answers with its own error, classified by the rows below. **JSON capability
+rule:** direct known-good hosts
 (api.openai.com, api.deepseek.com, api.groq.com, api.mistral.ai) get native `json_object`;
 **model-multiplexing gateways (openrouter.ai, api.together.xyz, api.fireworks.ai) and
 unknown hosts are prompt-only by default**: JSON-mode support there is per-MODEL, not
@@ -70,8 +81,15 @@ https://api.anthropic.com/v1/messages`; **`x-api-key`** + required
 the OpenAI-compat layer is not used: it ignores `response_format` and is documented as a
 testing tool: [Anthropic OpenAI SDK compat](https://docs.anthropic.com/en/api/openai-sdk))
 Request: `model`, `max_tokens` (**always sent**, required by Anthropic; default 4096 when
-the route sets none), `messages: [{role:'user', content: prompt}]`, `temperature` (0–1;
-core-range values are clamped, documented). JSON is prompt-driven in v0.1.
+the route sets none), `messages: [{role:'user', content}]`, `temperature` (0–1;
+core-range values are clamped, documented). JSON is prompt-driven.
+**Content mapping:** a request whose parts are exactly one text part sends `content` as that
+plain string; every other parts list sends a block array, one block per part in order —
+text → `{type:'text', text}`; PDF → `{type:'document', source:{ type:'base64',
+media_type:'application/pdf', data }}`; image → `{type:'image', source:{ type:'base64',
+media_type, data }}`. Neither block has a filename field, so a part's `filename` is never
+sent ([PDF support](https://docs.anthropic.com/en/docs/build-with-claude/pdf-support),
+[vision](https://docs.anthropic.com/en/docs/build-with-claude/vision)).
 Response: first `text` block of `content[]`; `stop_reason` normalized to
 `ProviderResponse.kind`: `max_tokens` **and `model_context_window_exceeded`** →
 `'truncated'`; `refusal` → `'refused'`; `end_turn`/`stop_sequence` → `'complete'`; other →
@@ -98,9 +116,17 @@ which this design depends on ([Gemini OpenAI compat](https://ai.google.dev/gemin
 [native usage fields](https://ai.google.dev/api/generate-content); the compat-usage
 discrepancy observed in the research is recorded as an empirical fixture-verification item,
 not the primary rationale).
-Request: `contents: [{role:'user', parts:[{text: prompt}]}]`, `generationConfig:
+Request: `contents: [{role:'user', parts}]`, `generationConfig:
 { maxOutputTokens?, temperature?, responseMimeType: 'application/json' }` (MIME only for
 JSON-object format; prompt still carries the shape).
+**Content mapping:** one `parts` entry per content part, in order — text → `{text}`; file →
+`{inline_data:{ mime_type, data }}`, the same form for PDFs and images
+([document understanding](https://ai.google.dev/gemini-api/docs/document-processing),
+[image understanding](https://ai.google.dev/gemini-api/docs/image-understanding)). ProtoJSON
+accepts the `inlineData`/`mimeType` spelling as well; the snake_case spelling the REST
+examples print is the pinned one. The image guide lists png, jpeg, webp, heic and heif, so
+an `image/gif` part is unverified rather than unsupported: it goes on the wire unchanged and
+surfaces whatever Gemini answers.
 Response: `candidates[0].content.parts[]` text concatenated; termination normalized to
 `ProviderResponse.kind`: `promptFeedback.blockReason` present → `'refused'`; no candidates
 WITHOUT block metadata → throw `ProviderError('malformed_response')`; `finishReason`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -322,9 +322,20 @@ any other 4xx (incl. 409/413/422) → `invalid_request`; any 5xx (incl. 504/529)
 **`openaiCompatible({ apiKey, baseUrl?, jsonMode?, tokenParam? })`, the universal transport.**
 Default `baseUrl` `https://api.openai.com/v1`; `POST {baseUrl}/chat/completions`;
 `Authorization: Bearer`. ([OpenAI API reference](https://platform.openai.com/docs/api-reference/chat))
-Request: `model`, `messages: [{role:'user', content: prompt}]`, `max_tokens`,
+Request: `model`, `messages: [{role:'user', content}]`, `max_tokens`,
 `temperature`, and `response_format: { type: 'json_object' }` only when JSON-object format
-AND the JSON capability applies. **JSON capability rule:** direct known-good hosts
+AND the JSON capability applies. **Content mapping:** a request whose parts are exactly one
+text part sends `content` as that plain string; every other parts list sends a content-part
+array, one entry per part in order — text → `{type:'text', text}`; image → `{type:
+'image_url', image_url:{ url: 'data:<mediaType>;base64,<data>' }}`; PDF → `{type:'file',
+file:{ filename, file_data: 'data:application/pdf;base64,<data>' }}`, `filename` falling
+back to `document.pdf` when the part carries none
+([images](https://platform.openai.com/docs/guides/images-vision),
+[PDF files](https://platform.openai.com/docs/guides/pdf-files)). **Both media forms are
+best-effort across compatible servers:** they are pinned to OpenAI's published Chat
+Completions shapes, no named compatible host is claimed to accept either, and a server
+lacking one answers with its own error, classified by the rows below. **JSON capability
+rule:** direct known-good hosts
 (api.openai.com, api.deepseek.com, api.groq.com, api.mistral.ai) get native `json_object`;
 **model-multiplexing gateways (openrouter.ai, api.together.xyz, api.fireworks.ai) and
 unknown hosts are prompt-only by default**: JSON-mode support there is per-MODEL, not
@@ -360,8 +371,15 @@ https://api.anthropic.com/v1/messages`; **`x-api-key`** + required
 the OpenAI-compat layer is not used: it ignores `response_format` and is documented as a
 testing tool: [Anthropic OpenAI SDK compat](https://docs.anthropic.com/en/api/openai-sdk))
 Request: `model`, `max_tokens` (**always sent**, required by Anthropic; default 4096 when
-the route sets none), `messages: [{role:'user', content: prompt}]`, `temperature` (0–1;
-core-range values are clamped, documented). JSON is prompt-driven in v0.1.
+the route sets none), `messages: [{role:'user', content}]`, `temperature` (0–1;
+core-range values are clamped, documented). JSON is prompt-driven.
+**Content mapping:** a request whose parts are exactly one text part sends `content` as that
+plain string; every other parts list sends a block array, one block per part in order —
+text → `{type:'text', text}`; PDF → `{type:'document', source:{ type:'base64',
+media_type:'application/pdf', data }}`; image → `{type:'image', source:{ type:'base64',
+media_type, data }}`. Neither block has a filename field, so a part's `filename` is never
+sent ([PDF support](https://docs.anthropic.com/en/docs/build-with-claude/pdf-support),
+[vision](https://docs.anthropic.com/en/docs/build-with-claude/vision)).
 Response: first `text` block of `content[]`; `stop_reason` normalized to
 `ProviderResponse.kind`: `max_tokens` **and `model_context_window_exceeded`** →
 `'truncated'`; `refusal` → `'refused'`; `end_turn`/`stop_sequence` → `'complete'`; other →
@@ -386,9 +404,17 @@ which this design depends on ([Gemini OpenAI compat](https://ai.google.dev/gemin
 [native usage fields](https://ai.google.dev/api/generate-content); the compat-usage
 discrepancy observed in the research is recorded as an empirical fixture-verification item,
 not the primary rationale).
-Request: `contents: [{role:'user', parts:[{text: prompt}]}]`, `generationConfig:
+Request: `contents: [{role:'user', parts}]`, `generationConfig:
 { maxOutputTokens?, temperature?, responseMimeType: 'application/json' }` (MIME only for
 JSON-object format; prompt still carries the shape).
+**Content mapping:** one `parts` entry per content part, in order — text → `{text}`; file →
+`{inline_data:{ mime_type, data }}`, the same form for PDFs and images
+([document understanding](https://ai.google.dev/gemini-api/docs/document-processing),
+[image understanding](https://ai.google.dev/gemini-api/docs/image-understanding)). ProtoJSON
+accepts the `inlineData`/`mimeType` spelling as well; the snake_case spelling the REST
+examples print is the pinned one. The image guide lists png, jpeg, webp, heic and heif, so
+an `image/gif` part is unverified rather than unsupported: it goes on the wire unchanged and
+surfaces whatever Gemini answers.
 Response: `candidates[0].content.parts[]` text concatenated; termination normalized to
 `ProviderResponse.kind`: `promptFeedback.blockReason` present → `'refused'`; no candidates
 WITHOUT block metadata → throw `ProviderError('malformed_response')`; `finishReason`

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "sizeBudget": 34435,
+  "sizeBudget": 34816,
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit && node scripts/check-types-fixtures.mjs --target spec",

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -7,12 +7,13 @@
 import { ProviderError } from '../errors'
 import type {
   ApiKeyResolver,
+  ContentPart,
   PreparedProvider,
   Provider,
   ProviderRequest,
   ProviderResponse,
 } from '../types'
-import { readSoleTextPart } from './parts'
+import { soleTextPart } from './parts'
 import {
   buildUsage,
   fetchJson,
@@ -46,15 +47,28 @@ export function anthropic(opts: { apiKey: ApiKeyResolver }): Provider {
   }
 }
 
+/** The user message's `content`: a plain string for a lone text part, blocks otherwise (§5c). */
+function anthropicContent(parts: readonly ContentPart[]): string | unknown[] {
+  const sole = soleTextPart(parts)
+  if (sole !== null) return sole
+  return parts.map((part) => {
+    if (part.type === 'text') return { type: 'text', text: part.text }
+    const source = { type: 'base64', media_type: part.mediaType, data: part.data }
+    // PDFs are documents, every other media type is an image; neither block carries a
+    // filename field, so `part.filename` has nowhere to go.
+    if (part.mediaType === 'application/pdf') return { type: 'document', source }
+    return { type: 'image', source }
+  })
+}
+
 async function completeAnthropic(
   apiKey: string,
   req: ProviderRequest,
 ): Promise<ProviderResponse> {
-  const promptText = readSoleTextPart(req.parts)
   const body: Record<string, unknown> = {
     model: req.model,
     max_tokens: req.maxOutputTokens ?? DEFAULT_MAX_TOKENS,
-    messages: [{ role: 'user', content: promptText }],
+    messages: [{ role: 'user', content: anthropicContent(req.parts) }],
   }
   if (req.temperature !== undefined) {
     body.temperature = Math.min(1, Math.max(0, req.temperature))

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -7,12 +7,12 @@
 import { ProviderError } from '../errors'
 import type {
   ApiKeyResolver,
+  ContentPart,
   PreparedProvider,
   Provider,
   ProviderRequest,
   ProviderResponse,
 } from '../types'
-import { readSoleTextPart } from './parts'
 import {
   buildUsage,
   classifyByStatusFamily,
@@ -54,8 +54,18 @@ export function gemini(opts: { apiKey: ApiKeyResolver }): Provider {
   }
 }
 
+/**
+ * One `parts` entry per content part, in order (§5c). ProtoJSON accepts `inlineData` and
+ * `mimeType` too; the snake_case spelling the REST examples print is the pinned one.
+ */
+function geminiParts(parts: readonly ContentPart[]): unknown[] {
+  return parts.map((part) => {
+    if (part.type === 'text') return { text: part.text }
+    return { inline_data: { mime_type: part.mediaType, data: part.data } }
+  })
+}
+
 async function completeGemini(apiKey: string, req: ProviderRequest): Promise<ProviderResponse> {
-  const promptText = readSoleTextPart(req.parts)
   const url = `${HOST}/models/${encodeURIComponent(req.model)}:generateContent`
   const generationConfig: Record<string, unknown> = {}
   if (req.maxOutputTokens !== undefined) generationConfig.maxOutputTokens = req.maxOutputTokens
@@ -65,7 +75,7 @@ async function completeGemini(apiKey: string, req: ProviderRequest): Promise<Pro
   }
 
   const body: Record<string, unknown> = {
-    contents: [{ role: 'user', parts: [{ text: promptText }] }],
+    contents: [{ role: 'user', parts: geminiParts(req.parts) }],
   }
   if (Object.keys(generationConfig).length > 0) {
     body.generationConfig = generationConfig

--- a/src/providers/openai-compatible.ts
+++ b/src/providers/openai-compatible.ts
@@ -7,12 +7,13 @@
 import { ProviderError } from '../errors'
 import type {
   ApiKeyResolver,
+  ContentPart,
   PreparedProvider,
   Provider,
   ProviderRequest,
   ProviderResponse,
 } from '../types'
-import { readSoleTextPart } from './parts'
+import { soleTextPart } from './parts'
 import {
   buildUsage,
   classifyByStatusFamily,
@@ -22,6 +23,10 @@ import {
 } from './transport'
 
 const DEFAULT_BASE = 'https://api.openai.com/v1'
+
+// `file.filename` is required by the file content part; a part that carries none still has
+// to send something.
+const DEFAULT_PDF_FILENAME = 'document.pdf'
 
 const NATIVE_JSON_HOSTS = new Set([
   'api.openai.com',
@@ -89,6 +94,27 @@ function tokenParamFor(
   return host === 'api.openai.com' ? 'max_completion_tokens' : 'max_tokens'
 }
 
+/**
+ * The user message's `content`: a plain string for a lone text part, content parts
+ * otherwise (§5c). The media forms are pinned to OpenAI's published shapes; a compatible
+ * server that lacks either answers with its own error.
+ */
+function openAIContent(parts: readonly ContentPart[]): string | unknown[] {
+  const sole = soleTextPart(parts)
+  if (sole !== null) return sole
+  return parts.map((part) => {
+    if (part.type === 'text') return { type: 'text', text: part.text }
+    const url = `data:${part.mediaType};base64,${part.data}`
+    if (part.mediaType === 'application/pdf') {
+      return {
+        type: 'file',
+        file: { filename: part.filename ?? DEFAULT_PDF_FILENAME, file_data: url },
+      }
+    }
+    return { type: 'image_url', image_url: { url } }
+  })
+}
+
 async function completeOpenAI(
   apiKey: string,
   baseUrl: string,
@@ -96,11 +122,10 @@ async function completeOpenAI(
   tokenParam: 'max_tokens' | 'max_completion_tokens' | undefined,
   req: ProviderRequest,
 ): Promise<ProviderResponse> {
-  const promptText = readSoleTextPart(req.parts)
   const host = hostOf(baseUrl)
   const body: Record<string, unknown> = {
     model: req.model,
-    messages: [{ role: 'user', content: promptText }],
+    messages: [{ role: 'user', content: openAIContent(req.parts) }],
   }
 
   if (req.maxOutputTokens !== undefined) {

--- a/src/providers/parts.ts
+++ b/src/providers/parts.ts
@@ -5,25 +5,18 @@
  * @module
  */
 
-import { ProviderError } from '../errors'
 import type { ContentPart } from '../types'
 
 /**
- * The text of a request carrying exactly one text part, which every adapter serializes the
- * plain way (§5c).
+ * The text of a request carrying exactly one text part, which Anthropic and the
+ * OpenAI-compatible transport send as a plain string `content` (§5c).
  *
  * @param parts The request's normalized parts.
- * @returns That part's text, `''` included.
- * @throws `ProviderError` with kind `invalid_request` for any other parts list. The wire
- *   mappings for documents and images are not in place yet, so such a request is rejected
- *   before dispatch rather than serialized as something the model was never sent.
+ * @returns That part's text, `''` included, or `null` for every other parts list, which
+ *   both adapters send as an array instead.
  */
-export function readSoleTextPart(parts: readonly ContentPart[]): string {
+export function soleTextPart(parts: readonly ContentPart[]): string | null {
   const first = parts[0]
-  if (parts.length !== 1 || first?.type !== 'text') {
-    throw new ProviderError('invalid_request', {
-      message: 'only a single text part is supported',
-    })
-  }
+  if (parts.length !== 1 || first?.type !== 'text') return null
   return first.text
 }

--- a/test/unit/providers/helpers.ts
+++ b/test/unit/providers/helpers.ts
@@ -20,6 +20,8 @@ export interface CapturedRequest {
   method: string
   headers: Record<string, string>
   body: unknown
+  /** The serialized body, for assertions parsed JSON cannot make: field order, spacing. */
+  rawBody: string | undefined
   redirect: RequestInit['redirect']
   signal: AbortSignal | undefined
 }
@@ -86,6 +88,7 @@ export function captureRequests(handler: FetchHandler = () => jsonResponse(200, 
       method: init.method ?? 'GET',
       headers: toHeaders(init),
       body: parseBody(init),
+      rawBody: typeof init.body === 'string' ? init.body : undefined,
       redirect: init.redirect,
       signal: init.signal ?? undefined,
     })

--- a/test/unit/providers/parts.test.ts
+++ b/test/unit/providers/parts.test.ts
@@ -1,7 +1,7 @@
 /**
- * What every built-in adapter does with `ProviderRequest.parts`: the single text part is
- * serialized the plain way each adapter's own suite asserts, and anything else is refused
- * as `invalid_request` before a request is made, carrying no part data or filename.
+ * How each built-in adapter turns `ProviderRequest.parts` into its wire body (spec §5c):
+ * the mapped shape per part kind, order preserved, the single-text form pinned to the exact
+ * bytes it has always serialized, and file data and filenames kept out of every error path.
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -10,95 +10,332 @@ import { ProviderError } from '../../../src/errors'
 import { anthropic } from '../../../src/providers/anthropic'
 import { gemini } from '../../../src/providers/gemini'
 import { openaiCompatible } from '../../../src/providers/openai-compatible'
-import type { ContentPart, PreparedProvider } from '../../../src/types'
-import { baseRequest, captureRequests, textParts, withPrepared } from './helpers'
+import type { ContentPart, PreparedProvider, ProviderRequest } from '../../../src/types'
+import type { CapturedRequest } from './helpers'
+import {
+  baseRequest,
+  captureRequests,
+  installFetch,
+  jsonResponse,
+  withPrepared,
+} from './helpers'
+
+const PDF_DATA = 'JVBERi0xLjQK'
+const PNG_DATA = 'iVBORw0KGgo='
+const GIF_DATA = 'R0lGODlhAQAB'
 
 const DATA_SENTINEL = 'U0VOVElORUxfREFUQV84YjJm'
 const FILENAME_SENTINEL = 'SENTINEL_FILENAME_4d7e.pdf'
 
+const TEXT: ContentPart = { type: 'text', text: 'read this' }
 const PDF: ContentPart = {
+  type: 'file',
+  mediaType: 'application/pdf',
+  data: PDF_DATA,
+  filename: 'report.pdf',
+}
+const UNNAMED_PDF: ContentPart = { type: 'file', mediaType: 'application/pdf', data: PDF_DATA }
+const PNG: ContentPart = { type: 'file', mediaType: 'image/png', data: PNG_DATA }
+const GIF: ContentPart = { type: 'file', mediaType: 'image/gif', data: GIF_DATA }
+const SENTINEL_PDF: ContentPart = {
   type: 'file',
   mediaType: 'application/pdf',
   data: DATA_SENTINEL,
   filename: FILENAME_SENTINEL,
 }
 
-const ADAPTERS: { name: string; build: () => Promise<PreparedProvider['complete']> }[] = [
-  { name: 'anthropic', build: () => withPrepared(anthropic({ apiKey: () => 'k' })) },
-  { name: 'gemini', build: () => withPrepared(gemini({ apiKey: () => 'k' })) },
-  {
-    name: 'openai-compatible',
-    build: () => withPrepared(openaiCompatible({ apiKey: () => 'k' })),
-  },
-]
+const JSON_OBJECT: ProviderRequest['responseFormat'] = { type: 'json', topLevel: 'object' }
 
-const UNSUPPORTED: { name: string; parts: readonly ContentPart[] }[] = [
-  { name: 'a file part', parts: [PDF] },
-  { name: 'a text part beside a file part', parts: [{ type: 'text', text: 'read this' }, PDF] },
-  {
-    name: 'two text parts',
-    parts: [
-      { type: 'text', text: 'one' },
-      { type: 'text', text: 'two' },
-    ],
+interface Adapter {
+  name: string
+  /** A 200 body this adapter reads as a normal completion. */
+  ok: unknown
+  build: () => Promise<PreparedProvider['complete']>
+  /** The mapped parts, wherever this adapter puts them in its body. */
+  content: (body: Record<string, unknown>) => unknown
+  /** The exact body a single-text request has always serialized to. */
+  golden: string
+  /** The mapped content of the lone empty text part, which is a legal prompt. */
+  emptyText: unknown
+}
+
+function messageContent(body: Record<string, unknown>): unknown {
+  const messages = body.messages as { content: unknown }[]
+  return messages[0]!.content
+}
+
+const ANTHROPIC: Adapter = {
+  name: 'anthropic',
+  ok: { content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn' },
+  build: () => withPrepared(anthropic({ apiKey: () => 'k' })),
+  content: messageContent,
+  golden:
+    '{"model":"test-model","max_tokens":4096,"messages":[{"role":"user","content":"hello"}]}',
+  emptyText: '',
+}
+
+const OPENAI: Adapter = {
+  name: 'openai-compatible',
+  ok: { choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }] },
+  build: () => withPrepared(openaiCompatible({ apiKey: () => 'k' })),
+  content: messageContent,
+  golden: '{"model":"test-model","messages":[{"role":"user","content":"hello"}]}',
+  emptyText: '',
+}
+
+const GEMINI: Adapter = {
+  name: 'gemini',
+  ok: { candidates: [{ content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' }] },
+  build: () => withPrepared(gemini({ apiKey: () => 'k' })),
+  content: (body) => {
+    const contents = body.contents as { parts: unknown }[]
+    return contents[0]!.parts
   },
-]
+  golden: '{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}',
+  emptyText: [{ text: '' }],
+}
+
+const ADAPTERS = [ANTHROPIC, OPENAI, GEMINI]
 
 afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-for (const { name, build } of ADAPTERS) {
-  describe(`${name} on parts it cannot map yet`, () => {
-    for (const unsupported of UNSUPPORTED) {
-      it(`refuses ${unsupported.name} as invalid_request without dispatching`, async () => {
-        const { requests } = captureRequests()
-        const complete = await build()
-        await expect(complete(baseRequest({ parts: unsupported.parts }))).rejects.toSatisfy(
-          (error: unknown) => ProviderError.is(error) && error.kind === 'invalid_request',
-        )
-        expect(requests).toHaveLength(0)
-      })
-    }
+/** What `call` rejected with, or `null` when it resolved, which no caller here expects. */
+async function rejectionOf(call: Promise<unknown>): Promise<unknown> {
+  return call.then(
+    () => null,
+    (thrown: unknown) => thrown,
+  )
+}
 
-    it('keeps the file data and filename out of the refusal message', async () => {
-      captureRequests()
-      const complete = await build()
-      try {
-        await complete(baseRequest({ parts: [PDF] }))
-        expect.unreachable('expected a rejection')
-      } catch (error) {
-        const { message } = error as Error
-        expect(message).not.toContain(DATA_SENTINEL)
-        expect(message).not.toContain(FILENAME_SENTINEL)
-      }
+/** Dispatches one request through `adapter` and returns what fetch was handed. */
+async function dispatch(
+  adapter: Adapter,
+  overrides: Partial<ProviderRequest>,
+): Promise<CapturedRequest> {
+  const { requests } = captureRequests(() => jsonResponse(200, adapter.ok))
+  const complete = await adapter.build()
+  await complete(baseRequest(overrides))
+  return requests[0]!
+}
+
+/** The parts of `overrides` as `adapter` mapped them. */
+async function contentOf(adapter: Adapter, parts: readonly ContentPart[]): Promise<unknown> {
+  const captured = await dispatch(adapter, { parts })
+  return adapter.content(captured.body as Record<string, unknown>)
+}
+
+describe('anthropic content blocks', () => {
+  it('sends a lone text part as a plain string', async () => {
+    expect(await contentOf(ANTHROPIC, [{ type: 'text', text: 'say hi' }])).toBe('say hi')
+  })
+
+  it('sends a PDF part as a base64 document block', async () => {
+    expect(await contentOf(ANTHROPIC, [PDF])).toEqual([
+      {
+        type: 'document',
+        source: { type: 'base64', media_type: 'application/pdf', data: PDF_DATA },
+      },
+    ])
+  })
+
+  it('sends an image part as a base64 image block carrying its media type', async () => {
+    expect(await contentOf(ANTHROPIC, [PNG])).toEqual([
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: PNG_DATA } },
+    ])
+  })
+
+  it('keeps text and file blocks in the order the parts arrived', async () => {
+    expect(await contentOf(ANTHROPIC, [TEXT, PDF, PNG])).toEqual([
+      { type: 'text', text: 'read this' },
+      {
+        type: 'document',
+        source: { type: 'base64', media_type: 'application/pdf', data: PDF_DATA },
+      },
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: PNG_DATA } },
+    ])
+  })
+
+  it('sends multiple text parts as one text block each', async () => {
+    expect(
+      await contentOf(ANTHROPIC, [
+        { type: 'text', text: 'one' },
+        { type: 'text', text: 'two' },
+      ]),
+    ).toEqual([
+      { type: 'text', text: 'one' },
+      { type: 'text', text: 'two' },
+    ])
+  })
+
+  it('never puts a filename on the wire', async () => {
+    const captured = await dispatch(ANTHROPIC, { parts: [PDF] })
+    expect(captured.rawBody).not.toContain('report.pdf')
+  })
+
+  it('stays prompt-only for json format beside a file part', async () => {
+    const captured = await dispatch(ANTHROPIC, {
+      parts: [TEXT, PNG],
+      responseFormat: JSON_OBJECT,
+    })
+    const body = captured.body as Record<string, unknown>
+    expect(Object.keys(body).sort()).toEqual(['max_tokens', 'messages', 'model'])
+  })
+})
+
+describe('openai-compatible content parts', () => {
+  it('sends a lone text part as a plain string', async () => {
+    expect(await contentOf(OPENAI, [{ type: 'text', text: 'say hi' }])).toBe('say hi')
+  })
+
+  it('sends an image part as a data-URL image_url part', async () => {
+    expect(await contentOf(OPENAI, [PNG])).toEqual([
+      { type: 'image_url', image_url: { url: `data:image/png;base64,${PNG_DATA}` } },
+    ])
+  })
+
+  it('sends a PDF part as a file part carrying the part filename', async () => {
+    expect(await contentOf(OPENAI, [PDF])).toEqual([
+      {
+        type: 'file',
+        file: { filename: 'report.pdf', file_data: `data:application/pdf;base64,${PDF_DATA}` },
+      },
+    ])
+  })
+
+  it('falls back to document.pdf when the part carries no filename', async () => {
+    expect(await contentOf(OPENAI, [UNNAMED_PDF])).toEqual([
+      {
+        type: 'file',
+        file: {
+          filename: 'document.pdf',
+          file_data: `data:application/pdf;base64,${PDF_DATA}`,
+        },
+      },
+    ])
+  })
+
+  it('keeps text and file parts in the order the parts arrived', async () => {
+    expect(await contentOf(OPENAI, [TEXT, PDF, PNG])).toEqual([
+      { type: 'text', text: 'read this' },
+      {
+        type: 'file',
+        file: { filename: 'report.pdf', file_data: `data:application/pdf;base64,${PDF_DATA}` },
+      },
+      { type: 'image_url', image_url: { url: `data:image/png;base64,${PNG_DATA}` } },
+    ])
+  })
+
+  it('sends multiple text parts as one text part each', async () => {
+    expect(
+      await contentOf(OPENAI, [
+        { type: 'text', text: 'one' },
+        { type: 'text', text: 'two' },
+      ]),
+    ).toEqual([
+      { type: 'text', text: 'one' },
+      { type: 'text', text: 'two' },
+    ])
+  })
+
+  it('still sends response_format for json format beside a file part', async () => {
+    const captured = await dispatch(OPENAI, { parts: [TEXT, PNG], responseFormat: JSON_OBJECT })
+    const body = captured.body as Record<string, unknown>
+    expect(body.response_format).toEqual({ type: 'json_object' })
+  })
+})
+
+describe('gemini content parts', () => {
+  it('sends a lone text part as a single text entry', async () => {
+    expect(await contentOf(GEMINI, [{ type: 'text', text: 'say hi' }])).toEqual([
+      { text: 'say hi' },
+    ])
+  })
+
+  it('sends a file part as snake_case inline_data', async () => {
+    expect(await contentOf(GEMINI, [PDF])).toEqual([
+      { inline_data: { mime_type: 'application/pdf', data: PDF_DATA } },
+    ])
+  })
+
+  it('sends an image part through the same inline_data form', async () => {
+    expect(await contentOf(GEMINI, [PNG])).toEqual([
+      { inline_data: { mime_type: 'image/png', data: PNG_DATA } },
+    ])
+  })
+
+  // Gemini's image guide lists png/jpeg/webp/heic/heif; a gif goes on the wire unchanged
+  // and surfaces whatever Gemini answers (§5c).
+  it('sends a gif part unchanged rather than refusing it', async () => {
+    expect(await contentOf(GEMINI, [GIF])).toEqual([
+      { inline_data: { mime_type: 'image/gif', data: GIF_DATA } },
+    ])
+  })
+
+  it('keeps text and file entries in the order the parts arrived', async () => {
+    expect(await contentOf(GEMINI, [TEXT, PDF, PNG])).toEqual([
+      { text: 'read this' },
+      { inline_data: { mime_type: 'application/pdf', data: PDF_DATA } },
+      { inline_data: { mime_type: 'image/png', data: PNG_DATA } },
+    ])
+  })
+
+  it('sends multiple text parts as one entry each', async () => {
+    expect(
+      await contentOf(GEMINI, [
+        { type: 'text', text: 'one' },
+        { type: 'text', text: 'two' },
+      ]),
+    ).toEqual([{ text: 'one' }, { text: 'two' }])
+  })
+
+  it('never puts a filename on the wire', async () => {
+    const captured = await dispatch(GEMINI, { parts: [PDF] })
+    expect(captured.rawBody).not.toContain('report.pdf')
+  })
+
+  it('still sets responseMimeType for json format beside a file part', async () => {
+    const captured = await dispatch(GEMINI, { parts: [TEXT, PNG], responseFormat: JSON_OBJECT })
+    const body = captured.body as Record<string, unknown>
+    const config = body.generationConfig as Record<string, unknown>
+    expect(config.responseMimeType).toBe('application/json')
+  })
+})
+
+for (const adapter of ADAPTERS) {
+  describe(`${adapter.name} on a text-only request`, () => {
+    // Parsed-JSON equality would pass however the fields moved: the single-text body is
+    // pinned to its exact serialization, so no multimodal branch can shift it.
+    it('serializes the exact body it has always sent', async () => {
+      const captured = await dispatch(adapter, {})
+      expect(captured.rawBody).toBe(adapter.golden)
     })
 
-    it('carries nothing beyond the fixed message and the classification', async () => {
-      captureRequests()
-      const complete = await build()
-      try {
-        await complete(baseRequest({ parts: [PDF] }))
-        expect.unreachable('expected a rejection')
-      } catch (error) {
-        const thrown = error as ProviderError
-        expect(thrown.message).toBe('only a single text part is supported')
-        expect(thrown.kind).toBe('invalid_request')
-        expect(thrown.status).toBeUndefined()
-        expect('cause' in thrown).toBe(false)
-        // Its own fields are exactly the class's fixed pair: none was added for a part to
-        // travel in, and neither holds anything the caller supplied.
-        expect(Object.keys(thrown).sort()).toEqual(['kind', 'name'])
-        expect(JSON.stringify(Object.values(thrown))).not.toContain(DATA_SENTINEL)
-        expect(JSON.stringify(Object.values(thrown))).not.toContain(FILENAME_SENTINEL)
-      }
+    it('serializes an empty text part, which is a legal prompt', async () => {
+      expect(await contentOf(adapter, [{ type: 'text', text: '' }])).toEqual(adapter.emptyText)
     })
+  })
 
-    it('still serializes an empty text part, which is a legal prompt', async () => {
-      const { requests } = captureRequests()
-      const complete = await build()
-      await complete(baseRequest({ parts: textParts('') })).catch(() => undefined)
-      expect(requests).toHaveLength(1)
+  describe(`${adapter.name} on a failed request carrying a file part`, () => {
+    it('keeps the file data and filename out of the thrown message', async () => {
+      installFetch(() =>
+        jsonResponse(400, { error: { message: `bad: ${DATA_SENTINEL} ${FILENAME_SENTINEL}` } }),
+      )
+      const complete = await adapter.build()
+      const error = await rejectionOf(complete(baseRequest({ parts: [TEXT, SENTINEL_PDF] })))
+
+      // The classification is asserted first: it is what proves the sweep below ran against
+      // the adapter's own error rather than a resolved call or a stray assertion failure.
+      expect(ProviderError.is(error)).toBe(true)
+      const thrown = error as ProviderError
+      expect(thrown.kind).toBe('invalid_request')
+      expect(thrown.status).toBe(400)
+      expect(thrown.message).not.toContain(DATA_SENTINEL)
+      expect(thrown.message).not.toContain(FILENAME_SENTINEL)
+      const own = JSON.stringify(Object.values(thrown))
+      expect(own).not.toContain(DATA_SENTINEL)
+      expect(own).not.toContain(FILENAME_SENTINEL)
     })
   })
 }

--- a/test/unit/providers/redirect.test.ts
+++ b/test/unit/providers/redirect.test.ts
@@ -1,5 +1,5 @@
 /**
- * The redirect-exfiltration fixture (spec §5c/§8, plan §2 box 1): a real `fetch` against a
+ * The redirect-exfiltration fixture (spec §5c/§8): a real `fetch` against a
  * local two-endpoint `node:http` pair, source answering 302 to target. Proves what
  * `redirect: 'error'` does under the real runtime, no scripted fetch can show this.
  */
@@ -10,7 +10,11 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { ProviderError } from '../../../src/errors'
 import { openaiCompatible } from '../../../src/providers/openai-compatible'
+import type { ContentPart } from '../../../src/types'
 import { baseRequest, SENTINEL, textParts, withPrepared } from './helpers'
+
+const DATA_SENTINEL = 'U0VOVElORUxfREFUQV84YjJm'
+const FILENAME_SENTINEL = 'SENTINEL_FILENAME_4d7e.pdf'
 
 interface Logged {
   method: string | undefined
@@ -60,7 +64,8 @@ describe('redirect exfiltration fixture', () => {
     await close(target)
   })
 
-  it('rejects transient, hits the source once, never reaches the target with credentials or prompt', async () => {
+  /** Starts the redirecting pair and returns the transport aimed at the source. */
+  async function startPair(): Promise<Awaited<ReturnType<typeof withPrepared>>> {
     targetLog = []
     sourceLog = []
 
@@ -84,11 +89,16 @@ describe('redirect exfiltration fixture', () => {
     })
     sourcePort = await listen(source)
 
-    const provider = openaiCompatible({
-      apiKey: () => 'sk-should-never-leave-source',
-      baseUrl: 'http://localhost:' + String(sourcePort),
-    })
-    const complete = await withPrepared(provider)
+    return withPrepared(
+      openaiCompatible({
+        apiKey: () => 'sk-should-never-leave-source',
+        baseUrl: 'http://localhost:' + String(sourcePort),
+      }),
+    )
+  }
+
+  it('rejects transient, hits the source once, never reaches the target with credentials or prompt', async () => {
+    const complete = await startPair()
 
     await expect(complete(baseRequest({ parts: textParts(SENTINEL) }))).rejects.toSatisfy(
       (error: unknown) => ProviderError.is(error) && error.kind === 'transient',
@@ -102,5 +112,35 @@ describe('redirect exfiltration fixture', () => {
     // in its own terms rather than only via the count.
     expect(targetLog.every((entry) => entry.headers.authorization === undefined)).toBe(true)
     expect(targetLog.every((entry) => !entry.body.includes(SENTINEL))).toBe(true)
+  })
+
+  it('carries file bytes and a filename no further than the source, and names neither', async () => {
+    const complete = await startPair()
+    const pdf: ContentPart = {
+      type: 'file',
+      mediaType: 'application/pdf',
+      data: DATA_SENTINEL,
+      filename: FILENAME_SENTINEL,
+    }
+
+    const error = await complete(
+      baseRequest({ parts: [{ type: 'text', text: SENTINEL }, pdf] }),
+    ).then(
+      () => null,
+      (thrown: unknown) => thrown,
+    )
+
+    expect(ProviderError.is(error)).toBe(true)
+    const thrown = error as ProviderError
+    expect(thrown.kind).toBe('transient')
+    expect(thrown.message).not.toContain(DATA_SENTINEL)
+    expect(thrown.message).not.toContain(FILENAME_SENTINEL)
+
+    expect(sourceLog.length).toBe(1)
+    expect(targetLog.length).toBe(0)
+    expect(sourceLog[0]!.body).toContain(DATA_SENTINEL)
+    expect(sourceLog[0]!.body).toContain(FILENAME_SENTINEL)
+    expect(targetLog.every((entry) => !entry.body.includes(DATA_SENTINEL))).toBe(true)
+    expect(targetLog.every((entry) => !entry.body.includes(FILENAME_SENTINEL))).toBe(true)
   })
 })


### PR DESCRIPTION
### What's in it

The three built-in adapters put file parts on the wire: Anthropic as document and image blocks with base64 sources, OpenAI-compatible as `image_url` and `file` content parts with data URLs, Gemini as `inline_data` parts, all in part order. A lone text part still serializes byte-for-byte as before, now pinned by raw-body golden tests. A redirecting endpoint provably never receives file bytes or a filename, and provider error paths are sentinel-tested for both.

Spec §5c carries the new mappings with primary-source links, the best-effort note for OpenAI-compatible servers, and Gemini's pinned snake_case spelling; `docs/providers.md` is regenerated from it.

### How to check it

Read §5c's three new content-mapping paragraphs next to `anthropicContent`, `openAIContent` and `geminiParts` — they should match word for word. The mapping tests in `test/unit/providers/parts.test.ts` assert exact wire bodies per part kind, and the goldens compare the raw request body string, not a re-serialization.

### Acceptance

- [ ] Wire shapes match §5c and the linked provider docs
- [ ] Text-only requests emit unchanged bytes (goldens)
- [ ] No payload reaches an error message or a redirect target
- [ ] JSON-mode and token-param host gating untouched

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
