### PR TITLE
feat: configurable base url for the anthropic adapter

### DIFF
--- a/.changeset/anthropic-base-url.md
+++ b/.changeset/anthropic-base-url.md
@@ -1,0 +1,5 @@
+---
+'llmdispatch': minor
+---
+
+`anthropic()` accepts a `baseUrl`, defaulting to `https://api.anthropic.com`, so Anthropic-format endpoints on other hosts are reachable the same way OpenAI-compatible ones already are.

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -50,6 +50,7 @@ declare class ProviderError extends Error {
 /** Builds an Anthropic Messages provider. Keys resolve in `prepare()`, not at construction. */
 declare function anthropic(opts: {
   apiKey: ApiKeyResolver;
+  baseUrl?: string;
 }): Provider;
 //#endregion
 //#region src/providers/openai-compatible.d.ts

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -75,9 +75,10 @@ Errors ([OpenAI error codes](https://developers.openai.com/api/docs/guides/error
 
 ## `anthropic`
 
-**`anthropic({ apiKey })`, native Messages API.** `POST
-https://api.anthropic.com/v1/messages`; **`x-api-key`** + required
-**`anthropic-version: 2023-06-01`**. ([Anthropic Messages](https://docs.anthropic.com/en/api/messages);
+**`anthropic({ apiKey, baseUrl? })`, native Messages API.** Default `baseUrl`
+`https://api.anthropic.com`; `POST {baseUrl}/v1/messages`; **`x-api-key`** + required
+**`anthropic-version: 2023-06-01`**. A non-default `baseUrl` promises this wire format,
+not any third-party host's fidelity to it. ([Anthropic Messages](https://docs.anthropic.com/en/api/messages);
 the OpenAI-compat layer is not used: it ignores `response_format` and is documented as a
 testing tool: [Anthropic OpenAI SDK compat](https://docs.anthropic.com/en/api/openai-sdk))
 Request: `model`, `max_tokens` (**always sent**, required by Anthropic; default 4096 when

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -365,9 +365,10 @@ Errors ([OpenAI error codes](https://developers.openai.com/api/docs/guides/error
 400/413/422 → `invalid_request`; unparseable body → classify by status; unknown status →
 `transient` (a real HTTP outcome, unlike unclassified thrown values).
 
-**`anthropic({ apiKey })`, native Messages API.** `POST
-https://api.anthropic.com/v1/messages`; **`x-api-key`** + required
-**`anthropic-version: 2023-06-01`**. ([Anthropic Messages](https://docs.anthropic.com/en/api/messages);
+**`anthropic({ apiKey, baseUrl? })`, native Messages API.** Default `baseUrl`
+`https://api.anthropic.com`; `POST {baseUrl}/v1/messages`; **`x-api-key`** + required
+**`anthropic-version: 2023-06-01`**. A non-default `baseUrl` promises this wire format,
+not any third-party host's fidelity to it. ([Anthropic Messages](https://docs.anthropic.com/en/api/messages);
 the OpenAI-compat layer is not used: it ignores `response_format` and is documented as a
 testing tool: [Anthropic OpenAI SDK compat](https://docs.anthropic.com/en/api/openai-sdk))
 Request: `model`, `max_tokens` (**always sent**, required by Anthropic; default 4096 when
@@ -592,7 +593,7 @@ export declare class ProviderError extends Error {
 }
 
 // built-in factories (fetch-based, zero dependencies; implement prepare(); wire contracts §5c)
-export declare function anthropic(opts: { apiKey: ApiKeyResolver }): Provider
+export declare function anthropic(opts: { apiKey: ApiKeyResolver; baseUrl?: string }): Provider
 export declare function openaiCompatible(opts: {
   apiKey: ApiKeyResolver
   baseUrl?: string

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -22,12 +22,17 @@ import {
   classifyByStatusFamily,
 } from './transport'
 
-const ENDPOINT = 'https://api.anthropic.com/v1/messages'
+const DEFAULT_BASE = 'https://api.anthropic.com'
 const VERSION = '2023-06-01'
 const DEFAULT_MAX_TOKENS = 4096
 
+function normalizeBase(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '')
+}
+
 /** Builds an Anthropic Messages provider. Keys resolve in `prepare()`, not at construction. */
-export function anthropic(opts: { apiKey: ApiKeyResolver }): Provider {
+export function anthropic(opts: { apiKey: ApiKeyResolver; baseUrl?: string }): Provider {
+  const endpoint = `${normalizeBase(opts.baseUrl ?? DEFAULT_BASE)}/v1/messages`
   return {
     async prepare(): Promise<PreparedProvider> {
       const key = await opts.apiKey()
@@ -37,7 +42,7 @@ export function anthropic(opts: { apiKey: ApiKeyResolver }): Provider {
       const apiKey = key
       return {
         complete(req: ProviderRequest): Promise<ProviderResponse> {
-          return completeAnthropic(apiKey, req)
+          return completeAnthropic(apiKey, endpoint, req)
         },
       }
     },
@@ -63,6 +68,7 @@ function anthropicContent(parts: readonly ContentPart[]): string | unknown[] {
 
 async function completeAnthropic(
   apiKey: string,
+  endpoint: string,
   req: ProviderRequest,
 ): Promise<ProviderResponse> {
   const body: Record<string, unknown> = {
@@ -74,7 +80,7 @@ async function completeAnthropic(
     body.temperature = Math.min(1, Math.max(0, req.temperature))
   }
 
-  const http = await fetchJson(ENDPOINT, {
+  const http = await fetchJson(endpoint, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',

--- a/test/types/spec-surface.d.ts
+++ b/test/types/spec-surface.d.ts
@@ -161,7 +161,7 @@ export declare class ProviderError extends Error {
 }
 
 // built-in factories (fetch-based, zero dependencies; implement prepare(); wire contracts §5c)
-export declare function anthropic(opts: { apiKey: ApiKeyResolver }): Provider
+export declare function anthropic(opts: { apiKey: ApiKeyResolver; baseUrl?: string }): Provider
 export declare function openaiCompatible(opts: {
   apiKey: ApiKeyResolver
   baseUrl?: string

--- a/test/unit/providers/anthropic.test.ts
+++ b/test/unit/providers/anthropic.test.ts
@@ -29,11 +29,26 @@ const OK_BODY = {
 }
 
 describe('request shape', () => {
-  it('posts to the fixed Messages endpoint', async () => {
+  // A wrong baseUrl join or a missing trailing-slash strip sends every request to a 404.
+  it.each([
+    ['default baseUrl', undefined, 'https://api.anthropic.com/v1/messages'],
+    [
+      'custom baseUrl, no trailing slash',
+      'https://example.com/anthropic',
+      'https://example.com/anthropic/v1/messages',
+    ],
+    [
+      'custom baseUrl, trailing slash',
+      'https://example.com/anthropic/',
+      'https://example.com/anthropic/v1/messages',
+    ],
+  ])('posts to the Messages endpoint: %s', async (_label, baseUrl, expectedUrl) => {
     const { requests } = captureRequests(() => jsonResponse(200, OK_BODY))
-    const run = await complete()
+    const run = await withPrepared(
+      anthropic({ apiKey: KEY, ...(baseUrl === undefined ? {} : { baseUrl }) }),
+    )
     await run(baseRequest())
-    expect(requests[0]!.url).toBe('https://api.anthropic.com/v1/messages')
+    expect(requests[0]!.url).toBe(expectedUrl)
     expect(requests[0]!.method).toBe('POST')
   })
 


### PR DESCRIPTION
Closes #32.

## What's in it

`anthropic()` takes an optional `baseUrl`, defaulting to `https://api.anthropic.com`, mirroring the option `openaiCompatible` has always had. The endpoint is resolved once at registration (`{baseUrl}/v1/messages`, trailing slashes stripped the same way), and nothing else about the adapter moves: headers, version pin, error mapping, content mapping and the one-request-per-attempt rule are untouched. With no option the adapter behaves byte-identically to before.

Spec §5c and §6 carry the new signature, with the honesty caveat that a non-default host gets the wire format promised, not any third party's fidelity to it. `docs/providers.md` is regenerated, the recorded API surface is updated, and a minor changeset rides along.

## How to check it

`npm test` and `npm run check` are green (865 tests, full battery). The endpoint tests in `test/unit/providers/anthropic.test.ts` now cover the default, a custom base, and a trailing-slash base. Checked live against DeepSeek's Anthropic-format endpoint: `anthropic({ baseUrl: 'https://api.deepseek.com/anthropic' })` with `deepseek-v4-flash` returned a `complete` response with usage reported.

## Acceptance

- Default construction hits `https://api.anthropic.com/v1/messages` exactly as before; the pinned request-body expectations did not change.
- A custom `baseUrl`, with or without trailing slash, posts to `{base}/v1/messages`.
- Spec, generated provider reference, spec-surface fixture and recorded API surface all agree on the new signature.
