### PR TITLE
fix: pin a live-check OpenAI model that reads images

### DIFF
--- a/scripts/live-check-providers.mjs
+++ b/scripts/live-check-providers.mjs
@@ -44,13 +44,16 @@ const USAGE = 'usage: live-check-providers.mjs [--release <path-to-tgz>]\n'
 /**
  * The adapters, each with the credential it needs and the model it is checked on.
  *
- * The models are the smallest each provider offers, and the runner asks for a handful of
- * tokens: a full run should cost a fraction of a cent. Change them here when a provider
- * retires one: nowhere else names a model.
+ * The models are the smallest each provider offers that handle every checked modality,
+ * and the runner asks for a handful of tokens: a full run should cost a fraction of a
+ * cent. Change them here when a provider retires one: nowhere else names a model.
+ * gpt-4.1-nano and gpt-4.1-mini are out: OpenAI silently drops image parts for both
+ * (verified against the raw endpoint — the request carries the image, the reported
+ * prompt tokens show it never reached the model), so they cannot pass the image check.
  */
 const PROVIDERS = [
   { name: 'anthropic', key: 'ANTHROPIC_API_KEY', model: 'claude-haiku-4-5' },
-  { name: 'openai-compatible', key: 'OPENAI_API_KEY', model: 'gpt-4.1-nano' },
+  { name: 'openai-compatible', key: 'OPENAI_API_KEY', model: 'gpt-4o-mini' },
   { name: 'gemini', key: 'GEMINI_API_KEY', model: 'gemini-3.5-flash-lite' },
 ]
 


### PR DESCRIPTION
Release verification of 0.2.0 failed its openai-compatible image call: gpt-4.1-nano, like gpt-4.1-mini, silently drops image parts at the endpoint (the raw request carries the image; the reported prompt tokens show it never reached the model). The adapter is fine — the tarball's conformance suites and the other adapters' live checks all pass. gpt-4o-mini is the smallest OpenAI model that handles every checked modality, so the harness pins that instead, with the reasoning recorded where the models are named. Harness only; no package code.