### PR TITLE
feat: conformance and live checks for multimodal requests

### DIFF
--- a/.changeset/conformance-media-scenarios.md
+++ b/.changeset/conformance-media-scenarios.md
@@ -1,0 +1,12 @@
+---
+'llmdispatch': minor
+---
+
+The provider conformance suite can now verify document and image handling.
+`runProviderConformance` takes two further optional scenarios, `document` and `image`, plus
+a `requests` map supplying the request each one dispatches. Both halves are needed: a
+scenario without its request, or a request without its scenario, stays in `skipped` like
+any other unverified case. A media scenario that does run has to dispatch a request
+carrying a file part of that media class — `application/pdf` for `document`, an `image/*`
+type for `image` — and come back complete, so a text-only request fails it rather than
+passing it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
-Thanks for looking. This package is pre-release: the design in [`docs/spec.md`](docs/spec.md)
-is settled and the implementation is being written against it. If you are thinking of a
-change, open an issue first. It is a short conversation, and it saves you from writing
+Thanks for looking. The design in [`docs/spec.md`](docs/spec.md) is settled and the published
+package implements it, so changing what the package does means changing that document first.
+If you are thinking of a change, open an issue first. It is a short conversation, and it saves you from writing
 code against a contract that says something different.
 
 ## Getting set up

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ console.log(result.data)
 
 The fallback needs its own API key. Delete the `fallback` line and the second provider if you only have one.
 
+## Documents and images
+
+A prompt can return an array of content parts instead of a string, so an operation can send a PDF or an image alongside its text:
+
+```ts
+prompt: ({ note, invoice }) => [
+  { type: 'text', text: `Answer using the attached invoice.\n\n${note}` },
+  { type: 'file', mediaType: 'application/pdf', data: invoice, filename: 'invoice.pdf' },
+]
+```
+
+`data` is base64. The media types are `application/pdf`, `image/jpeg`, `image/png`, `image/webp` and `image/gif`, and one request may carry up to 15,000,000 base64 characters of file data, roughly 11 MB decoded. Over that the call fails before it reaches a provider or spends quota.
+
+Returning a string still works exactly as before. There is no capability model: route an operation that sends a file to a model that cannot read one and the call fails with that provider's own error, rather than being quietly sent somewhere else.
+
 ## Production
 
 `memoryStores()` holds routes and quota counters in one process. It is for development and it resets on restart.
@@ -83,7 +98,7 @@ Admin code on your server calls `ai.setConfig()` to change a route or a daily li
 
 ## Limits
 
-Server-side only, Node.js 20 or newer, ESM and CJS. Input is text, output is text or validated JSON. No streaming, no PDF or image input yet. Those are the v0.2 candidates.
+Server-side only, Node.js 20 or newer, ESM and CJS. Input is text, PDFs and images, output is text or validated JSON. Files go up as base64 in the request; URLs, file references and audio or video are not supported. No streaming yet.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ The fallback needs its own API key. Delete the `fallback` line and the second pr
 A prompt can return an array of content parts instead of a string, so an operation can send a PDF or an image alongside its text:
 
 ```ts
-prompt: ({ note, invoice }) => [
+prompt: ({ note, invoice }) => [                      // invoice: buffer.toString('base64')
   { type: 'text', text: `Answer using the attached invoice.\n\n${note}` },
   { type: 'file', mediaType: 'application/pdf', data: invoice, filename: 'invoice.pdf' },
 ]
 ```
 
-`data` is base64. The media types are `application/pdf`, `image/jpeg`, `image/png`, `image/webp` and `image/gif`, and one request may carry up to 15,000,000 base64 characters of file data, roughly 11 MB decoded. Over that the call fails before it reaches a provider or spends quota.
+`data` is a base64 string, not a `Buffer`. The media types are `application/pdf`, `image/jpeg` (not `image/jpg`, which is rejected), `image/png`, `image/webp` and `image/gif`, and one request may carry up to 15,000,000 base64 characters of file data, roughly 11 MB decoded. Over that the call fails before it reaches a provider or spends quota. Unknown fields on a part are dropped rather than rejected, so spell it `filename`.
 
 Returning a string still works exactly as before. There is no capability model: route an operation that sends a file to a model that cannot read one and the call fails with that provider's own error, rather than being quietly sent somewhere else.
 

--- a/api/conformance.d.ts
+++ b/api/conformance.d.ts
@@ -57,8 +57,10 @@ declare function runUsageStoreConformance(opts: {
 }): Promise<ConformanceResult>;
 //#endregion
 //#region src/conformance/provider.d.ts
-/** Optional scenarios the harness can drive when the adopter supplies them. */
+/** Optional classification scenarios the harness can drive when the adopter supplies them. */
 type OptionalScenario = 'auth' | 'rate_limit' | 'model_not_found' | 'invalid_request' | 'transient' | 'malformed_response' | 'truncated' | 'refused';
