### PR TITLE
fix: the openai live-check model must pass the document check too

### DIFF
--- a/scripts/live-check-providers.mjs
+++ b/scripts/live-check-providers.mjs
@@ -47,13 +47,14 @@ const USAGE = 'usage: live-check-providers.mjs [--release <path-to-tgz>]\n'
  * The models are the smallest each provider offers that handle every checked modality,
  * and the runner asks for a handful of tokens: a full run should cost a fraction of a
  * cent. Change them here when a provider retires one: nowhere else names a model.
- * gpt-4.1-nano and gpt-4.1-mini are out: OpenAI silently drops image parts for both
- * (verified against the raw endpoint — the request carries the image, the reported
- * prompt tokens show it never reached the model), so they cannot pass the image check.
+ * For OpenAI that is not a small model at all: gpt-4.1-nano and gpt-4.1-mini silently
+ * drop image parts (verified against the raw endpoint — the request carries the image,
+ * the reported prompt tokens show it never reached the model), and gpt-4o-mini reads
+ * images but fails the document check. gpt-4.1 is the smallest that passes all four.
  */
 const PROVIDERS = [
   { name: 'anthropic', key: 'ANTHROPIC_API_KEY', model: 'claude-haiku-4-5' },
-  { name: 'openai-compatible', key: 'OPENAI_API_KEY', model: 'gpt-4o-mini' },
+  { name: 'openai-compatible', key: 'OPENAI_API_KEY', model: 'gpt-4.1' },
   { name: 'gemini', key: 'GEMINI_API_KEY', model: 'gemini-3.5-flash-lite' },
 ]
 


### PR DESCRIPTION
gpt-4o-mini turned out to be the image-reading half of the problem only: it fails the document known-answer check the same way gpt-4.1-mini fails the image one. gpt-4.1 is the smallest OpenAI model verified to pass all four calls (plain, JSON, image, document), so the harness pins that, with the full model history recorded in the comment. Harness only; no package code.