+/** Optional media scenarios: success-class conditions dispatching a request that carries a file. */
+type MediaScenario = 'document' | 'image';
 /** Controls that let the suite verify responseFormat and capability without guessing. */
 interface ProviderConformanceControls {
   /** Declares whether the provider under test supports native JSON mode. */
@@ -70,6 +72,7 @@ interface ProviderConformanceControls {
  * Checks a `Provider` against the behaviour spec §8 requires of one.
  *
  * `success` is mandatory. Absent optional scenarios are reported in `skipped` (unverified).
+ * A media scenario also needs its request in `requests`; either half absent and it is skipped.
  * `passed` is true exactly when `failures` is empty.
  */
 declare function runProviderConformance(opts: {
@@ -77,7 +80,8 @@ declare function runProviderConformance(opts: {
   requestFactory: () => ProviderRequest;
   scenarios: {
     success: () => Promise<void>;
-  } & Partial<Record<OptionalScenario, () => Promise<void>>>;
+  } & Partial<Record<OptionalScenario | MediaScenario, () => Promise<void>>>;
+  requests?: Partial<Record<MediaScenario, () => ProviderRequest>>;
   controls?: ProviderConformanceControls;
 }): Promise<ConformanceResult>;
 //#endregion

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -14,9 +14,11 @@ review: {
     { type: 'file', mediaType: 'application/pdf', data: invoice, filename: 'invoice.pdf' },
   ],
 }
+
+await ai.run('review', { input: { question, invoice: buffer.toString('base64') }, subjectId })
 ```
 
-The media types are `application/pdf`, `image/jpeg`, `image/png`, `image/webp` and `image/gif`. `filename` is optional and only some providers send it on. Parts arrive at the provider in the order you return them, one wire entry each, and each adapter maps them to its own shape (spec §5c). A prompt that returns a plain string is unchanged: it becomes a single text part and the adapters send the same body they always sent.
+The media types are `application/pdf`, `image/jpeg`, `image/png`, `image/webp` and `image/gif`; it is `image/jpeg`, because `image/jpg` is not a media type and is rejected. `data` is a base64 **string**, never a `Buffer` — convert at the edge, as above. `filename` is optional and only some providers send it on, and unknown fields on a part are dropped during normalization rather than rejected, so a misspelled `fileName` is silently ignored. Parts arrive at the provider in the order you return them, one wire entry each, and each adapter maps them to its own shape (spec §5c). A prompt that returns a plain string is unchanged: it becomes a single text part and the adapters send the same body they always sent.
 
 Parts are checked and frozen **before a quota slot is reserved**, so a bad part costs nothing. A malformed part — an unknown media type, base64 with whitespace or a data-URL prefix, an oversized filename — raises a `TypeError`, and more than **15,000,000 base64 characters of file data in one request** (about 11 MB decoded) raises a `RangeError`. Both are your bugs rather than llmdispatch failures, so they pass through unwrapped with no error code and no attempt record, and neither message ever quotes your file's bytes or its filename (spec §6).
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -2,6 +2,28 @@
 
 Everything llmdispatch does past the [README](../README.md) quickstart, in roughly the order you will need it. This is the working reference. The exact contract (state machine, store protocol, wire formats) is [spec.md](./spec.md).
 
+## Input: documents and images
+
+An operation's `prompt` returns a string, or an array of **content parts** when the call needs to carry a file. A `text` part is a string; a `file` part is base64 data plus the media type it is:
+
+```ts
+review: {
+  input: z.object({ question: z.string(), invoice: z.string() }),  // invoice is base64
+  prompt: ({ question, invoice }) => [
+    { type: 'text', text: question },
+    { type: 'file', mediaType: 'application/pdf', data: invoice, filename: 'invoice.pdf' },
+  ],
+}
+```
+
+The media types are `application/pdf`, `image/jpeg`, `image/png`, `image/webp` and `image/gif`. `filename` is optional and only some providers send it on. Parts arrive at the provider in the order you return them, one wire entry each, and each adapter maps them to its own shape (spec §5c). A prompt that returns a plain string is unchanged: it becomes a single text part and the adapters send the same body they always sent.
+
+Parts are checked and frozen **before a quota slot is reserved**, so a bad part costs nothing. A malformed part — an unknown media type, base64 with whitespace or a data-URL prefix, an oversized filename — raises a `TypeError`, and more than **15,000,000 base64 characters of file data in one request** (about 11 MB decoded) raises a `RangeError`. Both are your bugs rather than llmdispatch failures, so they pass through unwrapped with no error code and no attempt record, and neither message ever quotes your file's bytes or its filename (spec §6).
+
+That cap bounds file payload only, and it is llmdispatch's own ceiling rather than a promise that the request fits a given model. Tighter provider limits — per-image byte caps, page counts, total request size — surface as that provider's own error and classify like any other (spec §5b).
+
+**There is no capability model.** llmdispatch does not know which models read PDFs or images, and will not reroute around one that doesn't: a route aimed at a model that cannot take a file part fails with that provider's own error, which typically classifies as `invalid_request` and so does not fall back, though the classification follows whatever the provider actually answers (spec §5b). Point the route at a model that can read the file.
+
 ## Output: from model text to typed data
 
 Each operation declares its `format`: `'json'` (the default, a top-level JSON object), `'json-any'` (arrays and scalars), or `'text'`. Built-in adapters enable the provider's native JSON mode when the format is a top-level object and the provider genuinely supports it (verified per provider, spec §5c). Responses are unwrapped from a whole-response code fence if present, parsed, then validated with your Zod schema (async transforms supported). A parse or validation failure is an **output rejection**: fallback-eligible, never silently returned. An optional `quality` gate runs after validation:
@@ -92,7 +114,7 @@ Routing and daily limits live in the config store, with code-declared defaults u
 
 ```ts
 await ai.getConfig()                    // authoritative: { stored, effective } per operation
-await ai.setConfig('summarize', {       // replace-only, validated, last-write-wins (late/racing writes possible cross-process; CAS is v0.2), privileged
+await ai.setConfig('summarize', {       // replace-only, validated, last-write-wins (late/racing writes possible cross-process; CAS is deferred), privileged
   provider: 'openai',                   // must be a provider ID registered in code
   model: 'gpt-4.1-mini',
   quota: { perDay: 50 },                // optional: overrides the limit declared in code
@@ -187,7 +209,7 @@ createSwitch({
 })
 ```
 
-`result.cost` is a **simple input/output-token estimate** (cached-token discounts and request fees are out of scope in v0.1, spec §7), and it's `null` whenever any dispatched attempt is unpriced or has unknown usage. Explicitly unknown, never a misleading zero.
+`result.cost` is a **simple input/output-token estimate** (cached-token discounts and request fees are out of scope, spec §7), and it's `null` whenever any dispatched attempt is unpriced or has unknown usage. Explicitly unknown, never a misleading zero.
 
 ## TypeScript
 
@@ -195,7 +217,7 @@ Inference-first: operation names are typed (`ai.run('summarize', …)` compiles,
 
 ## Compatibility
 
-- **Node.js ≥ 20**, server-side only. Browsers and edge runtimes are not supported in v0.1.
+- **Node.js ≥ 20**, server-side only. Browsers and edge runtimes are not supported.
 - **No bundled runtime dependencies.** **Zod 4** is the one required peer you install alongside it.
 - **ESM and CJS** both supported, with explicit `exports` and bundled type declarations.
 - Postgres adapter: PostgreSQL ≥ 14, bring your own pool (any object with a `query` method, so `pg` works but isn't required by llmdispatch).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -93,8 +93,8 @@ Per-operation resolution matrix:
   caller deadline (ConfigStore has no cancellation contract), so a timed-out write may
   still land late and overwrite a subsequent write, in-process as well as cross-process.
   This is the documented last-write-wins/unknown-ack limitation; the deferred CAS/revision
-  mechanism (v0.2, settled) is the full fix. Custom ConfigStores must give the writing client
-  read-your-writes.
+  mechanism (settled, not in this contract) is the full fix. Custom ConfigStores must give
+  the writing client read-your-writes.
 - Admin method matrix (operation name validated first; unknown → `INVALID_INPUT`):
 
   | Method | Store call | Deadline | Failure → | Cache effect |
@@ -124,8 +124,8 @@ Per-operation resolution matrix:
    **`'text'`**. No schema introspection: text-shaped output schemas MUST set `'text'`.
 2. The adapter receives `responseFormat: { type: 'text' } | { type: 'json'; topLevel:
    'object' | 'any' }` and enables native generic JSON mode only per its §5c capability
-   rule AND `topLevel: 'object'`. Schema-constrained structured output is NOT v0.1;
-   the prompt carries the shape.
+   rule AND `topLevel: 'object'`. Schema-constrained structured output is NOT in this
+   contract; the prompt carries the shape.
 3. **Termination is checked before content**: adapters normalize termination metadata
    into `ProviderResponse.kind` (§5c). `'truncated'` classifies `truncated`; `'refused'`
    classifies `refused`; unknown terminal states are the ADAPTER'S job to map (unmappable →
@@ -186,7 +186,7 @@ active envelope.
   duplicate → no-op; conflicting payload after settlement → ignored (first write wins);
   pending/expired/**unknown** reservation → record attempts against the envelope's
   key/day without changing slot accounting. Attempt order = dispatch order.
-- **Settlement execution (v0.1, non-durable):** initial `settle` awaited (10s deadline)
+- **Settlement execution (non-durable):** initial `settle` awaited (10s deadline)
   in finalization, and settlement failure never changes an otherwise successful outcome,
   though delivery may be delayed by up to that deadline; then up to 3 detached retries
   (1s/5s/25s, same per-attempt deadline); remaining failure →
@@ -710,7 +710,7 @@ store that had to narrow the domain itself would not be substitutable.
 `ConfigStore.getAll` 5s; `set`/`delete` 10s (unknown-ack semantics per §2);
 `reserve`/`commit`/`snapshot` 10s; `settle` 10s per attempt including each detached retry.
 `getQuota` may spend both in sequence: a `getAll` that is not served from cache, then
-`snapshot`, so its worst case is 15s. Constants in v0.1.
+`snapshot`, so its worst case is 15s. Constants, not settings.
 
 ## 6b. Packaged operational surfaces (exact declarations)
 
@@ -758,11 +758,18 @@ export declare function runProviderConformance(opts: {
   requestFactory: () => ProviderRequest
   // 'success' is MANDATORY; each other scenario puts the adopter's backend into the named
   // condition and resolves when ready; the harness dispatches and asserts the resulting
-  // ProviderResponse.kind or ProviderError classification. Absent optional scenarios are
-  // reported in `skipped`: a skipped scenario means that classification is UNVERIFIED.
+  // ProviderResponse.kind or ProviderError classification. 'document' and 'image' are
+  // success-class instead: the backend answers normally and the harness dispatches that
+  // scenario's request from `requests` below. Absent optional scenarios are reported in
+  // `skipped`: a skipped scenario means that classification is UNVERIFIED.
   scenarios: { success: () => Promise<void> } & Partial<Record<
     'auth' | 'rate_limit' | 'model_not_found' | 'invalid_request' | 'transient'
-    | 'malformed_response' | 'truncated' | 'refused', () => Promise<void>>>
+    | 'malformed_response' | 'truncated' | 'refused' | 'document' | 'image', () => Promise<void>>>
+  // The request each media scenario dispatches, which MUST carry a file part of that
+  // scenario's media class: 'application/pdf' for document, an image/* type for image. A
+  // media scenario runs only when both its scenario callback and its request are supplied;
+  // with either absent it is reported in `skipped` like any other unsupplied scenario.
+  requests?: Partial<Record<'document' | 'image', () => ProviderRequest>>
   // Optional controls: declare JSON capability and observe dispatched requests so the
   // harness can verify responseFormat without guessing the provider's wire behaviour.
   controls?: {
@@ -790,7 +797,7 @@ aggregate field overflowed (field-wise clamp to `Number.MAX_SAFE_INTEGER` on ove
 `cost` = `inputTokens × inputPerM/1e6 + outputTokens × outputPerM/1e6` per attempt, priced
 by registered provider ID + model. Every dispatched attempt is potentially billable: if
 any dispatched attempt lacks usage or a price, aggregate `cost` is `null`. Cached-token
-discounts, tiered pricing, and request fees are out of scope in v0.1.
+discounts, tiered pricing, and request fees are out of scope.
 
 ## 8. Conformance suite (adopter-facing)
 
@@ -818,7 +825,17 @@ persists only a whitelist of route fields, needs updating. Coverage:
 - **Provider:** mandatory success dispatch (correct `kind`/text/usage shape); honors
   `signal`; classifies each supplied scenario via `ProviderResponse.kind` or
   `ProviderError`; respects `responseFormat` per its capability; normalizes usage or
-  returns `null`. Skipped optional scenarios are reported as unverified. Core-behavior
+  returns `null`; and carries two optional media scenarios, `document` and `image`. Those
+  two are success-class: the backend answers normally, and each is verified by dispatching
+  its own request from `requests` rather than the shared `requestFactory`, because what is
+  under test is a request carrying a file part. Each runs only when BOTH its scenario
+  callback and its matching request are supplied; with either absent it is reported as
+  unverified like any other unsupplied scenario. The dispatched request must carry a file
+  part of the scenario's media class — `application/pdf` for `document`, an `image/*` type
+  for `image` — so a text-only request fails the scenario rather than passing it, and the
+  dispatch must answer `kind: 'complete'` with the same text and usage shape the mandatory
+  success case requires. Skipped optional scenarios are reported as unverified.
+  Core-behavior
   checks are internal package tests, not part of this suite: state machine, matrices,
   sanitization, validation-on-read, default-restoration, effective-quota precedence
   (including a stored row without `quota`), a stored `quota` enabling subject enforcement and

--- a/scripts/live-check-providers.mjs
+++ b/scripts/live-check-providers.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
- * Calls every built-in adapter against its real provider, once with a plain prompt and once
- * asking for a JSON object, and checks that what comes back is what the package documents.
+ * Calls every built-in adapter against its real provider four times — a plain prompt, a request
+ * for a JSON object, an image and a PDF — and checks that what comes back is what the package
+ * documents.
  *
  * Recorded fixtures prove the adapters read the shapes that were recorded; only this proves
  * the providers still send them. Manual by design: it spends money and needs keys, so it is
@@ -53,8 +54,8 @@ const PROVIDERS = [
   { name: 'gemini', key: 'GEMINI_API_KEY', model: 'gemini-3.5-flash-lite' },
 ]
 
-/** Two calls to a live provider; anything beyond this is a hang, not a slow model. */
-const CHECK_DEADLINE = 2 * 60_000
+/** Four calls to a live provider, two of them carrying a file; beyond this it is a hang. */
+const CHECK_DEADLINE = 4 * 60_000
 
 /** The one adapter whose endpoint may be pointed elsewhere, and the name that does it. */
 const ENDPOINT_OVERRIDE = { provider: 'openai-compatible', name: 'OPENAI_BASE_URL' }

--- a/scripts/runners/live-check.mjs
+++ b/scripts/runners/live-check.mjs
@@ -2,10 +2,12 @@
 /**
  * One provider's live check, in a process that holds one provider's credential.
  *
- * Two calls: a plain one and one asking for a JSON object. Both have to come back complete,
- * with text, and with usage the package was able to normalize: a provider whose wire shape
- * has moved under the adapter shows up here as a null usage or a missing field, which is the
- * whole reason this check exists.
+ * Four calls: a plain one, one asking for a JSON object, one sending an image and one sending
+ * a PDF. All have to come back complete, with text, and with usage the package was able to
+ * normalize: a provider whose wire shape has moved under the adapter shows up here as a null
+ * usage or a missing field, which is the whole reason this check exists. The two media calls
+ * also have to answer what their fixture put in front of the model, so an adapter that sent a
+ * well-formed body the model never actually read cannot pass them.
  *
  * Nothing it prints carries a credential, a prompt, a request or a response body. The key is
  * read from the environment, never from an argument, and every line goes out through a
@@ -17,7 +19,7 @@
  *
  * Usage: node live-check.mjs <provider> <model> [--release]
  * With `--release` the package is required to come from the project this runner sits in.
- * Exit codes: 0 both calls were as documented, 1 one was not, 2 wrong usage.
+ * Exit codes: 0 every call was as documented, 1 one was not, 2 wrong usage.
  *
  * @module
  */
@@ -33,9 +35,25 @@ const KEYS = {
 
 /** Small enough that a run costs almost nothing, large enough for a one-line answer. */
 const MAX_OUTPUT_TOKENS = 64
-/** The two prompts, kept to a sentence each for the same reason. */
+/** The prompts, kept to a sentence each for the same reason. */
 const PLAIN_PROMPT = 'Reply with the single word: ready'
 const JSON_PROMPT = 'Reply with only this JSON object and nothing else: {"ok": true}'
+const IMAGE_PROMPT = 'Reply with the single word naming the colour of this image.'
+const DOCUMENT_PROMPT = 'Reply with the text of the attached document and nothing else.'
+
+/**
+ * The media fixtures and the answer each one admits.
+ *
+ * A 64x64 image of one colour and a one-page PDF carrying one invented word: a model that was
+ * handed either can say what is in it, and a model that was handed a well-formed request the
+ * provider never decoded cannot.
+ */
+const IMAGE_FIXTURE =
+  'iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAb0lEQVR4nO3PAQkAAAyEwO9feoshgnABdLep8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3IPanc8OLDQitxAAAAAElFTkSuQmCC'
+const IMAGE_ANSWER = 'red'
+const DOCUMENT_FIXTURE =
+  'JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA2MTIgNzkyXSAvQ29udGVudHMgNCAwIFIgL1Jlc291cmNlcyA8PCAvRm9udCA8PCAvRjEgNSAwIFIgPj4gPj4gPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0xlbmd0aCA0NCA+PgpzdHJlYW0KQlQgL0YxIDI0IFRmIDcyIDcwMCBUZCAoQ0lOTkFCQVJIRVJPTikgVGogRVQKZW5kc3RyZWFtCmVuZG9iago1IDAgb2JqCjw8IC9UeXBlIC9Gb250IC9TdWJ0eXBlIC9UeXBlMSAvQmFzZUZvbnQgL0hlbHZldGljYSA+PgplbmRvYmoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDA5IDAwMDAwIG4gCjAwMDAwMDAwNTggMDAwMDAgbiAKMDAwMDAwMDExNSAwMDAwMCBuIAowMDAwMDAwMjQxIDAwMDAwIG4gCjAwMDAwMDAzMzUgMDAwMDAgbiAKdHJhaWxlcgo8PCAvU2l6ZSA2IC9Sb290IDEgMCBSID4+CnN0YXJ0eHJlZgo0MDUKJSVFT0YK'
+const DOCUMENT_ANSWER = 'CINNABARHERON'
 
 /** A credential can only be printed if it is in the string; this makes sure it is not. */
 function redactor(secret) {
@@ -73,6 +91,22 @@ function checkResponse(label, response, problems) {
     if (!Number.isSafeInteger(value) || value < 0) {
       problems.push(`${label}: ${field} was not a non-negative whole number`)
     }
+  }
+}
+
+/**
+ * Whether a media call's answer carries what its fixture put in front of the model.
+ *
+ * Matched on word boundaries, not as a substring: 'red' sits inside 'rendered' and 'coloured',
+ * so a substring test passes answers that never name the colour at all.
+ *
+ * The expected word is never printed: it is part of a prompt, and this runner quotes neither
+ * prompts nor answers.
+ */
+function checkAnswer(label, response, expected, problems) {
+  if (response.kind !== 'complete') return
+  if (!new RegExp(`\\b${expected}\\b`, 'i').test(response.text)) {
+    problems.push(`${label}: the answer did not carry what the fixture put in the request`)
   }
 }
 
@@ -139,17 +173,18 @@ async function main() {
   // One controller for the whole run, so an interrupt reaches the call in flight.
   const inFlight = new AbortController()
   abortOnSignal(inFlight)
-  const request = (prompt, responseFormat) => ({
-    parts: [{ type: 'text', text: prompt }],
+  const request = (parts, responseFormat) => ({
+    parts,
     model,
     responseFormat,
     maxOutputTokens: MAX_OUTPUT_TOKENS,
     temperature: 0,
     signal: inFlight.signal,
   })
+  const text = (prompt) => [{ type: 'text', text: prompt }]
 
   try {
-    const plain = await prepared.complete(request(PLAIN_PROMPT, { type: 'text' }))
+    const plain = await prepared.complete(request(text(PLAIN_PROMPT), { type: 'text' }))
     checkResponse('the plain call', plain, problems)
   } catch (error) {
     problems.push(`the plain call: ${describeFailure(error, ProviderError)}`)
@@ -157,7 +192,7 @@ async function main() {
 
   try {
     const json = await prepared.complete(
-      request(JSON_PROMPT, { type: 'json', topLevel: 'object' }),
+      request(text(JSON_PROMPT), { type: 'json', topLevel: 'object' }),
     )
     checkResponse('the JSON call', json, problems)
     if (json.kind === 'complete') checkJsonShape(json.text, problems)
@@ -165,9 +200,45 @@ async function main() {
     problems.push(`the JSON call: ${describeFailure(error, ProviderError)}`)
   }
 
+  try {
+    const image = await prepared.complete(
+      request(
+        [...text(IMAGE_PROMPT), { type: 'file', mediaType: 'image/png', data: IMAGE_FIXTURE }],
+        { type: 'text' },
+      ),
+    )
+    checkResponse('the image call', image, problems)
+    checkAnswer('the image call', image, IMAGE_ANSWER, problems)
+  } catch (error) {
+    problems.push(`the image call: ${describeFailure(error, ProviderError)}`)
+  }
+
+  // Sent to every adapter: all three map PDFs, so a model that will not take one is a result
+  // this check reports rather than something it routes around.
+  try {
+    const document = await prepared.complete(
+      request(
+        [
+          ...text(DOCUMENT_PROMPT),
+          {
+            type: 'file',
+            mediaType: 'application/pdf',
+            data: DOCUMENT_FIXTURE,
+            filename: 'live-check.pdf',
+          },
+        ],
+        { type: 'text' },
+      ),
+    )
+    checkResponse('the document call', document, problems)
+    checkAnswer('the document call', document, DOCUMENT_ANSWER, problems)
+  } catch (error) {
+    problems.push(`the document call: ${describeFailure(error, ProviderError)}`)
+  }
+
   for (const problem of problems) process.stdout.write(redact(`${problem}\n`))
   if (problems.length === 0) {
-    process.stdout.write(`${provider}: both calls completed with normalized usage\n`)
+    process.stdout.write(`${provider}: all four calls completed with normalized usage\n`)
   }
   return problems.length === 0 ? 0 : 1
 }

--- a/scripts/runners/release-conformance.mjs
+++ b/scripts/runners/release-conformance.mjs
@@ -30,6 +30,12 @@ import { assertInstalledPackageResolves } from './subpath-resolution.mjs'
 const TEMPLATE = join(import.meta.dirname, 'openai-chat-completion.json')
 /** Not a key and not shaped like one: the fixture only checks that it arrives verbatim. */
 const FIXTURE_KEY = 'fixture-credential-for-the-release-check'
+/** A 64x64 solid red PNG, base64. The media scenarios need a real file part to dispatch. */
+const IMAGE_FIXTURE =
+  'iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAb0lEQVR4nO3PAQkAAAyEwO9feoshgnABdLep8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3I8QUNyPEFDcjxBQ3IPanc8OLDQitxAAAAAElFTkSuQmCC'
+/** A one-page PDF, base64. */
+const DOCUMENT_FIXTURE =
+  'JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA2MTIgNzkyXSAvQ29udGVudHMgNCAwIFIgL1Jlc291cmNlcyA8PCAvRm9udCA8PCAvRjEgNSAwIFIgPj4gPj4gPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0xlbmd0aCA0NCA+PgpzdHJlYW0KQlQgL0YxIDI0IFRmIDcyIDcwMCBUZCAoQ0lOTkFCQVJIRVJPTikgVGogRVQKZW5kc3RyZWFtCmVuZG9iago1IDAgb2JqCjw8IC9UeXBlIC9Gb250IC9TdWJ0eXBlIC9UeXBlMSAvQmFzZUZvbnQgL0hlbHZldGljYSA+PgplbmRvYmoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDA5IDAwMDAwIG4gCjAwMDAwMDAwNTggMDAwMDAgbiAKMDAwMDAwMDExNSAwMDAwMCBuIAowMDAwMDAwMjQxIDAwMDAwIG4gCjAwMDAwMDAzMzUgMDAwMDAgbiAKdHJhaWxlcgo8PCAvU2l6ZSA2IC9Sb290IDEgMCBSID4+CnN0YXJ0eHJlZgo0MDUKJSVFT0YK'
 
 /* ------------------------------------------------------------------ the guard ---- */
 
@@ -56,7 +62,9 @@ async function importInstalledPackage() {
  *
  * The provider suite puts the backend into a named condition and then dispatches; this server
  * is that backend. Every classification row the built-in adapter documents is covered here, so
- * the suite reports nothing as unverified: a release must not ship on a partial answer.
+ * the suite reports nothing as unverified: a release must not ship on a partial answer. The
+ * media scenarios need no condition of their own, being success-class; what they verify is the
+ * request the suite dispatches for them.
  */
 function renderScenario(template, scenario) {
   const body = structuredClone(template)
@@ -231,17 +239,18 @@ async function runProviderSuite(state, port) {
     state.scenario = scenario
     return Promise.resolve()
   }
+  const request = (parts) => ({
+    parts,
+    // The model the fixture's recorded response names; anything else and the backend would
+    // answer with a body claiming to be a different model.
+    model: state.model,
+    responseFormat: { type: 'text' },
+    maxOutputTokens: 16,
+    signal: new AbortController().signal,
+  })
   return installed.conformance.runProviderConformance({
     provider,
-    requestFactory: () => ({
-      parts: [{ type: 'text', text: 'reply with {"ok":true}' }],
-      // The model the fixture's recorded response names; anything else and the backend would
-      // answer with a body claiming to be a different model.
-      model: state.model,
-      responseFormat: { type: 'text' },
-      maxOutputTokens: 16,
-      signal: new AbortController().signal,
-    }),
+    requestFactory: () => request([{ type: 'text', text: 'reply with {"ok":true}' }]),
     scenarios: {
       success: enter('success'),
       auth: enter('auth'),
@@ -252,6 +261,27 @@ async function runProviderSuite(state, port) {
       malformed_response: enter('malformed_response'),
       truncated: enter('truncated'),
       refused: enter('refused'),
+      // The media scenarios are success-class, and they are driven after the error ones, so
+      // each re-enters the success condition rather than inheriting the last one set.
+      document: enter('success'),
+      image: enter('success'),
+    },
+    requests: {
+      document: () =>
+        request([
+          { type: 'text', text: 'reply with {"ok":true}' },
+          {
+            type: 'file',
+            mediaType: 'application/pdf',
+            data: DOCUMENT_FIXTURE,
+            filename: 'release-check.pdf',
+          },
+        ]),
+      image: () =>
+        request([
+          { type: 'text', text: 'reply with {"ok":true}' },
+          { type: 'file', mediaType: 'image/png', data: IMAGE_FIXTURE },
+        ]),
     },
     controls: { jsonCapability: 'native' },
   })

--- a/src/conformance/provider.ts
+++ b/src/conformance/provider.ts
@@ -15,7 +15,7 @@ import type {
   TokenUsage,
 } from '../types'
 
-/** Optional scenarios the harness can drive when the adopter supplies them. */
+/** Optional classification scenarios the harness can drive when the adopter supplies them. */
 type OptionalScenario =
   | 'auth'
   | 'rate_limit'
@@ -37,6 +37,17 @@ const OPTIONAL: readonly OptionalScenario[] = [
   'refused',
 ]
 
+/** Optional media scenarios: success-class conditions dispatching a request that carries a file. */
+type MediaScenario = 'document' | 'image'
+
+const MEDIA: readonly MediaScenario[] = ['document', 'image']
+
+/** What each media scenario's request has to carry, in the words its failure message uses. */
+const MEDIA_EXPECTATION: Readonly<Record<MediaScenario, string>> = {
+  document: "an 'application/pdf' file part",
+  image: 'an image file part',
+}
+
 /** Controls that let the suite verify responseFormat and capability without guessing. */
 export interface ProviderConformanceControls {
   /** Declares whether the provider under test supports native JSON mode. */
@@ -49,14 +60,16 @@ export interface ProviderConformanceControls {
  * Checks a `Provider` against the behaviour spec §8 requires of one.
  *
  * `success` is mandatory. Absent optional scenarios are reported in `skipped` (unverified).
+ * A media scenario also needs its request in `requests`; either half absent and it is skipped.
  * `passed` is true exactly when `failures` is empty.
  */
 export async function runProviderConformance(opts: {
   provider: Provider
   requestFactory: () => ProviderRequest
   scenarios: { success: () => Promise<void> } & Partial<
-    Record<OptionalScenario, () => Promise<void>>
+    Record<OptionalScenario | MediaScenario, () => Promise<void>>
   >
+  requests?: Partial<Record<MediaScenario, () => ProviderRequest>>
   controls?: ProviderConformanceControls
 }): Promise<ConformanceResult> {
   const failures: string[] = []
@@ -145,7 +158,42 @@ export async function runProviderConformance(opts: {
     }
   }
 
+  for (const name of MEDIA) {
+    const setup = opts.scenarios[name]
+    const requestFactory = opts.requests?.[name]
+    if (setup === undefined || requestFactory === undefined) {
+      skipped.push(name)
+      continue
+    }
+    try {
+      await setup()
+      const req = requestFactory()
+      // Guarded before dispatch: a text-only request would pass the success assertion below
+      // while proving nothing about the media the scenario names.
+      if (!carriesMedia(name, req)) {
+        failures.push(
+          `${name}: expected a request carrying ${MEDIA_EXPECTATION[name]} but it carried none`,
+        )
+        continue
+      }
+      assertSuccess(await dispatch(req), failures, name)
+    } catch (error) {
+      failures.push(`${name}: ${thrown(error)}`)
+    }
+  }
+
   return { passed: failures.length === 0, failures, skipped }
+}
+
+/** Whether a request carries a file part of the scenario's media class (spec §6b). */
+function carriesMedia(name: MediaScenario, req: ProviderRequest): boolean {
+  return req.parts.some(
+    (part) =>
+      part.type === 'file' &&
+      (name === 'document'
+        ? part.mediaType === 'application/pdf'
+        : part.mediaType.startsWith('image/')),
+  )
 }
 
 function assertSuccess(response: ProviderResponse, failures: string[], label: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,7 @@
  * The only module that assembles the pieces: the factory that turns providers, operations
  * and stores into a working switch, the built-in adapters, the in-memory stores, the errors,
  * and the types describing them. The surface is spec §6, listed name by name rather than
- * re-exported wholesale so a new declaration cannot reach adopters by accident. The package
- * is pre-release; the remaining values land before the first publish.
+ * re-exported wholesale so a new declaration cannot reach adopters by accident.
  *
  * @module
  */

--- a/test/types/spec-surface-conformance.d.ts
+++ b/test/types/spec-surface-conformance.d.ts
@@ -32,11 +32,18 @@ export declare function runProviderConformance(opts: {
   requestFactory: () => ProviderRequest
   // 'success' is MANDATORY; each other scenario puts the adopter's backend into the named
   // condition and resolves when ready; the harness dispatches and asserts the resulting
-  // ProviderResponse.kind or ProviderError classification. Absent optional scenarios are
-  // reported in `skipped`: a skipped scenario means that classification is UNVERIFIED.
+  // ProviderResponse.kind or ProviderError classification. 'document' and 'image' are
+  // success-class instead: the backend answers normally and the harness dispatches that
+  // scenario's request from `requests` below. Absent optional scenarios are reported in
+  // `skipped`: a skipped scenario means that classification is UNVERIFIED.
   scenarios: { success: () => Promise<void> } & Partial<Record<
     'auth' | 'rate_limit' | 'model_not_found' | 'invalid_request' | 'transient'
-    | 'malformed_response' | 'truncated' | 'refused', () => Promise<void>>>
+    | 'malformed_response' | 'truncated' | 'refused' | 'document' | 'image', () => Promise<void>>>
+  // The request each media scenario dispatches, which MUST carry a file part of that
+  // scenario's media class: 'application/pdf' for document, an image/* type for image. A
+  // media scenario runs only when both its scenario callback and its request are supplied;
+  // with either absent it is reported in `skipped` like any other unsupplied scenario.
+  requests?: Partial<Record<'document' | 'image', () => ProviderRequest>>
   // Optional controls: declare JSON capability and observe dispatched requests so the
   // harness can verify responseFormat without guessing the provider's wire behaviour.
   controls?: {

--- a/test/unit/conformance/provider-runner.test.ts
+++ b/test/unit/conformance/provider-runner.test.ts
@@ -27,7 +27,12 @@ const OPTIONAL_ORDER = [
   'malformed_response',
   'truncated',
   'refused',
+  'document',
+  'image',
 ]
+
+/** Base64 short enough to read; no adapter here decodes it. */
+const FILE_DATA = 'AAAA'
 
 type Handler = (req: ProviderRequest) => ProviderResponse | Promise<ProviderResponse>
 
@@ -162,6 +167,150 @@ describe('runner behavior', () => {
   })
 })
 
+describe('media scenarios', () => {
+  const pdfRequest = () =>
+    baseRequest({
+      parts: [
+        { type: 'text', text: 'read it' },
+        { type: 'file', mediaType: 'application/pdf', data: FILE_DATA },
+      ],
+    })
+  const imageRequest = () =>
+    baseRequest({
+      parts: [
+        { type: 'text', text: 'look at it' },
+        { type: 'file', mediaType: 'image/png', data: FILE_DATA },
+      ],
+    })
+
+  it('passes both when each has a scenario and a request carrying its media class', async () => {
+    const { provider } = scriptedProvider()
+    const result = await runProviderConformance({
+      provider,
+      requestFactory: () => baseRequest(),
+      scenarios: {
+        success: step(() => undefined),
+        document: step(() => undefined),
+        image: step(() => undefined),
+      },
+      requests: { document: pdfRequest, image: imageRequest },
+    })
+    expect(result.failures).toEqual([])
+    expect(result.skipped).not.toContain('document')
+    expect(result.skipped).not.toContain('image')
+  })
+
+  it('dispatches each media scenario its own request, not the shared requestFactory', async () => {
+    const { provider } = scriptedProvider()
+    const seen: ProviderRequest[] = []
+    await runProviderConformance({
+      provider,
+      requestFactory: () => baseRequest(),
+      scenarios: { success: step(() => undefined), image: step(() => undefined) },
+      requests: { image: imageRequest },
+      controls: { observeRequest: (req) => seen.push(req) },
+    })
+    expect(seen.at(-1)!.parts).toContainEqual({
+      type: 'file',
+      mediaType: 'image/png',
+      data: FILE_DATA,
+    })
+  })
+
+  it('skips a media scenario whose request is missing, and the other way round', async () => {
+    const { provider } = scriptedProvider()
+    const result = await runProviderConformance({
+      provider,
+      requestFactory: () => baseRequest(),
+      scenarios: { success: step(() => undefined), document: step(() => undefined) },
+      requests: { image: imageRequest },
+    })
+    expect(result.skipped).toContain('document')
+    expect(result.skipped).toContain('image')
+    expect(result.failures).toEqual([])
+  })
+
+  it('fails a media scenario whose request carries no file part at all', async () => {
+    const { provider } = scriptedProvider()
+    const result = await runProviderConformance({
+      provider,
+      requestFactory: () => baseRequest(),
+      scenarios: { success: step(() => undefined), document: step(() => undefined) },
+      requests: { document: () => baseRequest() },
+    })
+    expect(result.failures).toContainEqual(
+      expect.stringContaining("document: expected a request carrying an 'application/pdf'"),
+    )
+  })
+
+  it('fails the document scenario whose file part is an image instead', async () => {
+    const { provider } = scriptedProvider()
+    const result = await runProviderConformance({
+      provider,
+      requestFactory: () => baseRequest(),
+      scenarios: { success: step(() => undefined), document: step(() => undefined) },
+      requests: { document: imageRequest },
+    })
+    expect(result.failures).toContainEqual(
+      expect.stringContaining("document: expected a request carrying an 'application/pdf'"),
+    )
+  })
+
+  it('fails the image scenario whose file part is a document instead', async () => {
+    const { provider } = scriptedProvider()
+    const result = await runProviderConformance({
+      provider,
+      requestFactory: () => baseRequest(),
+      scenarios: { success: step(() => undefined), image: step(() => undefined) },
+      requests: { image: pdfRequest },
+    })
+    expect(result.failures).toContainEqual(
+      expect.stringContaining('image: expected a request carrying an image file part'),
+    )
+  })
+
+  it('fails a media scenario answered with a response that is not complete', async () => {
+    const { provider, set } = scriptedProvider()
+    const result = await runProviderConformance({
+      provider,
+      requestFactory: () => baseRequest(),
+      scenarios: {
+        success: step(() => undefined),
+        // Set inside the scenario, so only the media dispatch answers this way.
+        document: step(() => {
+          set(() => ({
+            kind: 'truncated',
+            text: 'partial',
+            usage: { inputTokens: 1, outputTokens: 1 },
+          }))
+        }),
+      },
+      requests: { document: pdfRequest },
+    })
+    expect(result.failures).toContainEqual(
+      "document: expected kind 'complete' but was 'truncated'",
+    )
+  })
+
+  it('fails a media scenario the provider rejects with a ProviderError', async () => {
+    const { provider, set } = scriptedProvider()
+    const result = await runProviderConformance({
+      provider,
+      requestFactory: () => baseRequest(),
+      scenarios: {
+        success: step(() => undefined),
+        image: step(() => {
+          set(throwing('invalid_request'))
+        }),
+      },
+      requests: { image: imageRequest },
+    })
+    expect(result.failures).toContainEqual(
+      expect.stringContaining('image: ProviderError(invalid_request)'),
+    )
+  })
+})
+
 describe('nonconforming fakes', () => {
   it('fails when the success scenario answers with the wrong ProviderResponse shape', async () => {
     const { provider, set } = scriptedProvider()
@@ -264,6 +413,26 @@ describe('responseFormat duty', () => {
 describe('the built-in adapters, driven end to end through the runner', () => {
   const KEY = () => 'sk-test'
 
+  /** The media requests for one adapter's model, each carrying the part its scenario checks. */
+  const mediaRequests = (model: string) => ({
+    document: () =>
+      baseRequest({
+        model,
+        parts: [
+          { type: 'text', text: 'read it' },
+          { type: 'file', mediaType: 'application/pdf', data: FILE_DATA },
+        ],
+      }),
+    image: () =>
+      baseRequest({
+        model,
+        parts: [
+          { type: 'text', text: 'look at it' },
+          { type: 'file', mediaType: 'image/png', data: FILE_DATA },
+        ],
+      }),
+  })
+
   it('passes openaiCompatible over scripted fetch, native json capability', async () => {
     const provider = openaiCompatible({ apiKey: KEY })
     const chatBody = (finishReason: string, content: string, refusal?: string) => ({
@@ -294,7 +463,14 @@ describe('the built-in adapters, driven end to end through the runner', () => {
           installFetch(() => jsonResponse(200, chatBody('length', 'partial'))),
         ),
         refused: step(() => installFetch(() => jsonResponse(200, chatBody('stop', '', 'no')))),
+        document: step(() =>
+          installFetch(() => jsonResponse(200, chatBody('stop', '{"ok":true}'))),
+        ),
+        image: step(() =>
+          installFetch(() => jsonResponse(200, chatBody('stop', '{"ok":true}'))),
+        ),
       },
+      requests: mediaRequests('gpt-x'),
       controls: { jsonCapability: 'native' },
     })
     expect(result).toEqual({ passed: true, failures: [], skipped: [] })
@@ -326,7 +502,14 @@ describe('the built-in adapters, driven end to end through the runner', () => {
           installFetch(() => jsonResponse(200, messageBody('max_tokens', 'partial'))),
         ),
         refused: step(() => installFetch(() => jsonResponse(200, messageBody('refusal', '')))),
+        document: step(() =>
+          installFetch(() => jsonResponse(200, messageBody('end_turn', '{"ok":true}'))),
+        ),
+        image: step(() =>
+          installFetch(() => jsonResponse(200, messageBody('end_turn', '{"ok":true}'))),
+        ),
       },
+      requests: mediaRequests('claude-x'),
       controls: { jsonCapability: 'prompt-only' },
     })
     expect(result).toEqual({ passed: true, failures: [], skipped: ['responseFormat:native'] })
@@ -357,7 +540,14 @@ describe('the built-in adapters, driven end to end through the runner', () => {
           installFetch(() => jsonResponse(200, generateBody('MAX_TOKENS', 'partial'))),
         ),
         refused: step(() => installFetch(() => jsonResponse(200, generateBody('SAFETY', '')))),
+        document: step(() =>
+          installFetch(() => jsonResponse(200, generateBody('STOP', '{"ok":true}'))),
+        ),
+        image: step(() =>
+          installFetch(() => jsonResponse(200, generateBody('STOP', '{"ok":true}'))),
+        ),
       },
+      requests: mediaRequests('gemini-x'),
       controls: { jsonCapability: 'prompt-only' },
     })
     expect(result).toEqual({ passed: true, failures: [], skipped: ['responseFormat:native'] })


### PR DESCRIPTION
### What's in it

The provider conformance runner gains optional `document` and `image` scenarios: each needs both its scenario callback and a matching request factory, the dispatched request must actually carry the named media class, and the answer must be a complete response — a text-only request or a truncated answer fails the scenario. The release checks supply both end to end, so their fail-on-any-skip rule still holds. The live check sends each provider a solid-red PNG and a one-page PDF with a known word and requires the answer to name what it saw. README and guide get a short document-and-image section, a changeset covers the conformance surface, and the stale pre-release phrasing is swept out.

Deliberately not here: the version bump. `npx changeset version` plus the lockfile refresh is its own reviewed commit at release time, per RELEASING.md.

### How to check it

`test/unit/conformance/provider-runner.test.ts` holds the media-scenario battery — the success-assertion and media-class tests were each verified to fail against a deliberately weakened runner before landing. The §6b fence diff is the conformance surface change; `surface:update`/`api:update` outputs are committed.

### Acceptance

- [ ] Media scenarios cannot pass on a text-only request or a non-complete answer
- [ ] `release-conformance` reports zero skips with the media scenarios wired
- [ ] Live-check media calls keep the no-quoting redaction discipline
- [ ] No version or lockfile change anywhere in the stack

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
